### PR TITLE
[FEAT] `<IconButton>`에서 `width` prop을 제거

### DIFF
--- a/src/components/common/IconButton/IconButton.stories.tsx
+++ b/src/components/common/IconButton/IconButton.stories.tsx
@@ -22,7 +22,6 @@ export const MediumWithSvgIcon: Story = {
   args: {
     name: '버튼',
     size: 'medium',
-    width: '70px',
     color: '#49aaff',
     iconSrc: <PackageIcon />,
     disabled: false,
@@ -37,7 +36,6 @@ export const MediumWithSvgIconDisabled: Story = {
   args: {
     name: '버튼',
     size: 'medium',
-    width: '70px',
     color: '#49aaff',
     iconSrc: <PackageIcon />,
     disabled: true,
@@ -52,7 +50,6 @@ export const LargeWithSvgIcon: Story = {
   args: {
     name: '버튼',
     size: 'large',
-    width: '90px',
     color: '#49aaff',
     iconSrc: <PackageIcon />,
     disabled: false,
@@ -67,7 +64,6 @@ export const MediumWithImageIcon: Story = {
   args: {
     name: '버튼',
     size: 'medium',
-    width: '70px',
     color: '#ff4949',
     iconSrc: YOUTUBE_IMAGE_ICON_SRC,
     disabled: false,
@@ -82,7 +78,6 @@ export const LargeWithImageIcon: Story = {
   args: {
     name: '버튼',
     size: 'large',
-    width: '90px',
     color: '#ff4949',
     iconSrc: YOUTUBE_IMAGE_ICON_SRC,
     disabled: false,
@@ -97,7 +92,6 @@ export const MediumWithNoIcon: Story = {
   args: {
     name: '버튼',
     size: 'medium',
-    width: '40px',
     color: '#d9d9d9',
     disabled: false,
     ariaLabel: '테스트용 버튼',
@@ -111,7 +105,6 @@ export const LargeWithNoIcon: Story = {
   args: {
     name: '버튼',
     size: 'large',
-    width: '52px',
     color: '#d9d9d9',
     disabled: false,
     ariaLabel: '테스트용 버튼',

--- a/src/components/common/IconButton/IconButton.styled.ts
+++ b/src/components/common/IconButton/IconButton.styled.ts
@@ -2,7 +2,6 @@ import { styled } from 'styled-components';
 
 export const Button = styled.button<{
   $size: 'large' | 'medium';
-  $width: string;
   $color: string;
 }>`
   display: flex;
@@ -11,7 +10,7 @@ export const Button = styled.button<{
   align-items: center;
   justify-content: space-between;
 
-  width: ${({ $width }) => $width};
+  width: auto;
   height: ${({ $size }) => ($size === 'large' ? '40px' : '32px')};
   padding: ${({ $size }) => ($size === 'large' ? '4px 6px' : '2px 4px')};
 
@@ -23,7 +22,7 @@ export const Button = styled.button<{
   color: ${({ $color }) => $color};
 
   &:disabled {
-    opacity: 0.75;
+    opacity: 0.6;
   }
 
   &:not([disabled]):hover {

--- a/src/components/common/IconButton/IconButton.tsx
+++ b/src/components/common/IconButton/IconButton.tsx
@@ -1,11 +1,9 @@
 import * as S from './IconButton.styled';
 import { SVGProps } from 'react';
-import type { CSSProperties } from 'styled-components';
 
 interface IconButtonProps {
   name: string;
   size: 'large' | 'medium';
-  width: CSSProperties['width'];
   color: string;
   iconSrc?: string | SVGProps<SVGSVGElement>;
   disabled: boolean;
@@ -14,13 +12,11 @@ interface IconButtonProps {
 }
 
 const IconButton = (props: IconButtonProps) => {
-  const { name, size, width, color, iconSrc, disabled, ariaLabel, onClick } =
-    props;
+  const { name, size, color, iconSrc, disabled, ariaLabel, onClick } = props;
 
   return (
     <S.Button
       $size={size}
-      $width={width}
       $color={color}
       aria-label={ariaLabel}
       disabled={disabled}

--- a/src/components/common/Modal/Modal.stories.tsx
+++ b/src/components/common/Modal/Modal.stories.tsx
@@ -61,7 +61,6 @@ export const TextModal: Story = {
         <IconButton
           name="모달 열기"
           size="large"
-          width="90px"
           color="#a15eff"
           disabled={false}
           ariaLabel="모달 열기"
@@ -106,7 +105,6 @@ export const TextModal: Story = {
  *     <IconButton
  *       name="취소"
  *       size="medium"
- *       width="70px"
  *       color="#ff665e"
  *       iconSrc={<CloseCircleIcon />}
  *       disabled={false}
@@ -119,7 +117,6 @@ export const TextModal: Story = {
  *     <IconButton
  *       name="확인"
  *       size="medium"
- *       width="70px"
  *       color="#5eff69"
  *       iconSrc={<CheckCircleIcon />}
  *       disabled={false}
@@ -161,7 +158,6 @@ export const TextWithControlButtons: Story = {
             <IconButton
               name="취소"
               size="medium"
-              width="70px"
               color="#ff665e"
               iconSrc={<CloseCircleIcon />}
               disabled={false}
@@ -174,7 +170,6 @@ export const TextWithControlButtons: Story = {
             <IconButton
               name="확인"
               size="medium"
-              width="70px"
               color="#5eff69"
               iconSrc={<CheckCircleIcon />}
               disabled={false}
@@ -189,7 +184,6 @@ export const TextWithControlButtons: Story = {
         <IconButton
           name="모달 열기"
           size="large"
-          width="90px"
           color="#a15eff"
           disabled={false}
           ariaLabel="모달 열기"
@@ -240,7 +234,6 @@ export const VeryLongTitle: Story = {
             <IconButton
               name="그렇군요"
               size="medium"
-              width="96px"
               color="#a3a3a3"
               iconSrc={<CheckCircleIcon />}
               disabled={false}
@@ -254,7 +247,6 @@ export const VeryLongTitle: Story = {
         <IconButton
           name="모달 열기"
           size="large"
-          width="90px"
           color="#a15eff"
           disabled={false}
           ariaLabel="모달 열기"


### PR DESCRIPTION
## PR 내용
본 PR에서는 `<IconButton>`에서 `width` prop을 제거했습니다. 즉, 이제 사용하는 측에서는 `width`를 설정할 수 없습니다.
- #33 에서 언급한 **글자 수가 서로 다른 버튼이어도 가로 길이가 같아야 하는 디자인**을 사용하지 않도록 결정이 되었습니다. 이에 따라, 더 이상 `width` prop을 유지할 필요가 없게 되었습니다.
- 이제 버튼의 가로 길이는 버튼의 텍스트 길이에 따라 좌우됩니다.