### PR TITLE
[FEAT] 공통 Input, Textarea 컴포넌트의 width/height로 더 넓은 범위의 사이즈를 설정할 수 있도록 변경

### DIFF
--- a/src/components/common/Input/Input.stories.tsx
+++ b/src/components/common/Input/Input.stories.tsx
@@ -16,7 +16,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     type: 'text',
-    width: 240,
+    width: '240px',
     value: '',
     textAlign: 'left',
     placeholder: '마음가는 대로 입력해 보세요',
@@ -28,7 +28,7 @@ export const Default: Story = {
 export const Error: Story = {
   args: {
     type: 'text',
-    width: 240,
+    width: '240px',
     value: '',
     textAlign: 'left',
     placeholder: '사람은 누구나 실수를 하죠',

--- a/src/components/common/Input/Input.styled.ts
+++ b/src/components/common/Input/Input.styled.ts
@@ -1,11 +1,12 @@
 import { styled } from 'styled-components';
+import type { CSSProperties } from 'styled-components';
 
 export const Input = styled.input<{
-  $width: number;
+  $width: CSSProperties['width'];
   $hasError: boolean;
   $textAlign: 'left' | 'center';
 }>`
-  width: ${({ $width }) => $width}px;
+  width: ${({ $width }) => $width};
   height: 30px;
   padding: 0 6px;
 

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -10,8 +10,7 @@ interface InputProps {
   placeholder: string;
   hasError: boolean;
   ariaLabel: string;
-
-  onChange: () => void;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
 }
 
 const Input = (props: InputProps) => {

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,8 +1,10 @@
+import type { ChangeEvent } from 'react';
+import type { CSSProperties } from 'styled-components';
 import * as S from './Input.styled';
 
 interface InputProps {
   type: 'text' | 'number';
-  width: number;
+  width: CSSProperties['width'];
   value: string;
   minLength?: number;
   maxLength?: number;

--- a/src/components/common/Textarea/Textarea.stories.tsx
+++ b/src/components/common/Textarea/Textarea.stories.tsx
@@ -15,8 +15,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    width: 560,
-    height: 140,
+    width: '560px',
+    height: '140px',
     value: '',
     placeholder: '마음가는 대로 입력해 보세요',
     hasError: false,
@@ -26,8 +26,8 @@ export const Default: Story = {
 
 export const Error: Story = {
   args: {
-    width: 560,
-    height: 140,
+    width: '560px',
+    height: '140px',
     value: '',
     placeholder: '사람은 누구나 실수를 하죠',
     hasError: true,

--- a/src/components/common/Textarea/Textarea.styled.ts
+++ b/src/components/common/Textarea/Textarea.styled.ts
@@ -1,12 +1,13 @@
 import { styled } from 'styled-components';
+import type { CSSProperties } from 'styled-components';
 
 export const Textarea = styled.textarea<{
-  $width: number;
-  $height: number;
+  $width: CSSProperties['width'];
+  $height: CSSProperties['height'];
   $hasError: boolean;
 }>`
-  width: ${({ $width }) => $width}px;
-  height: ${({ $height }) => $height}px;
+  width: ${({ $width }) => $width};
+  height: ${({ $height }) => $height};
   padding: 6px;
 
   border: 1.5px solid ${({ theme }) => theme.color.LIGHTER_BROWN};

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -1,8 +1,10 @@
+import type { ChangeEvent } from 'react';
+import type { CSSProperties } from 'styled-components';
 import * as S from './Textarea.styled';
 
 interface TextareaProps {
-  width: number;
-  height: number;
+  width: CSSProperties['width'];
+  height: CSSProperties['height'];
   value: string;
   minLength?: number;
   maxLength?: number;

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -9,7 +9,7 @@ interface TextareaProps {
   placeholder: string;
   hasError: boolean;
   ariaLabel: string;
-  onChange: () => void;
+  onChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 const Textarea = (props: TextareaProps) => {


### PR DESCRIPTION
## PR 내용
본 PR에서는 공통 인풋 컴포넌트인 `<Input>`, `<Textarea>`의 `width`/`height` prop에 대한 값으로, 정수만 사용할 수 있는 기존 방식에서 `CSSProperties['width']`와 같이, 더 넓은 범위의 길이 단위를 사용할 수 있도록 변경하였습니다.
- `%` 단위를 신규로 사용할 수 있게 되었고, `px` 의 경우 단위를 명시적으로 정하면서 사용할 수 있게 되었습니다.
- 모달 등에서 길이를 `100%` 와 같이 사용해야 하는 사용처가 생겨 이와 같은 변경사항을 내었습니다.

그 외에도, 아래의 문제를 수정했습니다.
- `<Input>`, `<Textarea>`의 `onChange` prop의 타입이 `() => void` 와 같이 잘못된 타입이 사용되고 있던 것을, `(event: ChangeEvent<HTMLInputElement>) => void`,  `(event: ChangeEvent<HTMLTextareaElement>) => void` 와 같이 실제 사용될 타입으로 수정했습니다.