### PR TITLE
[FEAT] 알고리즘 메뉴의 데이터 저장/불러오기 서비스워커 로직 구현

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -25,7 +25,11 @@
     },
 
     runtime: {
-      sendMessage: async ({ message }) => {
+      sendMessage: ({ command, message }, callback) => {
+        if (command === 'fetchCheckedAlgorithmIds') {
+          callback({ checkedIds: [1, 2, 4, 8, 16, 32, 64] });
+        }
+
         if (message === 'getRandomDefenseHistory') {
           const randomDefenseHistory = [
             {
@@ -83,6 +87,8 @@
             isHidden: false,
           };
         }
+
+        return {};
       },
     },
   };

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,5 +5,8 @@
   "manifest_version": 3,
   "permissions": ["storage"],
   "host_permissions": ["https://solved.ac/api/v3/search/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
   "options_page": "options.html"
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,3 @@
+chrome.runtime.onMessage.addListener(
+  (message: unknown, sender, sendResponse) => {},
+);

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,7 @@
 import { isObject } from '~types/typeGuards';
 import { COMMANDS } from '~constants/commands';
 import { fetchCheckedAlgorithmIds } from '~domains/algorithm/fetchCheckedAlgorithmIds';
+import { saveCheckedAlgorithmIds } from '~domains/algorithm/saveCheckedAlgorithmIds';
 
 chrome.runtime.onMessage.addListener(
   (message: unknown, sender, sendResponse) => {
@@ -18,6 +19,14 @@ chrome.runtime.onMessage.addListener(
       fetchCheckedAlgorithmIds().then((result) => {
         sendResponse(result);
       });
+    }
+
+    if (command === COMMANDS.SAVE_CHECKED_ALGORITHM_IDS) {
+      if (!('checkedIds' in message)) {
+        return;
+      }
+
+      saveCheckedAlgorithmIds(message.checkedIds);
     }
 
     return true;

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,6 @@
 import { isObject } from '~types/typeGuards';
+import { COMMANDS } from '~constants/commands';
+import { fetchCheckedAlgorithmIds } from '~domains/algorithm/fetchCheckedAlgorithmIds';
 
 chrome.runtime.onMessage.addListener(
   (message: unknown, sender, sendResponse) => {
@@ -9,5 +11,15 @@ chrome.runtime.onMessage.addListener(
     ) {
       throw Error('잘못된 메시지가 전달되었습니다.');
     }
+
+    const { command } = message;
+
+    if (command === COMMANDS.FETCH_CHECKED_ALGORITHM_IDS) {
+      fetchCheckedAlgorithmIds().then((result) => {
+        sendResponse(result);
+      });
+    }
+
+    return true;
   },
 );

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,3 +1,13 @@
+import { isObject } from '~types/typeGuards';
+
 chrome.runtime.onMessage.addListener(
-  (message: unknown, sender, sendResponse) => {},
+  (message: unknown, sender, sendResponse) => {
+    if (
+      !isObject(message) ||
+      !('command' in message) ||
+      typeof message.command !== 'string'
+    ) {
+      throw Error('잘못된 메시지가 전달되었습니다.');
+    }
+  },
 );

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -1,0 +1,7 @@
+export const COMMANDS = {
+  FETCH_CHECKED_ALGORITHM_IDS: 'fetchCheckedAlgorithmIds',
+};
+
+export const SYNC_STORAGE_KEY = {
+  CHECKED_ALGORITHM_IDS: 'checkedAlgorithmIds',
+};

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -1,5 +1,6 @@
 export const COMMANDS = {
   FETCH_CHECKED_ALGORITHM_IDS: 'fetchCheckedAlgorithmIds',
+  SAVE_CHECKED_ALGORITHM_IDS: 'saveCheckedAlgorithmIds',
 };
 
 export const SYNC_STORAGE_KEY = {

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -6,3 +6,12 @@ export const COMMANDS = {
 export const SYNC_STORAGE_KEY = {
   CHECKED_ALGORITHM_IDS: 'checkedAlgorithmIds',
 };
+
+/**
+ * 이 키들은 v1.1.*까지의 이전 버전에서 사용되던 키들입니다.
+ * v1.2부터는 사용되지 않지만, 이전 버전에서 업데이트를 한 유저를 위해 데이터를 옮겨야 하므로
+ * 필요한 키들입니다.
+ */
+export const LEGACY_SYNC_STORAGE_KEY = {
+  CHECKED_ALGORITHM_IDS: 'algorithm',
+};

--- a/src/domains/algorithm/fetchCheckedAlgorithmIds.ts
+++ b/src/domains/algorithm/fetchCheckedAlgorithmIds.ts
@@ -1,14 +1,21 @@
-import { SYNC_STORAGE_KEY } from '~constants/commands';
+import { LEGACY_SYNC_STORAGE_KEY, SYNC_STORAGE_KEY } from '~constants/commands';
 import { ALGORITHMS_COUNT } from '~constants/algorithmInfos';
 
 export const fetchCheckedAlgorithmIds = async () => {
   return new Promise((resolve) => {
     chrome.storage.sync.get(
-      SYNC_STORAGE_KEY.CHECKED_ALGORITHM_IDS,
+      [
+        SYNC_STORAGE_KEY.CHECKED_ALGORITHM_IDS,
+        LEGACY_SYNC_STORAGE_KEY.CHECKED_ALGORITHM_IDS,
+      ],
       (data: Record<string, unknown>) => {
-        const raw: unknown = data.checkedAlgorithmIds;
+        const raw = Array.isArray(data.checkedAlgorithmIds)
+          ? data.checkedAlgorithmIds
+          : Array.isArray(data.algorithm)
+            ? data.algorithm
+            : null;
 
-        if (!Array.isArray(raw)) {
+        if (!raw) {
           resolve({ checkedIds: [] });
           return;
         }

--- a/src/domains/algorithm/fetchCheckedAlgorithmIds.ts
+++ b/src/domains/algorithm/fetchCheckedAlgorithmIds.ts
@@ -1,0 +1,29 @@
+import { SYNC_STORAGE_KEY } from '~constants/commands';
+import { ALGORITHMS_COUNT } from '~constants/algorithmInfos';
+
+export const fetchCheckedAlgorithmIds = async () => {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(
+      SYNC_STORAGE_KEY.CHECKED_ALGORITHM_IDS,
+      (data: Record<string, unknown>) => {
+        const raw: unknown = data.checkedAlgorithmIds;
+
+        if (!Array.isArray(raw)) {
+          resolve({ checkedIds: [] });
+          return;
+        }
+
+        const checkedAlgorithmIds: number[] = raw.filter(
+          (value) =>
+            typeof value === 'number' &&
+            !isNaN(value) &&
+            value % 1 === 0 &&
+            value >= 1 &&
+            value <= ALGORITHMS_COUNT,
+        );
+
+        resolve({ checkedIds: checkedAlgorithmIds });
+      },
+    );
+  });
+};

--- a/src/domains/algorithm/saveCheckedAlgorithmIds.ts
+++ b/src/domains/algorithm/saveCheckedAlgorithmIds.ts
@@ -1,0 +1,21 @@
+import { SYNC_STORAGE_KEY } from '~constants/commands';
+import { ALGORITHMS_COUNT } from '~constants/algorithmInfos';
+
+export const saveCheckedAlgorithmIds = (checkedIds: unknown) => {
+  if (!Array.isArray(checkedIds)) {
+    return;
+  }
+
+  const filteredCheckedIds: number[] = checkedIds.filter(
+    (value) =>
+      typeof value === 'number' &&
+      !isNaN(value) &&
+      value % 1 === 0 &&
+      value >= 1 &&
+      value <= ALGORITHMS_COUNT,
+  );
+
+  chrome.storage.sync.set({
+    [SYNC_STORAGE_KEY.CHECKED_ALGORITHM_IDS]: filteredCheckedIds,
+  });
+};

--- a/src/hooks/algorithm/useAlgorithmPool.ts
+++ b/src/hooks/algorithm/useAlgorithmPool.ts
@@ -1,6 +1,7 @@
 import { getSearchResults } from '~domains/algorithm/getSearchResults';
 import { ALGORITHMS_COUNT } from '~constants/algorithmInfos';
 import { useState, useEffect } from 'react';
+import { COMMANDS } from '~constants/commands';
 import type { ChangeEventHandler } from 'react';
 
 const useAlgorithmPool = () => {
@@ -8,17 +9,16 @@ const useAlgorithmPool = () => {
   const [checkedIds, setCheckedIds] = useState<number[]>([]);
 
   useEffect(() => {
-    chrome.storage.sync.get('algorithm', (response) => {
-      if (!response.algorithm) {
-        return;
-      }
-
-      setCheckedIds(() => response.algorithm);
-    });
+    chrome.runtime.sendMessage(
+      { command: COMMANDS.FETCH_CHECKED_ALGORITHM_IDS },
+      (response) => {
+        setCheckedIds(() => response.checkedIds);
+      },
+    );
   }, []);
 
   useEffect(() => {
-    chrome.storage.sync.set({ algorithm: checkedIds });
+    // TODO: checkedIds가 변경되면 저장 요청 메시지를 보내는 기능 구현
   }, [checkedIds]);
 
   const handleChangeKeyword: ChangeEventHandler<HTMLInputElement> = (event) => {

--- a/src/hooks/algorithm/useAlgorithmPool.ts
+++ b/src/hooks/algorithm/useAlgorithmPool.ts
@@ -18,7 +18,10 @@ const useAlgorithmPool = () => {
   }, []);
 
   useEffect(() => {
-    // TODO: checkedIds가 변경되면 저장 요청 메시지를 보내는 기능 구현
+    chrome.runtime.sendMessage({
+      command: COMMANDS.SAVE_CHECKED_ALGORITHM_IDS,
+      checkedIds,
+    });
   }, [checkedIds]);
 
   const handleChangeKeyword: ChangeEventHandler<HTMLInputElement> = (event) => {

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -1,12 +1,12 @@
 import { render } from 'react-dom';
 import { StrictMode } from 'react';
 import { ThemeProvider } from 'styled-components';
-import { theme } from '@styles/theme';
-import GlobalStyle from '@styles/GlobalStyle';
-import Test from '@components/Test';
+import { theme } from '~styles/theme';
+import GlobalStyle from '~styles/GlobalStyle';
+import AlgorithmPool from '~components/AlgorithmPool';
 
 const Options = () => {
-  return <Test message="와 리액뜨!!" />;
+  return <AlgorithmPool />;
 };
 
 render(

--- a/src/types/typeGuards.ts
+++ b/src/types/typeGuards.ts
@@ -4,7 +4,7 @@ import type {
 } from '~types/randomDefense';
 import { solvedAcNumericTierIcons } from '~images/svg/tier';
 
-const isObject = (data: unknown): data is object => {
+export const isObject = (data: unknown): data is object => {
   return typeof data === 'object' && data !== null;
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
   mode: 'production',
   entry: {
     options: './src/options.tsx',
+    background: './src/background.ts',
   },
   module: {
     rules: [


### PR DESCRIPTION
## PR 내용
본 PR에서는 알고리즘 메뉴에서의 설정 변경사항을 저장하고 불러올 수 있는 서비스 워커의 로직을 구현하고, 이를 `<AlgorithmPool />` 에 적용했습니다.
- 첫 로드 시 저장된 정보를 불러옵니다.
  - 단, 데이터가 잘못되었거나 없는 경우 구버전의 키도 확인합니다. 이는 `v1.2` 부터 데이터를 저장하는 키의 이름이 바뀌기에 `v1.1.*` 를 사용하는 유저가 업데이트를 하는 경우 데이터가 유실되는 것을 막기 위함입니다.
- 정보가 변경될 때마다 스토리지에 저장을 진행합니다.
- 잘못된 데이터가 있는 경우 올바른 데이터만을 골라내어 복구를 시도하며, 복구가 불가능할 경우에는 `[]`로 초기화합니다.

## 서비스 워커 명세
### 알고리즘 분류에서 체크된 항목들에 해당하는 아이디 목록을 불러오기 ⬇️
- 커맨드: `fetchAlgorithmCheckedIds`
- 추가로 첨부해야 하는 정보: **없음**
- 메시지 형식 예시

```ts
{
  command: 'fetchAlgorithmCheckedIds'
}
```

- 응답 예시
```ts
{
  checkedIds: [1, 2, 4, 8, 16, 32]
}
```

### 알고리즘 분류에서 체크된 항목들에 해당하는 아이디 목록을 저장하기 ⬆️
- 커맨드: `saveAlgorithmCheckedIds`
- 추가로 첨부해야 하는 정보:
  - **아이디 목록(`number[]`)**
- 저장 위치: `chrome.storage.sync`
- 메시지 형식 예시

```ts
{
  command: 'saveAlgorithmCheckedIds',
  checkedIds: [1, 2, 4, 8, 16, 32]
}
```