### PR TITLE
[CHORE] 절대경로를 위한 path alias를 변경

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -20,14 +20,14 @@ const config: StorybookConfig = {
     if (config.resolve) {
       config.resolve.alias = {
         ...config.resolve.alias,
-        '@components': resolve(__dirname, '../src/components'),
-        '@constants': resolve(__dirname, '../src/constants'),
-        '@domains': resolve(__dirname, '../src/domains'),
-        '@hooks': resolve(__dirname, '../src/hooks'),
-        '@images': resolve(__dirname, '../src/images'),
-        '@types': resolve(__dirname, '../src/types'),
-        '@utils': resolve(__dirname, '../src/utils'),
-        '@styles': resolve(__dirname, '../src/styles'),
+        '~components': resolve(__dirname, '../src/components'),
+        '~constants': resolve(__dirname, '../src/constants'),
+        '~domains': resolve(__dirname, '../src/domains'),
+        '~hooks': resolve(__dirname, '../src/hooks'),
+        '~images': resolve(__dirname, '../src/images'),
+        '~types': resolve(__dirname, '../src/types'),
+        '~utils': resolve(__dirname, '../src/utils'),
+        '~styles': resolve(__dirname, '../src/styles'),
       };
     }
     const assetRules = config.module?.rules?.find((rule) => {

--- a/src/components/AlgorithmPool/AlgorithmList/AlgorithmList.stories.tsx
+++ b/src/components/AlgorithmPool/AlgorithmList/AlgorithmList.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import AlgorithmList from './AlgorithmList';
-import type { Algorithm } from '../../../types/algorithm';
+import type { Algorithm } from '~types/algorithm';
 
 /**
  * `AlgorithmList`는 여러 알고리즘 분류에 대한 체크 여부를 설정할 수 있는 목록입니다.

--- a/src/components/AlgorithmPool/AlgorithmList/AlgorithmList.tsx
+++ b/src/components/AlgorithmPool/AlgorithmList/AlgorithmList.tsx
@@ -1,6 +1,6 @@
 import * as S from './AlgorithmList.styled';
 import AlgorithmListItem from './AlgorithmListItem';
-import type { Algorithm } from '../../../types/algorithm';
+import type { Algorithm } from '~types/algorithm';
 
 interface AlgorithmListProps {
   items: Algorithm[];

--- a/src/components/AlgorithmPool/AlgorithmList/AlgorithmListItem/AlgorithmListItem.tsx
+++ b/src/components/AlgorithmPool/AlgorithmList/AlgorithmListItem/AlgorithmListItem.tsx
@@ -1,5 +1,5 @@
 import * as S from './AlgorithmListItem.styled';
-import Checkbox from '@components/common/Checkbox';
+import Checkbox from '~components/common/Checkbox';
 
 interface AlgorithmListItemProps {
   id: number;

--- a/src/components/AlgorithmPool/AlgorithmPool.tsx
+++ b/src/components/AlgorithmPool/AlgorithmPool.tsx
@@ -1,8 +1,8 @@
 import * as S from './AlgorithmPool.styled';
 import AlgorithmList from './AlgorithmList';
-import useAlgorithmPool from '@hooks/algorithm/useAlgorithmPool';
-import { SearchIcon } from '@images/svg';
-import { allCheckedIcon, allUncheckedIcon } from '@images/png';
+import useAlgorithmPool from '~hooks/algorithm/useAlgorithmPool';
+import { SearchIcon } from '~images/svg';
+import { allCheckedIcon, allUncheckedIcon } from '~images/png';
 
 const AlgorithmPool = () => {
   const {

--- a/src/components/Test/Test.tsx
+++ b/src/components/Test/Test.tsx
@@ -1,5 +1,5 @@
 import * as S from './Test.styled';
-import { totamjungStorybookLogo } from '@images';
+import { totamjungStorybookLogo } from '~images';
 
 type TestProps = {
   message: string;

--- a/src/constants/algorithmInfos.ts
+++ b/src/constants/algorithmInfos.ts
@@ -1,4 +1,4 @@
-import { AlgorithmInfo } from '../types/algorithm';
+import { AlgorithmInfo } from '~types/algorithm';
 
 export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
   {

--- a/src/domains/algorithm/getSearchResults.test.ts
+++ b/src/domains/algorithm/getSearchResults.test.ts
@@ -1,6 +1,6 @@
 import { getSearchResults } from './getSearchResults';
-import { ALGORITHM_INFOS } from '../../constants/algorithmInfos';
-import type { Algorithm } from '../../types/algorithm';
+import { ALGORITHM_INFOS } from '~constants/algorithmInfos';
+import type { Algorithm } from '~types/algorithm';
 
 const allAlgorithms = ALGORITHM_INFOS.map(({ id, name }) => ({ id, name }));
 

--- a/src/domains/algorithm/getSearchResults.ts
+++ b/src/domains/algorithm/getSearchResults.ts
@@ -1,5 +1,5 @@
-import { Algorithm } from '../../types/algorithm';
-import { ALGORITHM_INFOS } from '@constants/algorithmInfos';
+import { Algorithm } from '~types/algorithm';
+import { ALGORITHM_INFOS } from '~constants/algorithmInfos';
 
 const trimWord = (word: string) => {
   const loweredWord = word.toLowerCase();

--- a/src/hooks/algorithm/useAlgorithmPool.ts
+++ b/src/hooks/algorithm/useAlgorithmPool.ts
@@ -1,5 +1,5 @@
-import { getSearchResults } from '@domains/algorithm/getSearchResults';
-import { ALGORITHMS_COUNT } from '@constants/algorithmInfos';
+import { getSearchResults } from '~domains/algorithm/getSearchResults';
+import { ALGORITHMS_COUNT } from '~constants/algorithmInfos';
 import { useState, useEffect } from 'react';
 import type { ChangeEventHandler } from 'react';
 

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -1,5 +1,5 @@
 import 'styled-components';
-import type { Theme } from '@styles/theme';
+import type { Theme } from '~styles/theme';
 
 declare module 'styled-components' {
   export interface DefaultTheme extends Theme {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,16 +11,16 @@
     "noEmitOnError": true,
     "baseUrl": "./",
     "paths": {
-      "@components/*": ["src/components/*"],
-      "@constants/*": ["src/constants/*"],
-      "@domains/*": ["src/domains/*"],
-      "@hooks/*": ["src/hooks/*"],
-      "@images": ["src/images/index"],
-      "@images/*": ["src/images/*"],
-      "@types": ["src/types/*"],
-      "@types/*": ["src/types/*"],
-      "@utils/*": ["src/utils/*"],
-      "@styles/*": ["src/styles/*"]
+      "~components/*": ["src/components/*"],
+      "~constants/*": ["src/constants/*"],
+      "~domains/*": ["src/domains/*"],
+      "~hooks/*": ["src/hooks/*"],
+      "~images": ["src/images/index"],
+      "~images/*": ["src/images/*"],
+      "~types": ["src/types/*"],
+      "~types/*": ["src/types/*"],
+      "~utils/*": ["src/utils/*"],
+      "~styles/*": ["src/styles/*"]
     }
   },
   "include": ["src"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,14 +33,14 @@ module.exports = {
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
     alias: {
-      '@components': resolve(__dirname, 'src/components'),
-      '@constants': resolve(__dirname, 'src/constants'),
-      '@domains': resolve(__dirname, 'src/domains'),
-      '@hooks': resolve(__dirname, 'src/hooks'),
-      '@images': resolve(__dirname, 'src/images'),
-      '@types': resolve(__dirname, 'src/types'),
-      '@utils': resolve(__dirname, 'src/utils'),
-      '@styles': resolve(__dirname, 'src/styles'),
+      '~components': resolve(__dirname, 'src/components'),
+      '~constants': resolve(__dirname, 'src/constants'),
+      '~domains': resolve(__dirname, 'src/domains'),
+      '~hooks': resolve(__dirname, 'src/hooks'),
+      '~images': resolve(__dirname, 'src/images'),
+      '~types': resolve(__dirname, 'src/types'),
+      '~utils': resolve(__dirname, 'src/utils'),
+      '~styles': resolve(__dirname, 'src/styles'),
     },
   },
   output: {


### PR DESCRIPTION
## PR 설명
본 PR에서는 `@types/~~~` 와 같은 경로의 충돌을 해결하기 위해, 절대 경로를 위한 path alias를 `@` 에서 `~`로 변경하였습니다.
- 예시: `@components/FooBar` → `~components/FooBar`