### PR TITLE
[FEAT] 폼을 구성하는 공통 컴포넌트들에 필요한 props들을 추가

### DIFF
--- a/src/components/AlgorithmPool/AlgorithmPool.tsx
+++ b/src/components/AlgorithmPool/AlgorithmPool.tsx
@@ -40,6 +40,7 @@ const AlgorithmPool = () => {
         </S.SearchPanelContainer>
         <S.CheckButtonPanel>
           <S.CheckButton
+            type="button"
             onClick={checkAllAlgorithms}
             aria-label="알고리즘 분류 전체 선택"
           >
@@ -47,6 +48,7 @@ const AlgorithmPool = () => {
             <S.CheckButtonLabel>전체 선택</S.CheckButtonLabel>
           </S.CheckButton>
           <S.CheckButton
+            type="button"
             onClick={uncheckAllAlgorithms}
             aria-label="알고리즘 분류 전체 해제"
           >

--- a/src/components/DifficultyAdjustMenu/TierPresetButtonList/TierPresetButton/TierPresetButton.tsx
+++ b/src/components/DifficultyAdjustMenu/TierPresetButtonList/TierPresetButton/TierPresetButton.tsx
@@ -44,6 +44,7 @@ const TierPresetButtonProps = (props: TierPresetButtonProps) => {
   return (
     <S.Container>
       <S.Button
+        type="button"
         $rank={rank}
         aria-label={ARIA_LABEL_TEXTS[rank]}
         onClick={() => {

--- a/src/components/QuickSlotMenu/QuickSlotMenu.tsx
+++ b/src/components/QuickSlotMenu/QuickSlotMenu.tsx
@@ -44,6 +44,7 @@ const QuickSlotMenu = () => {
           <SlotInfo {...slot} />
           <S.SlotControlPanel>
             <IconButton
+              type="button"
               name="쿼리 복사"
               size="medium"
               color={theme.color.LIGHT_GRAY}
@@ -58,6 +59,7 @@ const QuickSlotMenu = () => {
               }}
             />
             <IconButton
+              type="button"
               name="수정"
               size="medium"
               color={theme.color.SKY_BLUE}
@@ -67,6 +69,7 @@ const QuickSlotMenu = () => {
               onClick={openEditModal}
             />
             <IconButton
+              type="button"
               name="삭제"
               size="medium"
               color={theme.color.RED}

--- a/src/components/QuickSlotMenu/SlotEditModal/SlotEditModal.stories.tsx
+++ b/src/components/QuickSlotMenu/SlotEditModal/SlotEditModal.stories.tsx
@@ -23,6 +23,7 @@ export const Default: Story = {
     return (
       <>
         <IconButton
+          type="button"
           name="모달 열기"
           size="large"
           color="#d1b072"

--- a/src/components/QuickSlotMenu/SlotEditModal/SlotEditModal.styled.ts
+++ b/src/components/QuickSlotMenu/SlotEditModal/SlotEditModal.styled.ts
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 
-export const ModalContent = styled.div`
+export const Form = styled.form`
   display: flex;
   flex-direction: column;
   row-gap: 12px;

--- a/src/components/QuickSlotMenu/SlotEditModal/SlotEditModal.tsx
+++ b/src/components/QuickSlotMenu/SlotEditModal/SlotEditModal.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { theme } from '~styles/theme';
 import Modal, { ModalActionButtonsContainer } from '~components/common/Modal';
 import IconButton from '~components/common/IconButton';
@@ -26,8 +25,6 @@ const SlotEditModal = (props: SlotEditModalProps) => {
     onClose,
     onSlotChange,
   } = props;
-  const slotNameRef = useRef(null);
-  const queryRef = useRef(null);
   const {
     slotName,
     query,
@@ -37,17 +34,17 @@ const SlotEditModal = (props: SlotEditModalProps) => {
     setQuery,
     setSlotName,
     submitSlotInfo,
+    slotNameRef,
+    queryRef,
   } = useSlotEditModal({
     initSlotName,
     initQuery,
-    slotNameRef,
-    queryRef,
     onSlotChange,
   });
 
   return (
     <Modal title="추첨 수정" open={open} onClose={onClose}>
-      <S.ModalContent>
+      <S.Form>
         <S.Label>
           <Text type="primary" fontSize="16px">
             추첨 이름
@@ -55,6 +52,7 @@ const SlotEditModal = (props: SlotEditModalProps) => {
           <Input
             type="text"
             width="100%"
+            name="title"
             value={slotName}
             ref={slotNameRef}
             textAlign="left"
@@ -74,6 +72,7 @@ const SlotEditModal = (props: SlotEditModalProps) => {
           <Textarea
             width="100%"
             height="150px"
+            name="query"
             value={query}
             ref={queryRef}
             maxLength={300}
@@ -86,9 +85,10 @@ const SlotEditModal = (props: SlotEditModalProps) => {
           />
         </S.Label>
         <ErrorText fontSize="14px" errorMessage={errorMessage} />
-      </S.ModalContent>
+      </S.Form>
       <ModalActionButtonsContainer>
         <IconButton
+          type="button"
           name="취소"
           size="medium"
           iconSrc={<CloseCircleIcon />}
@@ -98,15 +98,14 @@ const SlotEditModal = (props: SlotEditModalProps) => {
           onClick={onClose}
         />
         <IconButton
+          type="button"
           name="확인"
           size="medium"
           iconSrc={<CheckCircleIcon />}
           color={theme.color.GOLD}
           disabled={false}
           ariaLabel="확인"
-          onClick={() => {
-            submitSlotInfo();
-          }}
+          onClick={submitSlotInfo}
         />
       </ModalActionButtonsContainer>
     </Modal>

--- a/src/components/RandomDefenseCapsuleButton/RandomDefenseCapsuleButton.tsx
+++ b/src/components/RandomDefenseCapsuleButton/RandomDefenseCapsuleButton.tsx
@@ -12,6 +12,7 @@ const RandomDefenseCapsuleButton = (props: RandomDefenseCapsuleButtonProps) => {
   return (
     <S.Container>
       <S.LeftButton
+        type="button"
         $isActivated={mode === 'easy'}
         onClick={() => {
           onClick('easy');
@@ -21,6 +22,7 @@ const RandomDefenseCapsuleButton = (props: RandomDefenseCapsuleButtonProps) => {
         간편 입력
       </S.LeftButton>
       <S.RightButton
+        type="button"
         $isActivated={mode === 'manual'}
         onClick={() => {
           onClick('manual');

--- a/src/components/common/IconButton/IconButton.stories.tsx
+++ b/src/components/common/IconButton/IconButton.stories.tsx
@@ -20,6 +20,7 @@ const YOUTUBE_IMAGE_ICON_SRC =
 
 export const MediumWithSvgIcon: Story = {
   args: {
+    type: 'button',
     name: '버튼',
     size: 'medium',
     color: '#49aaff',
@@ -34,6 +35,7 @@ export const MediumWithSvgIcon: Story = {
 
 export const MediumWithSvgIconDisabled: Story = {
   args: {
+    type: 'button',
     name: '버튼',
     size: 'medium',
     color: '#49aaff',
@@ -48,6 +50,7 @@ export const MediumWithSvgIconDisabled: Story = {
 
 export const LargeWithSvgIcon: Story = {
   args: {
+    type: 'button',
     name: '버튼',
     size: 'large',
     color: '#49aaff',
@@ -62,6 +65,7 @@ export const LargeWithSvgIcon: Story = {
 
 export const MediumWithImageIcon: Story = {
   args: {
+    type: 'button',
     name: '버튼',
     size: 'medium',
     color: '#ff4949',
@@ -76,6 +80,7 @@ export const MediumWithImageIcon: Story = {
 
 export const LargeWithImageIcon: Story = {
   args: {
+    type: 'button',
     name: '버튼',
     size: 'large',
     color: '#ff4949',
@@ -90,6 +95,7 @@ export const LargeWithImageIcon: Story = {
 
 export const MediumWithNoIcon: Story = {
   args: {
+    type: 'button',
     name: '버튼',
     size: 'medium',
     color: '#d9d9d9',
@@ -103,6 +109,7 @@ export const MediumWithNoIcon: Story = {
 
 export const LargeWithNoIcon: Story = {
   args: {
+    type: 'button',
     name: '버튼',
     size: 'large',
     color: '#d9d9d9',

--- a/src/components/common/IconButton/IconButton.tsx
+++ b/src/components/common/IconButton/IconButton.tsx
@@ -1,27 +1,32 @@
 import * as S from './IconButton.styled';
 import { SVGProps } from 'react';
 
-interface IconButtonProps {
+interface CommonIconButtonProps {
   name: string;
   size: 'large' | 'medium';
   color: string;
   iconSrc?: string | SVGProps<SVGSVGElement>;
   disabled: boolean;
   ariaLabel: string;
+}
+
+interface ButtonTypeProps {
+  type: 'submit';
+}
+
+interface SubmitTypeProps {
+  type: 'button';
   onClick: () => void;
 }
 
+type IconButtonProps = CommonIconButtonProps &
+  (ButtonTypeProps | SubmitTypeProps);
+
 const IconButton = (props: IconButtonProps) => {
-  const { name, size, color, iconSrc, disabled, ariaLabel, onClick } = props;
+  const { name, size, color, iconSrc, ariaLabel, ...rest } = props;
 
   return (
-    <S.Button
-      $size={size}
-      $color={color}
-      aria-label={ariaLabel}
-      disabled={disabled}
-      onClick={onClick}
-    >
+    <S.Button $size={size} $color={color} aria-label={ariaLabel} {...rest}>
       {iconSrc &&
         (typeof iconSrc === 'string' ? (
           <S.IconImage src={iconSrc} alt={name} $size={size} />

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -6,6 +6,7 @@ import * as S from './Input.styled';
 interface InputProps {
   type: 'text' | 'number';
   width: CSSProperties['width'];
+  name?: string;
   value: string;
   minLength?: number;
   maxLength?: number;

--- a/src/components/common/Modal/Modal.stories.tsx
+++ b/src/components/common/Modal/Modal.stories.tsx
@@ -59,6 +59,7 @@ export const TextModal: Story = {
           </div>
         </Modal>
         <IconButton
+          type="button"
           name="모달 열기"
           size="large"
           color="#a15eff"
@@ -103,6 +104,7 @@ export const TextModal: Story = {
  *   </div>
  *   <ModalActionButtonsContainer>
  *     <IconButton
+ *       type="button"
  *       name="취소"
  *       size="medium"
  *       color="#ff665e"
@@ -115,6 +117,7 @@ export const TextModal: Story = {
  *       }}
  *     />
  *     <IconButton
+ *       type="button"
  *       name="확인"
  *       size="medium"
  *       color="#5eff69"
@@ -156,6 +159,7 @@ export const TextWithControlButtons: Story = {
           </div>
           <ModalActionButtonsContainer>
             <IconButton
+              type="button"
               name="취소"
               size="medium"
               color="#ff665e"
@@ -168,6 +172,7 @@ export const TextWithControlButtons: Story = {
               }}
             />
             <IconButton
+              type="button"
               name="확인"
               size="medium"
               color="#5eff69"
@@ -182,6 +187,7 @@ export const TextWithControlButtons: Story = {
           </ModalActionButtonsContainer>
         </Modal>
         <IconButton
+          type="button"
           name="모달 열기"
           size="large"
           color="#a15eff"
@@ -232,6 +238,7 @@ export const VeryLongTitle: Story = {
           </div>
           <ModalActionButtonsContainer>
             <IconButton
+              type="button"
               name="그렇군요"
               size="medium"
               color="#a3a3a3"
@@ -245,6 +252,7 @@ export const VeryLongTitle: Story = {
           </ModalActionButtonsContainer>
         </Modal>
         <IconButton
+          type="button"
           name="모달 열기"
           size="large"
           color="#a15eff"

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -6,6 +6,7 @@ import * as S from './Textarea.styled';
 interface TextareaProps {
   width: CSSProperties['width'];
   height: CSSProperties['height'];
+  name?: string;
   value: string;
   minLength?: number;
   maxLength?: number;

--- a/src/hooks/randomDefense/useSlotEditModal.ts
+++ b/src/hooks/randomDefense/useSlotEditModal.ts
@@ -1,24 +1,22 @@
-import { useState, useEffect } from 'react';
-import type { RefObject } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { validateSlot } from '~domains/randomDefense/slotValidator';
 
 interface UseSlotEditModalParams {
   initSlotName: string;
   initQuery: string;
-  slotNameRef: RefObject<HTMLInputElement>;
-  queryRef: RefObject<HTMLTextAreaElement>;
   onSlotChange: (slotName: string, query: string) => void;
 }
 
 const useSlotEditModal = (params: UseSlotEditModalParams) => {
-  const { initSlotName, initQuery, slotNameRef, queryRef, onSlotChange } =
-    params;
+  const { initSlotName, initQuery, onSlotChange } = params;
   const [slotName, setSlotName] = useState(initSlotName);
   const [query, setQuery] = useState(initQuery);
   const [errorMessage, setErrorMessage] = useState('');
   const [errorElementName, setErrorElementName] = useState<string | undefined>(
     undefined,
   );
+  const slotNameRef = useRef<HTMLInputElement>(null);
+  const queryRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     setSlotName(initSlotName);
@@ -64,6 +62,8 @@ const useSlotEditModal = (params: UseSlotEditModalParams) => {
     setQuery,
     setSlotName,
     submitSlotInfo,
+    slotNameRef,
+    queryRef,
   };
 };
 


### PR DESCRIPTION
## PR 설명
본 PR에서는 폼을 구성하는 공통 컴포넌트인 `<Input>`, `<Textarea>`, `<IconButton>` 에 폼 처리에 필요한 props를 추가했습니다.
- `<Input>`, `<Textarea>`: `name` props. 이 props는 optional입니다. `name` 을 필요로 하는 메뉴가 있고, 그렇지 않은 메뉴도 있기 때문입니다.
- `<IconButton>`: `type` props. `<form>`을 사용하게 되면서, 각 아이콘 버튼의 타입이 명확하게 명시되어야 해서 추가하였습니다.
- 위 3개의 컴포넌트의 변경으로 영향을 받게 된 컴포넌트들에 대한 변경사항도 포함되어 있습니다.
- 컴포넌트에서 선언한 `ref`들을 전부 커스텀 훅에서 선언하여 반환하도록 변경하였습니다. 이 방법이 더 UI 로직과 커스텀 훅의 로직을 분리하기에 적합해 보였기 때문입니다.