### PR TITLE
[FEAT] 공통 아이콘 버튼 컴포넌트 구현

### DIFF
--- a/src/components/common/IconButton/IconButton.stories.tsx
+++ b/src/components/common/IconButton/IconButton.stories.tsx
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import IconButton from './IconButton';
+import { PackageIcon } from '~images/svg';
+
+/**
+ * `IconButton`은 나중에 설명 추가 예정 또르르
+ */
+const meta = {
+  title: 'common/IconButton',
+  component: IconButton,
+  argTypes: {},
+} satisfies Meta<typeof IconButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const YOUTUBE_IMAGE_ICON_SRC =
+  'https://images.unsplash.com/photo-1634942536846-e9863ef9e78f?q=80&w=1780&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D';
+
+export const MediumWithSvgIcon: Story = {
+  args: {
+    name: '버튼',
+    size: 'medium',
+    width: '70px',
+    color: '#49aaff',
+    iconSrc: <PackageIcon />,
+    disabled: false,
+    ariaLabel: '테스트용 버튼',
+    onClick: () => {
+      alert('onClick()');
+    },
+  },
+};
+
+export const MediumWithSvgIconDisabled: Story = {
+  args: {
+    name: '버튼',
+    size: 'medium',
+    width: '70px',
+    color: '#49aaff',
+    iconSrc: <PackageIcon />,
+    disabled: true,
+    ariaLabel: '테스트용 버튼',
+    onClick: () => {
+      alert('onClick()');
+    },
+  },
+};
+
+export const LargeWithSvgIcon: Story = {
+  args: {
+    name: '버튼',
+    size: 'large',
+    width: '90px',
+    color: '#49aaff',
+    iconSrc: <PackageIcon />,
+    disabled: false,
+    ariaLabel: '테스트용 버튼',
+    onClick: () => {
+      alert('onClick()');
+    },
+  },
+};
+
+export const MediumWithImageIcon: Story = {
+  args: {
+    name: '버튼',
+    size: 'medium',
+    width: '70px',
+    color: '#ff4949',
+    iconSrc: YOUTUBE_IMAGE_ICON_SRC,
+    disabled: false,
+    ariaLabel: '테스트용 버튼',
+    onClick: () => {
+      alert('onClick()');
+    },
+  },
+};
+
+export const LargeWithImageIcon: Story = {
+  args: {
+    name: '버튼',
+    size: 'large',
+    width: '90px',
+    color: '#ff4949',
+    iconSrc: YOUTUBE_IMAGE_ICON_SRC,
+    disabled: false,
+    ariaLabel: '테스트용 버튼',
+    onClick: () => {
+      alert('onClick()');
+    },
+  },
+};
+
+export const MediumWithNoIcon: Story = {
+  args: {
+    name: '버튼',
+    size: 'medium',
+    width: '40px',
+    color: '#d9d9d9',
+    disabled: false,
+    ariaLabel: '테스트용 버튼',
+    onClick: () => {
+      alert('onClick()');
+    },
+  },
+};
+
+export const LargeWithNoIcon: Story = {
+  args: {
+    name: '버튼',
+    size: 'large',
+    width: '52px',
+    color: '#d9d9d9',
+    disabled: false,
+    ariaLabel: '테스트용 버튼',
+    onClick: () => {
+      alert('onClick()');
+    },
+  },
+};

