### PR TITLE
[FEAT] 알고리즘 검색 옵션을 정할 수 있는 컴포넌트 구현

### DIFF
--- a/src/components/SearchOperatorSelect/SearchOperatorSelect.stories.tsx
+++ b/src/components/SearchOperatorSelect/SearchOperatorSelect.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SearchOperatorSelect from './SearchOperatorSelect';
+
+/**
+ * `SearchOperatorSelect`는 추첨 생성 폼에서, 검색에 포함할 알고리즘들의 검색 방법을 정할 수 있는 컴포넌트입니다. 보다 구체적으로는, 여러 개의 알고리즘을 쿼리에 포함시킬 때, 사용할 연산자(`|`, `&`, `-`)를 정할 수 있습니다.
+ */
+const meta = {
+  title: 'SearchOperatorSelect',
+  component: SearchOperatorSelect,
+  argTypes: {},
+} satisfies Meta<typeof SearchOperatorSelect>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    searchOperator: 'AND',
+    onClick: (searchOperator) => {
+      alert(`onClick('${searchOperator}')`);
+    },
+  },
+};

--- a/src/components/SearchOperatorSelect/SearchOperatorSelect.styled.ts
+++ b/src/components/SearchOperatorSelect/SearchOperatorSelect.styled.ts
@@ -1,0 +1,56 @@
+import { styled, keyframes } from 'styled-components';
+
+export const Container = styled.ul`
+  display: flex;
+  justify-content: space-between;
+
+  width: 180px;
+  height: 18px;
+
+  user-select: none;
+`;
+
+export const ButtonContainer = styled.li`
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+  column-gap: 2px;
+
+  width: 52px;
+  height: 18px;
+`;
+
+const zoomInOut = keyframes`
+  from {
+    transform: scale(0.5);
+  }
+  
+  to {
+    transform: scale(1);
+  }
+`;
+
+export const CheckIconWrapper = styled.div`
+  width: 16px;
+  height: 16px;
+
+  & svg {
+    width: 16px;
+    height: 16px;
+
+    color: ${({ theme }) => theme.color.GOLD};
+
+    animation: ${zoomInOut} 0.15s forwards;
+  }
+`;
+
+export const Button = styled.button<{ $isSelected: boolean }>`
+  width: auto;
+  height: 18px;
+  background: transparent;
+
+  font-size: 16px;
+  font-weight: 600;
+  color: ${({ theme, $isSelected }) =>
+    $isSelected ? theme.color.GOLD : theme.color.LIGHT_GRAY};
+`;

--- a/src/components/SearchOperatorSelect/SearchOperatorSelect.tsx
+++ b/src/components/SearchOperatorSelect/SearchOperatorSelect.tsx
@@ -1,0 +1,39 @@
+import { CheckIcon } from '~images/svg';
+import * as S from './SearchOperatorSelect.styled';
+
+interface SearchOperatorSelectProps {
+  searchOperator: 'OR' | 'AND' | 'NOR';
+  onClick: (searchOperator: 'OR' | 'AND' | 'NOR') => void;
+}
+
+const OPERATORS = ['OR', 'AND', 'NOR'] as const;
+
+const SearchOperatorSelect = (props: SearchOperatorSelectProps) => {
+  const { searchOperator, onClick } = props;
+
+  return (
+    <S.Container>
+      {OPERATORS.map((operator) => (
+        <S.ButtonContainer>
+          {operator === searchOperator && (
+            <S.CheckIconWrapper>
+              <CheckIcon />
+            </S.CheckIconWrapper>
+          )}
+          <S.Button
+            type="button"
+            aria-label={`알고리즘 검색 옵션을 ${operator}로 설정하기`}
+            $isSelected={operator === searchOperator}
+            onClick={() => {
+              onClick(operator);
+            }}
+          >
+            {operator}
+          </S.Button>
+        </S.ButtonContainer>
+      ))}
+    </S.Container>
+  );
+};
+
+export default SearchOperatorSelect;

--- a/src/components/SearchOperatorSelect/index.ts
+++ b/src/components/SearchOperatorSelect/index.ts
@@ -1,0 +1,3 @@
+import SearchOperatorSelect from './SearchOperatorSelect';
+
+export default SearchOperatorSelect;

--- a/src/images/svg/check.svg
+++ b/src/images/svg/check.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M20 7L10 17l-5-5"/></svg>

--- a/src/images/svg/index.ts
+++ b/src/images/svg/index.ts
@@ -11,3 +11,4 @@ export { ReactComponent as SwitchIcon } from './switch.svg';
 export { ReactComponent as CopyIcon } from './copy.svg';
 export { ReactComponent as EditIcon } from './edit.svg';
 export { ReactComponent as WarningIcon } from './warning.svg';
+export { ReactComponent as CheckIcon } from './check.svg';


### PR DESCRIPTION
## PR 설명
본 PR에서는 알고리즘 검색 옵션을 정할 수 있는 컴포넌트를 구현했습니다. 보다 구체적으로는, 추첨 옵션에서 여러 개의 알고리즘을 검색어로 설정할 경우 사용할 연산자 (`|`, `&`, `-`)를 사용자가 설정할 수 있도록 옵션을 제공하는 컴포넌트입니다. -- `<SearchOperatorSelect>`

옵션은 **OR**, **AND**, **NOR**의 세 가지이며, 각각 `|`, `&`, `-` 에 대응됩니다.
- 선택한 옵션이 **OR**이라면 선택한 알고리즘 중 하나 이상을 포함하는 문제들만을 추첨에 포함합니다.
- 선택한 옵션이 **AND**라면 선택한 알고리즘 모두가 포함되면 문제들만을 추첨에 포함합니다.
- 선택한 옵션이 **NOR**이라면 선택한 알고리즘 모두를 포함하지 않는 문제들만을 추첨에 포함합니다.

어떤 알고리즘이든 검색에 포함할 수 있으나, 사용 가능한 알고리즘은 현재 최대 5개입니다. 좁은 UI와 쿼리 글자 수 제한으로 이러한 제한을 채택했으나, 이후 상황이 바뀌면 제한을 늘릴 수도 있습니다.

이 컴포넌트는 상대적으로 사용법이 직관적이지 않으므로 유저가 충분히 이 컴포넌트를 쉽게 사용할 수 있도록 가이드 등을 추가하는 방안을 고려하여야 합니다.


## 참고 자료
- `<SearchOperatorSelect>` 컴포넌트의 모습. `OR` 연산자를 선택한 모습입니다.
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/061e6f3f-148d-434b-be0e-705bf50592cc)

- 구버전 UI를 기준으로 `<SearchOperatorSelect>` 가 대응되는 부분입니다.
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/671bfc6a-98c8-4583-9082-accfdb9c51c6)
