### PR TITLE
[REFACTOR] `<AlgorithmSearchInput>`이 알고리즘 분류의 아이디만으로 기능을 수행하도록 변경

### DIFF
--- a/src/components/AlgorithmSearchInput/AlgorithmSearchInput.stories.tsx
+++ b/src/components/AlgorithmSearchInput/AlgorithmSearchInput.stories.tsx
@@ -29,17 +29,9 @@ export const Default: Story = {
     },
   ],
   args: {
-    selectedAlgorithms: [
-      { id: 8, name: '브루트포스 알고리즘' },
-      { id: 35, name: '트리에서의 다이나믹 프로그래밍' },
-      { id: 82, name: '가장 긴 증가하는 부분 수열 O(log n)' },
-    ],
-    onChange: (algorithms) => {
-      alert(
-        `onChange([${algorithms.map(
-          ({ id, name }) => `\n  ${JSON.stringify({ id, name })}`,
-        )}])`,
-      );
+    selectedAlgorithmIds: [8, 35, 82],
+    onChange: (algorithmIds) => {
+      alert(`onChange([${algorithmIds.join(', ')}])`);
     },
   },
 };
@@ -63,19 +55,9 @@ export const ReachedLimit: Story = {
     },
   ],
   args: {
-    selectedAlgorithms: [
-      { id: 8, name: '브루트포스 알고리즘' },
-      { id: 35, name: '트리에서의 다이나믹 프로그래밍' },
-      { id: 82, name: '가장 긴 증가하는 부분 수열 O(log n)' },
-      { id: 127, name: '덱을 이용한 다이나믹 프로그래밍' },
-      { id: 40, name: '느리게 갱신되는 세그먼트 트리' },
-    ],
-    onChange: (algorithms) => {
-      alert(
-        `onChange([${algorithms.map(
-          ({ id, name }) => `\n  ${JSON.stringify({ id, name })}`,
-        )}])`,
-      );
+    selectedAlgorithmIds: [8, 35, 82, 127, 40],
+    onChange: (algorithmIds) => {
+      alert(`onChange([${algorithmIds.join(', ')}])`);
     },
   },
 };

--- a/src/components/AlgorithmSearchInput/AlgorithmSearchInput.tsx
+++ b/src/components/AlgorithmSearchInput/AlgorithmSearchInput.tsx
@@ -1,30 +1,27 @@
-import { useRef } from 'react';
 import * as S from './AlgorithmSearchInput.styled';
 import MiniAlgorithmButton from './MiniAlgorithmButton';
 import useAlgorithmSearchInput from '~hooks/randomDefense/useAlgorithmSearchInput';
