### PR TITLE
[FIX] Textarea 컴포넌트에 누락된 index 파일의 내용을 작성

### DIFF
--- a/src/components/common/Textarea/index.ts
+++ b/src/components/common/Textarea/index.ts
@@ -1,0 +1,3 @@
+import Textarea from './Textarea';
+
+export default Textarea;


### PR DESCRIPTION
## PR 내용
본 PR에서는 #37 에서 누락된 `index.ts` 파일의 내용을 작성하였습니다.

<img src="https://github.com/wzrabbit/boj-totamjung/assets/87642422/9727d773-d4de-458c-89e0-d34d5419b1df" width="250" />
