### PR TITLE
[FEAT] 추첨 생성 폼에 필요한 캡슐 버튼 컴포넌트를 구현

### DIFF
--- a/src/components/RandomDefenseCapsuleButton/RandomDefenseCapsuleButton.stories.tsx
+++ b/src/components/RandomDefenseCapsuleButton/RandomDefenseCapsuleButton.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import RandomDefenseCapsuleButton from './RandomDefenseCapsuleButton';
+
+/**
+ * `RandomDefenseCapsuleButton`는 추첨 생성 메뉴에서 모드를 스위칭할 수 있는 캡슐 모양의 버튼입니다.
+ */
+const meta = {
+  title: 'RandomDefenseCapsuleButton',
+  component: RandomDefenseCapsuleButton,
+  argTypes: {},
+} satisfies Meta<typeof RandomDefenseCapsuleButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const EasyMode: Story = {
+  args: {
+    mode: 'easy',
+    onClick: (mode) => {
+      alert(`onClick('${mode}')`);
+    },
+  },
+};
+
+export const ManualMode: Story = {
+  args: {
+    mode: 'manual',
+    onClick: (mode) => {
+      alert(`onClick('${mode}')`);
+    },
+  },
+};

--- a/src/components/RandomDefenseCapsuleButton/RandomDefenseCapsuleButton.styled.ts
+++ b/src/components/RandomDefenseCapsuleButton/RandomDefenseCapsuleButton.styled.ts
@@ -1,0 +1,100 @@
+import { styled, css } from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  position: relative;
+
+  width: 180px;
+  height: 50px;
+
+  user-select: none;
+`;
+
+const capsuleButton = css`
+  width: 50%;
+
+  border: 1.5px solid ${({ theme }) => theme.color.LIGHTER_BROWN};
+  background-color: ${({ theme }) => theme.color.DARK_BROWN};
+
+  font-size: 16px;
+  font-weight: 800;
+  color: ${({ theme }) => theme.color.LIGHTER_BROWN};
+
+  transition: 0.2s;
+`;
+
+export const LeftButton = styled.button<{ $isActivated: boolean }>`
+  ${capsuleButton}
+
+  border-radius: 25px 0 0 25px;
+  padding-left: 10px;
+
+  text-align: left;
+
+  ${({ $isActivated }) =>
+    $isActivated
+      ? css`
+          border-color: ${({ theme }) => theme.color.MAGENTA};
+          background-color: ${({ theme }) => theme.color.MAGENTA};
+          box-shadow: 0 0 12px ${({ theme }) => theme.color.MAGENTA};
+
+          color: ${({ theme }) => theme.color.WHITE};
+        `
+      : css`
+          &:hover {
+            border-color: ${({ theme }) => theme.color.MAGENTA};
+            box-shadow: 0 0 12px ${({ theme }) => theme.color.MAGENTA};
+
+            color: ${({ theme }) => theme.color.MAGENTA};
+          }
+        `}
+`;
+
+export const RightButton = styled.button<{ $isActivated: boolean }>`
+  ${capsuleButton}
+
+  border-radius: 0 25px 25px 0;
+  padding-right: 10px;
+
+  text-align: right;
+
+  ${({ $isActivated }) =>
+    $isActivated
+      ? css`
+          border-color: ${({ theme }) => theme.color.AZURE_BLUE};
+          background-color: ${({ theme }) => theme.color.AZURE_BLUE};
+          box-shadow: 0 0 12px ${({ theme }) => theme.color.AZURE_BLUE};
+
+          color: ${({ theme }) => theme.color.WHITE};
+        `
+      : css`
+          &:hover {
+            border-color: ${({ theme }) => theme.color.AZURE_BLUE};
+            box-shadow: 0 0 12px ${({ theme }) => theme.color.AZURE_BLUE};
+
+            color: ${({ theme }) => theme.color.AZURE_BLUE};
+          }
+        `}
+`;
+
+export const MidCircle = styled.span`
+  display: inline-block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+
+  width: 32px;
+  height: 32px;
+
+  border: 1.5px solid ${({ theme }) => theme.color.LIGHTER_BROWN};
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.color.DARK_BROWN};
+
+  color: ${({ theme }) => theme.color.LIGHTER_BROWN};
+  font-size: 12px;
+  font-weight: 800;
+  text-align: center;
+  line-height: 29px;
+
+  transform: translate(-50%, -50%);
+`;

--- a/src/components/RandomDefenseCapsuleButton/RandomDefenseCapsuleButton.tsx
+++ b/src/components/RandomDefenseCapsuleButton/RandomDefenseCapsuleButton.tsx
@@ -1,0 +1,37 @@
+import * as S from './RandomDefenseCapsuleButton.styled';
+
+type RandomDefenseFormMode = 'easy' | 'manual';
+
+interface RandomDefenseCapsuleButtonProps {
+  mode: RandomDefenseFormMode;
+  onClick: (mode: RandomDefenseFormMode) => void;
+}
+
+const RandomDefenseCapsuleButton = (props: RandomDefenseCapsuleButtonProps) => {
+  const { mode, onClick } = props;
+  return (
+    <S.Container>
+      <S.LeftButton
+        $isActivated={mode === 'easy'}
+        onClick={() => {
+          onClick('easy');
+        }}
+        aria-label="간편 입력 모드로 변경하기"
+      >
+        간편 입력
+      </S.LeftButton>
+      <S.RightButton
+        $isActivated={mode === 'manual'}
+        onClick={() => {
+          onClick('manual');
+        }}
+        aria-label="직접 입력 모드로 변경하기"
+      >
+        직접 입력
+      </S.RightButton>
+      <S.MidCircle>OR</S.MidCircle>
+    </S.Container>
+  );
+};
+
+export default RandomDefenseCapsuleButton;

--- a/src/components/RandomDefenseCapsuleButton/index.ts
+++ b/src/components/RandomDefenseCapsuleButton/index.ts
@@ -1,0 +1,3 @@
+import RandomDefenseCapsuleButton from './RandomDefenseCapsuleButton';
+
+export default RandomDefenseCapsuleButton;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -11,6 +11,8 @@ export const theme = {
     TRANSPARENT_FAINT_WHITE: '#eeeeee20',
     GRAY: '#808080',
     RED: '#ff0000',
+    MAGENTA: '#ff005d',
+    AZURE_BLUE: '#007bff',
   },
 
   solvedAcTier: {


### PR DESCRIPTION
## PR 설명
본 PR에서는 추첨 생성 폼에 사용되는 캡슐 버튼 컴포넌트를 구현하였습니다. -- **`<RandomDefenseCapsuleButton>`**
- 범용적으로 사용되는 컴포넌트가 아닌 오직 폼을 위해서만 존재하는 컴포넌트이므로, 별도의 커스터마이징을 위한 props는 없습니다.
- 외관은 구버전과 거의 동일합니다.

## 참고 자료
- 구버전을 기준으로, **`<RandomDefenseCapsuleButton>`** 가 차지하는 부분을 하이라이트 한 스크린샷입니다.

![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/8597efb2-04c3-4757-aac0-eb87ff66de06)


- 실제로 구현한 **`<RandomDefenseCapsuleButton>`** 입니다.

<img src="https://github.com/wzrabbit/boj-totamjung/assets/87642422/610f2c48-9701-4252-8832-6bc531476baf" width="300px" />