--- a/src/components/common/IconButton/IconButton.styled.ts
+++ b/src/components/common/IconButton/IconButton.styled.ts
@@ -1,0 +1,64 @@
+import { styled } from 'styled-components';
+
+export const Button = styled.button<{
+  $size: 'large' | 'medium';
+  $width: string;
+  $color: string;
+}>`
+  display: flex;
+  overflow: hidden;
+  column-gap: 4px;
+  align-items: center;
+  justify-content: space-between;
+
+  width: ${({ $width }) => $width};
+  height: ${({ $size }) => ($size === 'large' ? '40px' : '32px')};
+  padding: ${({ $size }) => ($size === 'large' ? '4px 6px' : '2px 4px')};
+
+  border: ${({ $size, $color }) =>
+    $size === 'large' ? `3px solid ${$color}` : `2px solid ${$color}`};
+  border-radius: ${({ $size }) => ($size === 'large' ? '6px' : '4px')};
+  background-color: transparent;
+
+  color: ${({ $color }) => $color};
+
+  &:disabled {
+    opacity: 0.75;
+  }
+
+  &:not([disabled]):hover {
+    box-shadow: 0 0 10px ${({ $color }) => $color};
+  }
+
+  transition: 0.2s;
+`;
+
+export const Text = styled.p<{ $size: 'large' | 'medium'; $color: string }>`
+  font-size: ${({ $size }) => ($size === 'large' ? '20px' : '16px')};
+  font-weight: 600;
+  white-space: nowrap;
+`;
+
+export const IconImage = styled.img<{ $size: 'large' | 'medium' }>`
+  width: ${({ $size }) => ($size === 'large' ? '30px' : '24px')};
+  height: ${({ $size }) => ($size === 'large' ? '30px' : '24px')};
+
+  object-fit: contain;
+`;
+
+export const IconWrapper = styled.div<{
+  $size: 'large' | 'medium';
+  $color: string;
+}>`
+  flex-shrink: 0;
+
+  width: ${({ $size }) => ($size === 'large' ? '30px' : '24px')};
+  height: ${({ $size }) => ($size === 'large' ? '30px' : '24px')};
+
+  & > svg {
+    width: 100%;
+    height: 100%;
+
+    color: ${({ $color }) => $color};
+  }
+`;

--- a/src/components/common/IconButton/IconButton.tsx
+++ b/src/components/common/IconButton/IconButton.tsx
@@ -1,0 +1,42 @@
+import * as S from './IconButton.styled';
+import { SVGProps } from 'react';
+import type { CSSProperties } from 'styled-components';
+
+interface IconButtonProps {
+  name: string;
+  size: 'large' | 'medium';
+  width: CSSProperties['width'];
+  color: string;
+  iconSrc?: string | SVGProps<SVGSVGElement>;
+  disabled: boolean;
+  ariaLabel: string;
+  onClick: () => void;
+}
+
+const IconButton = (props: IconButtonProps) => {
+  const { name, size, width, color, iconSrc, disabled, ariaLabel, onClick } =
+    props;
+
+  return (
+    <S.Button
+      $size={size}
+      $width={width}
+      $color={color}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {iconSrc &&
+        (typeof iconSrc === 'string' ? (
+          <S.IconImage src={iconSrc} alt={name} $size={size} />
+        ) : (
+          <S.IconWrapper $size={size} $color={color}>
+            {iconSrc}
+          </S.IconWrapper>
+        ))}
+      <S.Text $size={size}>{name}</S.Text>
+    </S.Button>
+  );
+};
+
+export default IconButton;

--- a/src/components/common/IconButton/index.ts
+++ b/src/components/common/IconButton/index.ts
@@ -1,0 +1,3 @@
+import IconButton from './IconButton';
+
+export default IconButton;


### PR DESCRIPTION
## PR 설명
본 PR에서는 여러 메뉴에서 범용적으로 사용할 수 있는 공통 아이콘 버튼 컴포넌트를 구현하였습니다. -- **`<IconButton>`**
- 버튼에는 필수적으로 텍스트를 명시해야 되며, 아이콘의 경우에는 이미지 또는 svg 아이콘 중 원하는 방식의 종류의 아이콘을 사용할 수 있습니다. 아이콘의 사용은 필수적이지는 않습니다.
- svg 아이콘을 선택했을 경우 버튼의 색상과 동일한 색상으로 설정됩니다.
- 색상과 가로 길이는 자유롭게 정할 수 있는 반면, 세로 길이는 엄격하게 정해져 있습니다. 가로 길이도 글자 길이만큼만 차지하도록 일관성을 두어 제한할 수 있으나, 글자 수가 서로 다른 버튼이어도 가로 길이가 같아야 하는 디자인이 있어 가로 길이는 자유롭게 설정할 수 있도록 두었습니다.

## 참고 자료
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/ad612e8c-c84b-42b5-bb64-84dbf991f182)
