### PR TITLE
[FEAT] 텍스트 공통 컴포넌트에서 사용 가능한 폰트 사이즈의 선택지를 늘리고, code 옵션을 추가

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,6 +3,13 @@
   type="text/css"
   href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
 />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Oxanium:wght@200..800&display=swap"
+  rel="stylesheet"
+/>
+
 <script>
   var chrome = {
     runtime: {

--- a/src/components/common/Text/Text.stories.tsx
+++ b/src/components/common/Text/Text.stories.tsx
@@ -13,18 +13,83 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Primary: Story = {
+export const Primary16px: Story = {
   args: {
     type: 'primary',
+    fontSize: '16px',
     children:
       '아르페지오는 음악 용어로, 연주되는 음을 서로 다른 높낮이로 연속적으로 연주하는 기법을 가리킵니다. 주로 현악기나 기타와 같은 현악 악기에서 사용되며, 반주를 장식하거나 멜로디를 부각시키는 데에 쓰입니다. 이 용어는 이탈리아어 "arpeggiare"에서 비롯되었으며, "하나씩 피다"라는 뜻입니다. 아르페지오는 화음의 구성음들을 순차적으로 연주하여 하나의 화음을 나타내는 방식으로 사용되며, 주로 빠르고 부드러운 연주로 특징지어지며, 서정적이고 우아한 분위기를 만들어냅니다.',
   },
 };
 
-export const Normal: Story = {
+export const Primary14px: Story = {
   args: {
-    type: 'normal',
+    type: 'primary',
+    fontSize: '14px',
     children:
       '아르페지오는 음악 용어로, 연주되는 음을 서로 다른 높낮이로 연속적으로 연주하는 기법을 가리킵니다. 주로 현악기나 기타와 같은 현악 악기에서 사용되며, 반주를 장식하거나 멜로디를 부각시키는 데에 쓰입니다. 이 용어는 이탈리아어 "arpeggiare"에서 비롯되었으며, "하나씩 피다"라는 뜻입니다. 아르페지오는 화음의 구성음들을 순차적으로 연주하여 하나의 화음을 나타내는 방식으로 사용되며, 주로 빠르고 부드러운 연주로 특징지어지며, 서정적이고 우아한 분위기를 만들어냅니다.',
+  },
+};
+
+export const Primary13px: Story = {
+  args: {
+    type: 'primary',
+    fontSize: '13px',
+    children:
+      '아르페지오는 음악 용어로, 연주되는 음을 서로 다른 높낮이로 연속적으로 연주하는 기법을 가리킵니다. 주로 현악기나 기타와 같은 현악 악기에서 사용되며, 반주를 장식하거나 멜로디를 부각시키는 데에 쓰입니다. 이 용어는 이탈리아어 "arpeggiare"에서 비롯되었으며, "하나씩 피다"라는 뜻입니다. 아르페지오는 화음의 구성음들을 순차적으로 연주하여 하나의 화음을 나타내는 방식으로 사용되며, 주로 빠르고 부드러운 연주로 특징지어지며, 서정적이고 우아한 분위기를 만들어냅니다.',
+  },
+};
+
+export const Normal16px: Story = {
+  args: {
+    type: 'normal',
+    fontSize: '16px',
+    children:
+      '아르페지오는 음악 용어로, 연주되는 음을 서로 다른 높낮이로 연속적으로 연주하는 기법을 가리킵니다. 주로 현악기나 기타와 같은 현악 악기에서 사용되며, 반주를 장식하거나 멜로디를 부각시키는 데에 쓰입니다. 이 용어는 이탈리아어 "arpeggiare"에서 비롯되었으며, "하나씩 피다"라는 뜻입니다. 아르페지오는 화음의 구성음들을 순차적으로 연주하여 하나의 화음을 나타내는 방식으로 사용되며, 주로 빠르고 부드러운 연주로 특징지어지며, 서정적이고 우아한 분위기를 만들어냅니다.',
+  },
+};
+
+export const Normal14px: Story = {
+  args: {
+    type: 'normal',
+    fontSize: '14px',
+    children:
+      '아르페지오는 음악 용어로, 연주되는 음을 서로 다른 높낮이로 연속적으로 연주하는 기법을 가리킵니다. 주로 현악기나 기타와 같은 현악 악기에서 사용되며, 반주를 장식하거나 멜로디를 부각시키는 데에 쓰입니다. 이 용어는 이탈리아어 "arpeggiare"에서 비롯되었으며, "하나씩 피다"라는 뜻입니다. 아르페지오는 화음의 구성음들을 순차적으로 연주하여 하나의 화음을 나타내는 방식으로 사용되며, 주로 빠르고 부드러운 연주로 특징지어지며, 서정적이고 우아한 분위기를 만들어냅니다.',
+  },
+};
+
+export const Normal13px: Story = {
+  args: {
+    type: 'normal',
+    fontSize: '13px',
+    children:
+      '아르페지오는 음악 용어로, 연주되는 음을 서로 다른 높낮이로 연속적으로 연주하는 기법을 가리킵니다. 주로 현악기나 기타와 같은 현악 악기에서 사용되며, 반주를 장식하거나 멜로디를 부각시키는 데에 쓰입니다. 이 용어는 이탈리아어 "arpeggiare"에서 비롯되었으며, "하나씩 피다"라는 뜻입니다. 아르페지오는 화음의 구성음들을 순차적으로 연주하여 하나의 화음을 나타내는 방식으로 사용되며, 주로 빠르고 부드러운 연주로 특징지어지며, 서정적이고 우아한 분위기를 만들어냅니다.',
+  },
+};
+
+export const Code16px: Story = {
+  args: {
+    type: 'code',
+    fontSize: '16px',
+    children:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+  },
+};
+
+export const Code14px: Story = {
+  args: {
+    type: 'code',
+    fontSize: '14px',
+    children:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+  },
+};
+
+export const Code13px: Story = {
+  args: {
+    type: 'code',
+    fontSize: '13px',
+    children:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
   },
 };

--- a/src/components/common/Text/Text.styled.ts
+++ b/src/components/common/Text/Text.styled.ts
@@ -1,11 +1,23 @@
 import { styled, css } from 'styled-components';
 
-export const Text = styled.p<{ $type: 'primary' | 'normal' }>`
+export const Text = styled.p<{
+  $type: 'primary' | 'normal' | 'code';
+  $fontSize: '16px' | '14px' | '13px';
+}>`
+  font-size: ${({ $fontSize }) => $fontSize};
+
   ${({ theme, $type }) => {
     if ($type === 'primary') {
       return css`
         color: ${theme.color.GOLD};
         font-weight: 600;
+      `;
+    }
+
+    if ($type === 'code') {
+      return css`
+        font-family: 'IBM Plex Mono', Consolas, Pretendard;
+        color: ${theme.color.WHITE};
       `;
     }
 

--- a/src/components/common/Text/Text.tsx
+++ b/src/components/common/Text/Text.tsx
@@ -2,13 +2,18 @@ import type { PropsWithChildren } from 'react';
 import * as S from './Text.styled';
 
 interface TextProps {
-  type: 'primary' | 'normal';
+  type: 'primary' | 'normal' | 'code';
+  fontSize: '16px' | '14px' | '13px';
 }
 
 const Text = (props: PropsWithChildren<TextProps>) => {
-  const { type, children } = props;
+  const { type, fontSize, children } = props;
 
-  return <S.Text $type={type}>{children}</S.Text>;
+  return (
+    <S.Text $type={type} $fontSize={fontSize}>
+      {children}
+    </S.Text>
+  );
 };
 
 export default Text;

--- a/src/options.html
+++ b/src/options.html
@@ -5,9 +5,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Oxanium:wght@200..800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Oxanium:wght@200..800&display=swap"
       rel="stylesheet"
     />
+
     <link
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
     />


### PR DESCRIPTION
## PR 내용
본 PR에서는 일반 텍스트를 적을 때 사용하게 될 `<Text>` 컴포넌트의 기능을 필요에 따라 확장하였습니다.
- 폰트 크기로 이제 `13px | 14px | 16px` 중 하나를 골라 사용할 수 있습니다.
- `type="code"` 옵션을 추가했습니다. 이 옵션을 사용하면 폰트가 `IBM Plex Mono` 로 변경됩니다.

## 참고 자료
- #30 
- `type="code"`

![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/e537cf9c-b8c3-4199-b857-6d9d3a66aa9c)
