### PR TITLE
[FEAT] 텍스트 컴포넌트와 텍스트 링크 컴포넌트를 구현

### DIFF
--- a/src/components/common/Text/Text.stories.tsx
+++ b/src/components/common/Text/Text.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Text from './Text';
+
+/**
+ * `Text`는 내용을 작성할 때 쓰이는 공용 텍스트 컴포넌트입니다.
+ */
+const meta = {
+  title: 'common/Text',
+  component: Text,
+} satisfies Meta<typeof Text>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    type: 'primary',
+    children:
+      '아르페지오는 음악 용어로, 연주되는 음을 서로 다른 높낮이로 연속적으로 연주하는 기법을 가리킵니다. 주로 현악기나 기타와 같은 현악 악기에서 사용되며, 반주를 장식하거나 멜로디를 부각시키는 데에 쓰입니다. 이 용어는 이탈리아어 "arpeggiare"에서 비롯되었으며, "하나씩 피다"라는 뜻입니다. 아르페지오는 화음의 구성음들을 순차적으로 연주하여 하나의 화음을 나타내는 방식으로 사용되며, 주로 빠르고 부드러운 연주로 특징지어지며, 서정적이고 우아한 분위기를 만들어냅니다.',
+  },
+};
+
+export const Normal: Story = {
+  args: {
+    type: 'normal',
+    children:
+      '아르페지오는 음악 용어로, 연주되는 음을 서로 다른 높낮이로 연속적으로 연주하는 기법을 가리킵니다. 주로 현악기나 기타와 같은 현악 악기에서 사용되며, 반주를 장식하거나 멜로디를 부각시키는 데에 쓰입니다. 이 용어는 이탈리아어 "arpeggiare"에서 비롯되었으며, "하나씩 피다"라는 뜻입니다. 아르페지오는 화음의 구성음들을 순차적으로 연주하여 하나의 화음을 나타내는 방식으로 사용되며, 주로 빠르고 부드러운 연주로 특징지어지며, 서정적이고 우아한 분위기를 만들어냅니다.',
+  },
+};

--- a/src/components/common/Text/Text.styled.ts
+++ b/src/components/common/Text/Text.styled.ts
@@ -1,0 +1,16 @@
+import { styled, css } from 'styled-components';
+
+export const Text = styled.p<{ $type: 'primary' | 'normal' }>`
+  ${({ theme, $type }) => {
+    if ($type === 'primary') {
+      return css`
+        color: ${theme.color.GOLD};
+        font-weight: 600;
+      `;
+    }
+
+    return css`
+      color: ${theme.color.WHITE};
+    `;
+  }}
+`;

--- a/src/components/common/Text/Text.tsx
+++ b/src/components/common/Text/Text.tsx
@@ -1,0 +1,14 @@
+import type { PropsWithChildren } from 'react';
+import * as S from './Text.styled';
+
+interface TextProps {
+  type: 'primary' | 'normal';
+}
+
+const Text = (props: PropsWithChildren<TextProps>) => {
+  const { type, children } = props;
+
+  return <S.Text $type={type}>{children}</S.Text>;
+};
+
+export default Text;

--- a/src/components/common/Text/index.ts
+++ b/src/components/common/Text/index.ts
@@ -1,0 +1,3 @@
+import Text from './Text';
+
+export default Text;

--- a/src/components/common/TextLink/TextLink.stories.tsx
+++ b/src/components/common/TextLink/TextLink.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Text from '~components/common/Text';
+import TextLink from './TextLink';
+
+/**
+ * `TextLink`는 텍스트 형태의 링크를 작성할 때 쓰이는 공용 링크 컴포넌트입니다.
+ */
+const meta = {
+  title: 'common/TextLink',
+  component: TextLink,
+} satisfies Meta<typeof TextLink>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'BOJ 실험실 페이지',
+    href: 'https://www.acmicpc.net/labs',
+  },
+};
+
+/**
+ * `<Text>`와 `<TextLink>`를 조합하여 사용한 예시입니다.
+ */
+export const TextLinkWithText: Story = {
+  decorators: [
+    () => (
+      <Text type="normal">
+        Mathjax 수식을 간단하게 테스트해볼 수 있는 사이트로는{' '}
+        <TextLink href="https://www.mathjax.org/#demo">
+          Mathjax 데모 테스트 페이지
+        </TextLink>
+        , 또는{' '}
+        <TextLink href="https://www.acmicpc.net/labs">
+          BOJ 실험실 페이지
+        </TextLink>
+        가 있으니, 참고하시기 바랍니다.
+      </Text>
+    ),
+  ],
+  args: {
+    href: '',
+    children: '',
+  },
+};

