### PR TITLE
[FEAT] `<Input>`과 `<Textarea>`에 ref를 사용할 수 있도록 변경

### DIFF
--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import type { ChangeEvent } from 'react';
 import type { CSSProperties } from 'styled-components';
 import * as S from './Input.styled';
@@ -15,7 +16,7 @@ interface InputProps {
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
 }
 
-const Input = (props: InputProps) => {
+const Input = forwardRef((props: InputProps, ref) => {
   const { width, hasError, textAlign, ariaLabel, ...rest } = props;
 
   return (
@@ -24,9 +25,10 @@ const Input = (props: InputProps) => {
       $hasError={hasError}
       $textAlign={textAlign}
       aria-label={ariaLabel}
+      ref={ref}
       {...rest}
     />
   );
-};
+});
 
 export default Input;

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import type { ChangeEvent } from 'react';
 import type { CSSProperties } from 'styled-components';
 import * as S from './Textarea.styled';
@@ -14,7 +15,7 @@ interface TextareaProps {
   onChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
-const Textarea = (props: TextareaProps) => {
+const Textarea = forwardRef((props: TextareaProps, ref) => {
   const { width, height, hasError, ariaLabel, ...rest } = props;
 
   return (
@@ -23,9 +24,10 @@ const Textarea = (props: TextareaProps) => {
       $height={height}
       $hasError={hasError}
       aria-label={ariaLabel}
+      ref={ref}
       {...rest}
     />
   );
-};
+});
 
 export default Textarea;


### PR DESCRIPTION
## PR 설명
본 PR에서는 `<Input>` 와 `<Textarea>` 에 `ref` prop을 사용할 수 있도록, 컴포넌트 내부에 `forwardRef`를 사용해 주었습니다.
- 두 컴포넌트를 포커싱할 일이 생겼기 때문에, 해당 변경사항을 냈습니다. 예를 들어, 입력값을 검증한 결과 입력값이 잘못되었을 경우, 해당 인풋을 포커싱하면서 하이라이팅해주는 기능이 필요합니다.

두 컴포넌트를 처음 구현했었던 PR은 아래와 같습니다.

- #28 
- #37 