### PR TITLE
[CHORE] Jest의 테스트에서 svg 파일을 변형하여 사용할 수 있도록 설정 진행

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
   moduleNameMapper: {
     '^~((?:components|utils|hooks|constants|domains|types|images).*)$':
       '<rootDir>/src/$1',
+    '^.+\\.svg$': 'jest-svg-transformer',
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   testEnvironment: 'node',
   moduleNameMapper: {
-    '^@((?:components|utils|hooks|constants|domains).*)$': '<rootDir>/src/$1',
+    '^~((?:components|utils|hooks|constants|domains|types|images).*)$':
+      '<rootDir>/src/$1',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "eslint-webpack-plugin": "^4.0.1",
         "html-webpack-plugin": "^5.5.3",
         "jest": "^29.7.0",
+        "jest-svg-transformer": "^1.0.0",
         "prettier": "^3.1.0",
         "storybook": "^7.5.3",
         "ts-loader": "^9.5.1",
@@ -8620,13 +8621,13 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -8634,7 +8635,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -9469,9 +9470,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -11122,17 +11123,17 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -13654,6 +13655,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-svg-transformer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jest-svg-transformer/-/jest-svg-transformer-1.0.0.tgz",
+      "integrity": "sha512-+kD21VthJFHIbI3DZRz+jo4sBOSR1qWEMXhVC28owRMqC5nA+zEiJrHOlj+EqQIztYMouRc1dIjE8SJfFPJUXA==",
+      "dev": true,
+      "peerDependencies": {
+        "jest": ">22",
+        "react": ">=16"
+      }
+    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -15420,9 +15431,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -17869,9 +17880,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.1.tgz",
-      "integrity": "sha512-y51HrHaFeeWir0YO4f0g+9GwZawuigzcAdRNon6jErXy/SqV/+O6eaVAzDqE6t3e3NpGeR5CS+cCDaTC+V3yEQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.2.tgz",
+      "integrity": "sha512-Wu+EHmX326YPYUpQLKmKbTyZZJIB8/n6R09pTmB03kJmnMsVPTo9COzHZFr01txwaCAuZvfBJE4ZCHRcKs5JaQ==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-webpack-plugin": "^4.0.1",
     "html-webpack-plugin": "^5.5.3",
     "jest": "^29.7.0",
+    "jest-svg-transformer": "^1.0.0",
     "prettier": "^3.1.0",
     "storybook": "^7.5.3",
     "ts-loader": "^9.5.1",


### PR DESCRIPTION
## PR 설명
본 PR에서는 Jest에서 테스트 진행 시, `svg` 파일을 불러오려고 할 때 이를 읽어오지 못해 테스트가 중단되는 문제를 해결할 수 있도록 환경 설정을 진행해 주었습니다.
여담으로 `svg` 파일을 읽어오지 못하는 경우에는 흔히 `SyntaxError: Unexpected token "<"` 와 같은 오류가 발생합니다. Jest가 svg 파일들도 인식할 수 있도록 추가 설정을 해 주는 것이 필요했습니다.

그 외에도, #17 에서 변경된 path alias를 Jest의 config 파일에는 적용하지 못해 이 PR에서 이를 적용해 주었습니다.

## 참고 자료
- [Jest cannot load svg file](https://stackoverflow.com/questions/58603201/jest-cannot-load-svg-file)https://stackoverflow.com/questions/58603201/jest-cannot-load-svg-file
- [타입스크립트 jest import svg 할때 생기는 문제점에 대하여](https://all-dev-kang.tistory.com/entry/%ED%83%80%EC%9E%85%EC%8A%A4%ED%81%AC%EB%A6%BD%ED%8A%B8-jest-import-svg-%ED%95%A0%EB%95%8C-%EC%83%9D%EA%B8%B0%EB%8A%94-%EB%AC%B8%EC%A0%9C%EC%A0%90%EC%97%90-%EB%8C%80%ED%95%98%EC%97%AC)