### PR TITLE
[FIX] 알고리즘 메뉴를 빠르게 새로고침할 경우 데이터가 유실되는 버그 해결

### DIFF
--- a/src/components/AlgorithmPool/AlgorithmPool.tsx
+++ b/src/components/AlgorithmPool/AlgorithmPool.tsx
@@ -9,6 +9,7 @@ const AlgorithmPool = () => {
     keyword,
     items,
     checkedIds,
+    isLoaded,
     handleChangeKeyword,
     toggleAlgorithm,
     checkAllAlgorithms,
@@ -18,11 +19,13 @@ const AlgorithmPool = () => {
   return (
     <S.Container>
       <S.AlgorithmPanel>
-        <AlgorithmList
-          items={items}
-          checkedIds={checkedIds}
-          onChange={toggleAlgorithm}
-        />
+        {isLoaded && (
+          <AlgorithmList
+            items={items}
+            checkedIds={checkedIds}
+            onChange={toggleAlgorithm}
+          />
+        )}
       </S.AlgorithmPanel>
       <S.ControlPanel>
         <S.SearchPanelContainer>

--- a/src/hooks/algorithm/useAlgorithmPool.ts
+++ b/src/hooks/algorithm/useAlgorithmPool.ts
@@ -7,17 +7,23 @@ import type { ChangeEventHandler } from 'react';
 const useAlgorithmPool = () => {
   const [keyword, setKeyword] = useState('');
   const [checkedIds, setCheckedIds] = useState<number[]>([]);
+  const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
     chrome.runtime.sendMessage(
       { command: COMMANDS.FETCH_CHECKED_ALGORITHM_IDS },
       (response) => {
         setCheckedIds(() => response.checkedIds);
+        setIsLoaded(() => true);
       },
     );
   }, []);
 
   useEffect(() => {
+    if (!isLoaded) {
+      return;
+    }
+
     chrome.runtime.sendMessage({
       command: COMMANDS.SAVE_CHECKED_ALGORITHM_IDS,
       checkedIds,
@@ -59,6 +65,7 @@ const useAlgorithmPool = () => {
     keyword,
     items,
     checkedIds,
+    isLoaded,
     handleChangeKeyword,
     toggleAlgorithm,
     checkAllAlgorithms,


### PR DESCRIPTION
## PR 내용
본 PR에서는 알고리즘 메뉴를 빠르게 새로고침할 경우 체크해 두었던 알고리즘 목록들이 유실되는 문제를 해결했습니다.
- 완전히 로딩되지 않은 상태에서 `useEffect`에 의해 초깃값인 빈 데이터가 저장되고, 데이터를 불러온 이후 `useEffect`의 실행 전에 새로고침을 할 경우 실제 데이터를 반영하지 못하기에 발생했던 버그입니다.
- 로딩이 끝났는지의 여부를 나타내는 `loaded` 상태를 두어 로딩이 완료되지 않았다면 데이터 저장을 차단하도록 방지하여 해결했습니다.