### PR TITLE
[FEAT] `<TextLink>`의 폰트 크기를 16/14/13px로 정할 수 있도록 변경

### DIFF
--- a/src/components/common/TextLink/TextLink.stories.tsx
+++ b/src/components/common/TextLink/TextLink.stories.tsx
@@ -14,9 +14,26 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Size16px: Story = {
   args: {
     children: 'BOJ 실험실 페이지',
+    fontSize: '16px',
+    href: 'https://www.acmicpc.net/labs',
+  },
+};
+
+export const Size14px: Story = {
+  args: {
+    children: 'BOJ 실험실 페이지',
+    fontSize: '14px',
+    href: 'https://www.acmicpc.net/labs',
+  },
+};
+
+export const Size13px: Story = {
+  args: {
+    children: 'BOJ 실험실 페이지',
+    fontSize: '13px',
     href: 'https://www.acmicpc.net/labs',
   },
 };
@@ -27,13 +44,13 @@ export const Default: Story = {
 export const TextLinkWithText: Story = {
   decorators: [
     () => (
-      <Text type="normal">
+      <Text type="normal" fontSize="16px">
         Mathjax 수식을 간단하게 테스트해볼 수 있는 사이트로는{' '}
-        <TextLink href="https://www.mathjax.org/#demo">
+        <TextLink href="https://www.mathjax.org/#demo" fontSize="16px">
           Mathjax 데모 테스트 페이지
         </TextLink>
         , 또는{' '}
-        <TextLink href="https://www.acmicpc.net/labs">
+        <TextLink href="https://www.acmicpc.net/labs" fontSize="16px">
           BOJ 실험실 페이지
         </TextLink>
         가 있으니, 참고하시기 바랍니다.
@@ -42,6 +59,7 @@ export const TextLinkWithText: Story = {
   ],
   args: {
     href: '',
+    fontSize: '16px',
     children: '',
   },
 };

--- a/src/components/common/TextLink/TextLink.styled.ts
+++ b/src/components/common/TextLink/TextLink.styled.ts
@@ -2,13 +2,12 @@ import { styled } from 'styled-components';
 
 export const Container = styled.a`
   display: inline-flex;
+  align-items: center;
   column-gap: 2px;
 
-  font-size: 16px;
   color: ${({ theme }) => theme.color.LEMON};
 `;
 
-export const TextLink = styled.p`
 export const TextLink = styled.span<{ $fontSize: '16px' | '14px' | '13px' }>`
   font-size: ${({ $fontSize }) => $fontSize};
   text-decoration: underline 2px dotted;
@@ -23,11 +22,17 @@ export const TextLink = styled.span<{ $fontSize: '16px' | '14px' | '13px' }>`
   }
 `;
 
-export const LinkIconWrapper = styled.div`
-  width: 20px;
-  height: 20px;
+export const LinkIconWrapper = styled.span<{
+  $fontSize: '16px' | '14px' | '13px';
+}>`
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
 
-  & svg {
+  width: ${({ $fontSize }) => $fontSize};
+  height: ${({ $fontSize }) => $fontSize};
+
+  & > svg {
     width: 100%;
     height: 100%;
   }

--- a/src/components/common/TextLink/TextLink.styled.ts
+++ b/src/components/common/TextLink/TextLink.styled.ts
@@ -9,6 +9,8 @@ export const Container = styled.a`
 `;
 
 export const TextLink = styled.p`
+export const TextLink = styled.span<{ $fontSize: '16px' | '14px' | '13px' }>`
+  font-size: ${({ $fontSize }) => $fontSize};
   text-decoration: underline 2px dotted;
   -webkit-text-decoration-color: ${({ theme }) =>
     theme.color.TRANSPARENT_LEMON};

--- a/src/components/common/TextLink/TextLink.tsx
+++ b/src/components/common/TextLink/TextLink.tsx
@@ -3,16 +3,17 @@ import { LinkIcon } from '~images/svg';
 
 interface TextLinkProps {
   href: string;
+  fontSize: '16px' | '14px' | '13px';
   children: string;
 }
 
 const TextLink = (props: TextLinkProps) => {
-  const { href, children } = props;
+  const { href, fontSize, children } = props;
 
   return (
     <S.Container href={href} target="__blank" rel="noopener">
-      <S.TextLink>{children}</S.TextLink>
-      <S.LinkIconWrapper>
+      <S.TextLink $fontSize={fontSize}>{children}</S.TextLink>
+      <S.LinkIconWrapper $fontSize={fontSize}>
         <LinkIcon />
       </S.LinkIconWrapper>
     </S.Container>


### PR DESCRIPTION
## PR 내용
본 PR에서는 크기를 설정할 수 없던 `<TextLink>` 컴포넌트의 크기를 `16px`, `14px`, `13px` 중 하나로 설정할 수 있도록 변경하였습니다.
- `<TextLink>`의 경우 `<Text>`와 같이 범용적으로 자주 쓰일 것이 예상되며, 이 경우 `<TextLink>`와 `<Text>`의 폰트 크기가 같아야 어울리므로 `<Text>`와 마찬가지로 해당 컴포넌트도 상황에 따라 사용할 수 있도록 세 가지의 폰트 크기 중 원하는 크기를 설정할 수 있도록 변경했습니다.

그 외에, 본 컴포넌트의 경우 구조가 `<p>` 태그 내에 `<div>` 가 오는 구조였어서, 이 문제를 수정하고 `<p>` 태그 내에 `<span>`이 오는 구조로 바꾸었습니다.

## 참고 자료
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/347d4dc6-2e06-4ca4-bdf9-42894ca6bc4a)
