### PR TITLE
[FEAT] 알고리즘 메뉴의 컴포넌트들이 블록설정이 안 되도록 변경

### DIFF
--- a/src/components/AlgorithmPool/AlgorithmList/AlgorithmListItem/AlgorithmListItem.styled.ts
+++ b/src/components/AlgorithmPool/AlgorithmList/AlgorithmListItem/AlgorithmListItem.styled.ts
@@ -12,6 +12,7 @@ export const Container = styled.li<{
     $backgroundColor === 'brown' ? theme.color.BROWN : theme.color.LIGHT_BROWN};
 
   cursor: pointer;
+  user-select: none;
 `;
 
 export const Label = styled.label`

--- a/src/components/AlgorithmPool/AlgorithmPool.styled.ts
+++ b/src/components/AlgorithmPool/AlgorithmPool.styled.ts
@@ -67,6 +67,8 @@ export const SearchInput = styled.input`
 
 export const CheckButtonPanel = styled.div`
   display: flex;
+
+  user-select: none;
 `;
 
 export const CheckButton = styled.button`


### PR DESCRIPTION
## PR 내용
본 PR에서는 알고리즘 메뉴에서 불필요한 블록설정이 되지 않도록 개선했습니다.

## 참고 자료
### Before
<img width="600" src="https://github.com/wzrabbit/boj-totamjung/assets/87642422/f1ef0c89-224e-4b14-8667-68e28d300d28" />

### After
<img width="600" src="https://github.com/wzrabbit/boj-totamjung/assets/87642422/0f79010a-e5a2-442f-a4bc-f0b39997895a" />
