### PR TITLE
[FEAT] 공용 체크박스, 라디오 컴포넌트 구현

### DIFF
--- a/src/common/Checkbox/Checkbox.stories.tsx
+++ b/src/common/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Checkbox from './Checkbox';
+
+/**
+ * `Checkbox`는 공용 체크박스 컴포넌트입니다. 크기가 작기 때문에 단독으로 쓰이기보다는 다른 요소들과 같이 쓰입니다.
+ */
+const meta = {
+  title: 'common/Checkbox',
+  component: Checkbox,
+  argTypes: {
+    isChecked: {
+      description: '체크박스의 체크 여부를 의미합니다.',
+    },
+    onChange: {
+      description:
+        '체크박스의 체크 여부가 달라지는 경우 실행하게 될 함수를 의미합니다.',
+    },
+  },
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Checked: Story = {
+  args: {
+    isChecked: true,
+    onChange: () => {
+      alert('onChange()');
+    },
+  },
+};
+
+export const NotChecked: Story = {
+  args: {
+    isChecked: false,
+    onChange: () => {
+      alert('onChange()');
+    },
+  },
+};

--- a/src/common/Checkbox/Checkbox.styled.ts
+++ b/src/common/Checkbox/Checkbox.styled.ts
@@ -1,0 +1,30 @@
+import { styled, css } from 'styled-components';
+
+export const FakeVisualCheckbox = styled.div<{ $isChecked: boolean }>`
+  display: inline-block;
+  position: relative;
+
+  width: 16px;
+  height: 16px;
+
+  border: 3px solid ${({ theme }) => theme.color.GOLD};
+
+  border-radius: 3px;
+  transition: 0.15s;
+  cursor: pointer;
+
+  ${({ theme, $isChecked }) =>
+    $isChecked
+      ? css`
+          box-shadow: 0 0 8px ${theme.color.GOLD};
+          background-color: ${theme.color.GOLD};
+        `
+      : css`
+          box-shadow: 0 0 8px ${theme.color.DARK_BROWN};
+          background-color: transparent;
+        `}
+`;
+
+export const Checkbox = styled.input.attrs({ type: 'checkbox' })`
+  display: none;
+`;

--- a/src/common/Checkbox/Checkbox.tsx
+++ b/src/common/Checkbox/Checkbox.tsx
@@ -1,0 +1,19 @@
+import * as S from './Checkbox.styled';
+
+interface CheckboxProps {
+  isChecked: boolean;
+  onChange: () => void;
+}
+
+const Checkbox = (props: CheckboxProps) => {
+  const { isChecked, onChange } = props;
+
+  return (
+    <label>
+      <S.FakeVisualCheckbox $isChecked={isChecked} />
+      <S.Checkbox checked={isChecked} onChange={onChange} />
+    </label>
+  );
+};
+
+export default Checkbox;

--- a/src/common/Checkbox/index.ts
+++ b/src/common/Checkbox/index.ts
@@ -1,0 +1,3 @@
+import Checkbox from './Checkbox';
+
+export default Checkbox;

--- a/src/common/Radio/Radio.stories.tsx
+++ b/src/common/Radio/Radio.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Radio from './Radio';
+
+/**
+ * `Radio`는 공용 라디오 컴포넌트입니다. 크기가 작기 때문에 단독으로 쓰이기보다는 다른 요소들과 같이 쓰입니다.
+ */
+const meta = {
+  title: 'common/Radio',
+  component: Radio,
+  argTypes: {
+    isChecked: {
+      description: '라디오의 체크 여부를 의미합니다.',
+    },
+    onChange: {
+      description:
+        '라디오의 체크 여부가 달라지는 경우 실행하게 될 함수를 의미합니다.',
+    },
+  },
+} satisfies Meta<typeof Radio>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * `Checkbox`와 달리, `Radio`의 경우 해당 컴포넌트가 이미 선택되어 있을 경우 클릭하더라도 `onChange` 이벤트가 트리거되지 않습니다. 따라서 이 경우 클릭해도 함수가 호출되지 않습니다.
+ */
+export const Checked: Story = {
+  args: {
+    name: 'option-name',
+    isChecked: true,
+    onChange: () => {
+      alert('onChange()');
+    },
+  },
+};
+
+export const NotChecked: Story = {
+  args: {
+    name: 'option-name',
+    isChecked: false,
+    onChange: () => {
+      alert('onChange()');
+    },
+  },
+};

--- a/src/common/Radio/Radio.styled.ts
+++ b/src/common/Radio/Radio.styled.ts
@@ -1,0 +1,30 @@
+import { styled, css } from 'styled-components';
+
+export const FakeVisualRadio = styled.div<{ $isChecked: boolean }>`
+  display: inline-block;
+  position: relative;
+
+  width: 16px;
+  height: 16px;
+
+  border: 3px solid ${({ theme }) => theme.color.GOLD};
+
+  border-radius: 8px;
+  transition: 0.15s;
+  cursor: pointer;
+
+  ${({ theme, $isChecked }) =>
+    $isChecked
+      ? css`
+          box-shadow: 0 0 8px ${theme.color.GOLD};
+          background-color: ${theme.color.GOLD};
+        `
+      : css`
+          box-shadow: 0 0 8px ${theme.color.DARK_BROWN};
+          background-color: transparent;
+        `}
+`;
+
+export const Radio = styled.input.attrs({ type: 'radio' })`
+  display: none;
+`;

--- a/src/common/Radio/Radio.tsx
+++ b/src/common/Radio/Radio.tsx
@@ -1,0 +1,20 @@
+import * as S from './Radio.styled';
+
+interface RadioProps {
+  name: string;
+  isChecked: boolean;
+  onChange: () => void;
+}
+
+const Radio = (props: RadioProps) => {
+  const { name, isChecked, onChange } = props;
+
+  return (
+    <label>
+      <S.FakeVisualRadio $isChecked={isChecked} />
+      <S.Radio name={name} checked={isChecked} onChange={onChange} />
+    </label>
+  );
+};
+
+export default Radio;

--- a/src/common/Radio/index.ts
+++ b/src/common/Radio/index.ts
@@ -1,0 +1,3 @@
+import Radio from './Radio';
+
+export default Radio;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,6 +1,7 @@
 export const theme = {
   color: {
     GOLD: '#d1b072',
+    DARK_BROWN: '#1a0e0a',
   },
 };
 


### PR DESCRIPTION
## PR 설명
본 PR에서는 설정 페이지에서 다용도로 사용될 **공용 체크박스, 라디오 컴포넌트**를 구현하였습니다.
- 체크박스 컴포넌트의 경우, 현재로써는 알고리즘 항목이 유일한 사용처입니다.
- 라디오 컴포넌트의 경우, 설정에서의 여러 옵션이 사용처입니다.

## 작업한 내용
- [x] 공용 체크박스 컴포넌트 구현
- [x] 공용 라디오 컴포넌트 구현