### PR TITLE
[FEAT] 슬라이더의 시작 티어와 끝 티어가 엇갈리는 경우가 생길 경우 다른 한쪽의 슬라이더를 자동으로 조정하도록 개선

### DIFF
--- a/src/components/DifficultyAdjustMenu/TierSlider/TierSlider.tsx
+++ b/src/components/DifficultyAdjustMenu/TierSlider/TierSlider.tsx
@@ -23,9 +23,13 @@ const TierSlider = (props: TierSliderProps) => {
         aria-label="시작 범위 티어 설정하기"
         onChange={(event: ChangeEvent<HTMLInputElement>) => {
           const newStartTier = Number(event.target.value);
+          const newEndTier = Math.max(Number(newStartTier), endTier);
 
-          if (isTierWithoutNotRatable(newStartTier)) {
-            onChange(newStartTier, endTier);
+          if (
+            isTierWithoutNotRatable(newStartTier) &&
+            isTierWithoutNotRatable(newEndTier)
+          ) {
+            onChange(newStartTier, newEndTier);
           }
         }}
       />
@@ -37,9 +41,13 @@ const TierSlider = (props: TierSliderProps) => {
         aria-label="끝 범위 티어 설정하기"
         onChange={(event: ChangeEvent<HTMLInputElement>) => {
           const newEndTier = Number(event.target.value);
+          const newStartTier = Math.min(Number(newEndTier), startTier);
 
-          if (isTierWithoutNotRatable(newEndTier)) {
-            onChange(startTier, newEndTier);
+          if (
+            isTierWithoutNotRatable(newStartTier) &&
+            isTierWithoutNotRatable(newEndTier)
+          ) {
+            onChange(newStartTier, newEndTier);
           }
         }}
       />


### PR DESCRIPTION
## PR 내용
본 PR에서는 `<TierSlider>`의 범위 조작 도중 시작 티어와 끝 티어의 난이도가 엇갈리는 경우(시작 티어 > 끝 티어) 다른 한쪽의 슬라이더를 범위를 만족하도록 자동으로 조정하도록 개선하였습니다.

## 참고 자료

https://github.com/wzrabbit/boj-totamjung/assets/87642422/007cd2a0-e7a8-41f9-8f47-3430394ff0d3

