### PR TITLE
[STYLE] 스토리북 테마 설정 진행

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,0 +1,42 @@
+import { addons } from '@storybook/manager-api';
+import { create } from '@storybook/theming';
+
+const COLORS = {
+  BROWN100: '#1a0e0a',
+  BROWN200: '#2b1c17',
+  BROWN300: '#412a23',
+  GOLD: '#d1b072',
+  LEMON: '#fff2c8',
+  WHITE: '#eeeeee',
+};
+
+addons.setConfig({
+  theme: create({
+    base: 'dark',
+    brandTitle: '토탐정',
+    brandUrl: 'https://github.com/wzrabbit/boj-totamjung',
+    brandImage:
+      'https://github.com/wzrabbit/boj-totamjung/assets/87642422/47efbb57-7f2c-455c-a527-eeed74b8ce4d',
+
+    colorSecondary: COLORS.BROWN300,
+
+    appBg: COLORS.BROWN100,
+    appContentBg: COLORS.BROWN100,
+    appBorderColor: COLORS.BROWN300,
+
+    barTextColor: COLORS.GOLD,
+    barSelectedColor: COLORS.GOLD,
+    barHoverColor: COLORS.LEMON,
+    barBg: COLORS.BROWN200,
+
+    textColor: COLORS.WHITE,
+    textMutedColor: COLORS.GOLD,
+
+    booleanBg: COLORS.BROWN200,
+    booleanSelectedBg: COLORS.BROWN300,
+
+    inputBg: COLORS.BROWN100,
+    inputBorder: COLORS.BROWN300,
+    inputTextColor: COLORS.LEMON,
+  }),
+});

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,6 +4,11 @@ import GlobalStyle from '../src/styles/GlobalStyle';
 import { theme } from '../src/styles/theme';
 import React from 'react';
 
+const COLORS = {
+  BROWN: '#1a0e0a',
+  WHITE: '#ffffff',
+};
+
 const preview: Preview = {
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
@@ -12,6 +17,19 @@ const preview: Preview = {
         color: /(background|color)$/i,
         date: /Date$/,
       },
+    },
+    backgrounds: {
+      default: 'plain brown',
+      values: [
+        {
+          name: 'plain brown',
+          value: COLORS.BROWN,
+        },
+        {
+          name: 'white',
+          value: COLORS.WHITE,
+        },
+      ],
     },
   },
 };


### PR DESCRIPTION
## PR 내용
본 PR에서는 스토리북의 테마 설정을 진행했습니다.
- 토탐정에서 사용되는 컴포넌트들은 주로 어두운 배경에서 사용되기에 밝은 배경에서는 컴포넌트가 제대로 보이지 않을 수 있기에 실제 사용 환경과 같이 어두운 배경을 사용하는 것이 좋다고 판단됩니다.
- 그리고 개발하면서 가장 많이 보게 될 화면인데, 테마가 예쁘면 당연히 좋죠!

## 참고 자료
- 문서 페이지
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/1d429824-562a-4c0a-87b3-bd9e739dc3b0)
- 테스팅 페이지
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/b0cf5282-ef6e-4fb2-9a16-7572a82892bd)
