### PR TITLE
[FIX] `<TierPresetButtonList>`에 누락된 React key prop을 사용

### DIFF
--- a/src/components/DifficultyAdjustMenu/TierPresetButtonList/TierPresetButtonList.tsx
+++ b/src/components/DifficultyAdjustMenu/TierPresetButtonList/TierPresetButtonList.tsx
@@ -22,7 +22,7 @@ const TierPresetButtonList = (props: TierPresetButtonListProps) => {
   return (
     <S.Container>
       {RANK_NAMES.map((rankName) => (
-        <TierPresetButton rank={rankName} onClick={onClick} />
+        <TierPresetButton key={rankName} rank={rankName} onClick={onClick} />
       ))}
     </S.Container>
   );


### PR DESCRIPTION
## PR 내용
본 PR에서는 추첨 생성 메뉴의 부속품 컴포넌트인 `<TierPresetButtonList>`에 미처 사용하지 못했던, React key prop을 사용해 주었습니다.
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/0bd05cf3-9f4a-436b-8e93-0285d65624fe)

<img src="https://github.com/wzrabbit/boj-totamjung/assets/87642422/0ba3bb1d-a28a-4c0a-b7e0-408afcf43639" width="160px" />
