### PR TITLE
[FEAT] 공통 인풋 컴포넌트 구현

### DIFF
--- a/src/components/common/Input/Input.stories.tsx
+++ b/src/components/common/Input/Input.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Input from './Input';
+
+/**
+ * `Input`는 공통 인풋 컴포넌트입니다.
+ */
+const meta = {
+  title: 'common/Input',
+  component: Input,
+} satisfies Meta<typeof Input>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    type: 'text',
+    width: 240,
+    value: '',
+    textAlign: 'left',
+    placeholder: '마음가는 대로 입력해 보세요',
+    hasError: false,
+    ariaLabel: '아무 값이든 입력해 보세요',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    type: 'text',
+    width: 240,
+    value: '',
+    textAlign: 'left',
+    placeholder: '사람은 누구나 실수를 하죠',
+    hasError: true,
+    ariaLabel: '아무 값이든 입력해 보세요',
+  },
+};

--- a/src/components/common/Input/Input.styled.ts
+++ b/src/components/common/Input/Input.styled.ts
@@ -1,0 +1,30 @@
+import { styled } from 'styled-components';
+
+export const Input = styled.input<{
+  $width: number;
+  $hasError: boolean;
+  $textAlign: 'left' | 'center';
+}>`
+  width: ${({ $width }) => $width}px;
+  height: 30px;
+  padding: 0 6px;
+
+  border: 1.5px solid ${({ theme }) => theme.color.LIGHTER_BROWN};
+  border-radius: 4px;
+  background-color: ${({ theme }) => theme.color.DARK_BROWN};
+
+  color: ${({ theme }) => theme.color.WHITE};
+  text-align: ${({ $textAlign }) => $textAlign};
+  font-size: 13px;
+
+  &:focus,
+  &:active {
+    border-color: ${({ theme, $hasError }) =>
+      $hasError ? theme.color.RED : theme.color.LEMON};
+    outline: 3px solid
+      ${({ theme, $hasError }) =>
+        $hasError ? theme.color.RED : theme.color.LEMON}70;
+  }
+
+  transition: outline 0.05s;
+`;

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,0 +1,30 @@
+import * as S from './Input.styled';
+
+interface InputProps {
+  type: 'text' | 'number';
+  width: number;
+  value: string;
+  minLength?: number;
+  maxLength?: number;
+  textAlign: 'left' | 'center';
+  placeholder: string;
+  hasError: boolean;
+  ariaLabel: string;
+
+  onChange: () => void;
+}
+
+const Input = (props: InputProps) => {
+  const { width, hasError, textAlign, ...rest } = props;
+
+  return (
+    <S.Input
+      $width={width}
+      $hasError={hasError}
+      $textAlign={textAlign}
+      {...rest}
+    />
+  );
+};
+
+export default Input;

--- a/src/components/common/Input/index.ts
+++ b/src/components/common/Input/index.ts
@@ -1,0 +1,3 @@
+import Input from './Input';
+
+export default Input;

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -38,6 +38,17 @@ const GlobalStyle = createGlobalStyle`
   ul, ol, li {
     list-style: none;
   }
+  
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  
+  input[type=number] {
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
## PR 내용
본 PR에서는 공통 `<Input>` 컴포넌트를 구현하였습니다.
- 현재 사용처는 무작위 추첨 메뉴에서의 폼이고, 이후 사용 범위가 넓어질 경우 범용성을 위해 필요하다고 생각되는 prop들을 더 많이 추가할 예정입니다.
- 어느 인풋이 선택되었는지, 어느 인풋에서 오류가 발생해 수정해야 하는지를 시각적으로 명확하게 알 수 있도록 윤곽 디자인을 개선했습니다.

## 참고 자료
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/b7773d63-283e-4856-8ded-4fd56bdb51c6)