--- a/src/components/common/TextLink/TextLink.styled.ts
+++ b/src/components/common/TextLink/TextLink.styled.ts
@@ -1,0 +1,32 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.a`
+  display: inline-flex;
+  column-gap: 2px;
+
+  font-size: 16px;
+  color: ${({ theme }) => theme.color.LEMON};
+`;
+
+export const TextLink = styled.p`
+  text-decoration: underline 2px dotted;
+  -webkit-text-decoration-color: ${({ theme }) =>
+    theme.color.TRANSPARENT_LEMON};
+  text-decoration-color: ${({ theme }) => theme.color.TRANSPARENT_LEMON};
+  text-underline-offset: 2px;
+
+  &:hover {
+    text-decoration: underline 2px dotted;
+    text-decoration-color: ${({ theme }) => theme.color.LEMON};
+  }
+`;
+
+export const LinkIconWrapper = styled.div`
+  width: 20px;
+  height: 20px;
+
+  & svg {
+    width: 100%;
+    height: 100%;
+  }
+`;

--- a/src/components/common/TextLink/TextLink.tsx
+++ b/src/components/common/TextLink/TextLink.tsx
@@ -1,0 +1,22 @@
+import * as S from './TextLink.styled';
+import { LinkIcon } from '~images/svg';
+
+interface TextLinkProps {
+  href: string;
+  children: string;
+}
+
+const TextLink = (props: TextLinkProps) => {
+  const { href, children } = props;
+
+  return (
+    <S.Container href={href} target="__blank" rel="noopener">
+      <S.TextLink>{children}</S.TextLink>
+      <S.LinkIconWrapper>
+        <LinkIcon />
+      </S.LinkIconWrapper>
+    </S.Container>
+  );
+};
+
+export default TextLink;

--- a/src/components/common/TextLink/index.ts
+++ b/src/components/common/TextLink/index.ts
@@ -1,0 +1,3 @@
+import TextLink from './TextLink';
+
+export default TextLink;

--- a/src/images/svg/index.ts
+++ b/src/images/svg/index.ts
@@ -2,3 +2,4 @@ export { ReactComponent as SearchIcon } from './search.svg';
 export { ReactComponent as ClockIcon } from './clock.svg';
 export { ReactComponent as TrashIcon } from './trash.svg';
 export { ReactComponent as PackageIcon } from './package.svg';
+export { ReactComponent as LinkIcon } from './link.svg';

--- a/src/images/svg/link.svg
+++ b/src/images/svg/link.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><path fill="currentColor" d="M11 17H7q-2.075 0-3.537-1.463T2 12t1.463-3.537T7 7h4v2H7q-1.25 0-2.125.875T4 12t.875 2.125T7 15h4zm-3-4v-2h8v2zm5 4v-2h4q1.25 0 2.125-.875T20 12t-.875-2.125T17 9h-4V7h4q2.075 0 3.538 1.463T22 12t-1.463 3.538T17 17z"/></svg>

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,6 +1,7 @@
 export const theme = {
   color: {
     LEMON: '#fff2c8',
+    TRANSPARENT_LEMON: '#fff2c87f',
     GOLD: '#d1b072',
     LIGHTER_BROWN: '#694132',
     LIGHT_BROWN: '#412a23',


### PR DESCRIPTION
## PR 내용
본 PR에서는 일반 텍스트를 적을 때 사용하게 될 `<Text>` 컴포넌트와, 텍스트 형태의 링크를 적을 때 사용하게 될 `<TextLink>` 컴포넌트를 구현하였습니다.
- 사용할 수 있는 옵션이 굉장히 적은데, 이는 당장 사용될 사용처가 많지 않을 것으로 예상되기 때문입니다. 그래서, 디자인의 일관성을 지키고자 옵션을 제한하는 방향으로 구현하였습니다.

## 참고 자료
- `<Text>`

![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/a470d33e-3725-4b82-b339-2360814ab9f1)

- `<TextLink>`

![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/990612e7-01d7-4191-98af-7f4a5bde294a)