-import type { Algorithm } from '~types/algorithm';
+import { ALGORITHM_INFOS } from '~constants/algorithmInfos';
 
 interface AlgorithmSearchInputProps {
-  selectedAlgorithms: Algorithm[];
-  onChange: (selectedAlgorithms: Algorithm[]) => void;
+  selectedAlgorithmIds: number[];
+  onChange: (selectedAlgorithmIds: number[]) => void;
 }
 
 const AlgorithmSearchInput = (props: AlgorithmSearchInputProps) => {
-  const { selectedAlgorithms, onChange } = props;
-  const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const { selectedAlgorithmIds, onChange } = props;
   const {
     isOpen,
     inputValue,
-    searchedAlgorithms,
+    searchedAlgorithmIds,
     updateInputValue,
     processActionIfKeyPress,
-    addAlgorithm,
-    deleteAlgorithm,
-  } = useAlgorithmSearchInput({
+    addAlgorithmId,
+    deleteAlgorithmId,
     containerRef,
     inputRef,
-    selectedAlgorithms,
+  } = useAlgorithmSearchInput({
+    selectedAlgorithmIds,
     onChange,
   });
 
@@ -32,15 +29,24 @@ const AlgorithmSearchInput = (props: AlgorithmSearchInputProps) => {
     <S.Container ref={containerRef} $isOpen={isOpen} tabIndex={-1}>
       <S.InputPanel tabIndex={-1}>
         <>
-          {selectedAlgorithms.map(({ id, name }) => (
-            <MiniAlgorithmButton
-              key={id}
-              mode="delete"
-              id={id}
-              name={name}
-              onClick={deleteAlgorithm}
-            />
-          ))}
+          {selectedAlgorithmIds.map((selectedId) => {
+            const searchedAlgorithm = ALGORITHM_INFOS.find(
+              ({ id }) => id === selectedId,
+            );
+            const searchedName = searchedAlgorithm
+              ? searchedAlgorithm.name
+              : '';
+
+            return (
+              <MiniAlgorithmButton
+                key={selectedId}
+                mode="delete"
+                id={selectedId}
+                name={searchedName}
+                onClick={deleteAlgorithmId}
+              />
+            );
+          })}
           <S.SearchInput
             ref={inputRef}
             maxLength={100}
@@ -53,15 +59,22 @@ const AlgorithmSearchInput = (props: AlgorithmSearchInputProps) => {
         </>
       </S.InputPanel>
       <S.SearchResultPanel $isOpen={isOpen} tabIndex={-1}>
-        {searchedAlgorithms.map(({ id, name }) => (
-          <MiniAlgorithmButton
-            key={id}
-            mode="add"
-            id={id}
-            name={name}
-            onClick={addAlgorithm}
-          />
-        ))}
+        {searchedAlgorithmIds.map((selectedId) => {
+          const searchedAlgorithm = ALGORITHM_INFOS.find(
+            ({ id }) => id === selectedId,
+          );
+          const searchedName = searchedAlgorithm ? searchedAlgorithm.name : '';
+
+          return (
+            <MiniAlgorithmButton
+              key={selectedId}
+              mode="add"
+              id={selectedId}
+              name={searchedName}
+              onClick={addAlgorithmId}
+            />
+          );
+        })}
       </S.SearchResultPanel>
     </S.Container>
   );

--- a/src/components/AlgorithmSearchInput/MiniAlgorithmButton/MiniAlgorithmButton.tsx
+++ b/src/components/AlgorithmSearchInput/MiniAlgorithmButton/MiniAlgorithmButton.tsx
@@ -1,12 +1,11 @@
 import * as S from './MiniAlgorithmButton.styled';
-import type { Algorithm } from '~types/algorithm';
 import { CloseSmallIcon } from '~images/svg';
 
 interface MiniAlgorithmButtonProps {
   id: number;
   name: string;
   mode: 'add' | 'delete';
-  onClick: (algorithm: Algorithm) => void;
+  onClick: (algorithmId: number) => void;
 }
 
 const MiniAlgorithmButton = (props: MiniAlgorithmButtonProps) => {
@@ -15,13 +14,14 @@ const MiniAlgorithmButton = (props: MiniAlgorithmButtonProps) => {
   return (
     <S.Container>
       <S.Button
+        type="button"
         aria-label={
           mode === 'add'
             ? `${name}을 검색에 포함할 알고리즘 목록에 추가하기`
             : `${name}을 검색에 포함할 알고리즘 목록에서 제거하기`
         }
         onClick={() => {
-          onClick({ id, name });
+          onClick(id);
         }}
       >
         <S.Text>{name}</S.Text>

--- a/src/hooks/randomDefense/useAlgorithmSearchInput.ts
+++ b/src/hooks/randomDefense/useAlgorithmSearchInput.ts
@@ -1,45 +1,39 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { getSearchResults } from '~domains/algorithm/getSearchResults';
 import { MAX_SEARCH_ALGORITHM_COUNT } from '~constants/randomDefense';
-import type { Algorithm } from '~types/algorithm';
-import type {
-  ChangeEventHandler,
-  KeyboardEventHandler,
-  RefObject,
-} from 'react';
+import type { ChangeEventHandler, KeyboardEventHandler } from 'react';
 
 interface UseAlgorithmSearchInputParams {
-  containerRef: RefObject<HTMLDivElement>;
-  inputRef: RefObject<HTMLInputElement>;
-  selectedAlgorithms: Algorithm[];
-  onChange: (algorithms: Algorithm[]) => void;
+  selectedAlgorithmIds: number[];
+  onChange: (algorithmIds: number[]) => void;
 }
 
 const useAlgorithmSearchInput = (params: UseAlgorithmSearchInputParams) => {
-  const { containerRef, inputRef, selectedAlgorithms, onChange } = params;
+  const { selectedAlgorithmIds, onChange } = params;
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const updateInputValue: ChangeEventHandler<HTMLInputElement> = (event) => {
-    setInputValue(() => event.target.value);
+    setInputValue(event.target.value);
   };
 
-  const selectedAlgorithmIds = selectedAlgorithms.map(({ id }) => id);
-  const searchedAlgorithms =
-    selectedAlgorithms.length < MAX_SEARCH_ALGORITHM_COUNT
-      ? getSearchResults(inputValue).filter(
-          ({ id }) => !selectedAlgorithmIds.includes(id),
-        )
+  const searchedAlgorithmIds =
+    selectedAlgorithmIds.length < MAX_SEARCH_ALGORITHM_COUNT
+      ? getSearchResults(inputValue)
+          .filter(({ id }) => !selectedAlgorithmIds.includes(id))
+          .map(({ id }) => id)
       : [];
 
   const processActionIfKeyPress: KeyboardEventHandler = (event) => {
     if (event.key === 'Enter') {
-      if (searchedAlgorithms.length === 0) {
+      if (searchedAlgorithmIds.length === 0) {
         return;
       }
 
-      onChange([...selectedAlgorithms, searchedAlgorithms[0]]);
-      setInputValue(() => '');
+      onChange([...selectedAlgorithmIds, searchedAlgorithmIds[0]]);
+      setInputValue('');
     }
 
     if (event.key === 'Backspace') {
@@ -47,17 +41,17 @@ const useAlgorithmSearchInput = (params: UseAlgorithmSearchInputParams) => {
         return;
       }
 
-      onChange(selectedAlgorithms.slice(0, -1));
+      onChange(selectedAlgorithmIds.slice(0, -1));
     }
   };
 
-  const addAlgorithm = (algorithm: Algorithm) => {
-    onChange([...selectedAlgorithms, algorithm]);
-    setInputValue(() => '');
+  const addAlgorithmId = (algorithmId: number) => {
+    onChange([...selectedAlgorithmIds, algorithmId]);
+    setInputValue('');
   };
 
-  const deleteAlgorithm = (algorithm: Algorithm) => {
-    onChange(selectedAlgorithms.filter(({ id }) => id !== algorithm.id));
+  const deleteAlgorithmId = (algorithmId: number) => {
+    onChange(selectedAlgorithmIds.filter((id) => id !== algorithmId));
   };
 
   useEffect(() => {
@@ -99,11 +93,13 @@ const useAlgorithmSearchInput = (params: UseAlgorithmSearchInputParams) => {
   return {
     isOpen,
     inputValue,
-    searchedAlgorithms,
+    searchedAlgorithmIds,
     updateInputValue,
     processActionIfKeyPress,
-    addAlgorithm,
-    deleteAlgorithm,
+    addAlgorithmId,
+    deleteAlgorithmId,
+    containerRef,
+    inputRef,
   };
 };
 


### PR DESCRIPTION
## PR 설명
본 PR에서는 `<AlgorithmSearchInput>`에서 알고리즘 분류들을 다룰 때, 기존의 `Algorithm[]` 타입 대신, `number[]` 타입 형태로만 알고리즘 분류들을 관리하도록 변경하였습니다.
- 스토리지를 포함해 부모 단계의 컴포넌트에서는 `number[]` 형태로 알고리즘 분류들의 `id`만을 이용해 관리하고 있기 때문에, 하위 컴포넌트인 `<AlgorithmSearchInput>`가 `number[]` 형태로 알고리즘 분류들의 데이터를 받아 사용이 편하도록 하기 위함입니다.
- 알고리즘의 이름은 `<AlgorithmSearchInput>` 컴포넌트 자신이 직접 이름을 찾아 렌더링하므로, 사용처에서는 아이디를 제외한 그 어떠한 정보를 모르더라도 구현이 가능하며, 각 컴포넌트가 자신의 역할만을 충실하게 수행하도록 하는 데 용이한 결정이라고 판단하였습니다.