### PR TITLE
[FEAT] 로딩 스피너 컴포넌트 구현

### DIFF
--- a/src/components/common/Loading/Loading.stories.tsx
+++ b/src/components/common/Loading/Loading.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Loading from './Loading';
+
+/**
+ * `Loading`은 콘텐츠가 로딩 중일 경우 이를 시각적으로 전달하는 역할을 하는 공통 컴포넌트입니다.
+ */
+const meta = {
+  title: 'common/Loading',
+  component: Loading,
+} satisfies Meta<typeof Loading>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/common/Loading/Loading.stories.tsx
+++ b/src/components/common/Loading/Loading.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Loading from './Loading';
 
 /**
- * `Loading`은 콘텐츠가 로딩 중일 경우 이를 시각적으로 전달하는 역할을 하는 공통 컴포넌트입니다.
+ * `Loading`은 콘텐츠가 로딩 중일 경우 이를 시각적으로 전달하는 역할을 하는 공통 컴포넌트입니다. 이 컴포넌트는 항상 부모 요소를 기준으로 상하좌우로 중앙에 배치됩니다.
  */
 const meta = {
   title: 'common/Loading',

--- a/src/components/common/Loading/Loading.styled.ts
+++ b/src/components/common/Loading/Loading.styled.ts
@@ -1,0 +1,28 @@
+import { styled, keyframes } from 'styled-components';
+
+export const spin = keyframes`
+  from {
+    transform: rotate(0);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 100%;
+
+  & > svg {
+    width: 24px;
+    height: 24px;
+
+    color: ${({ theme }) => theme.color.GOLD};
+
+    animation: ${spin} 2s forwards infinite linear;
+  }
+`;

--- a/src/components/common/Loading/Loading.tsx
+++ b/src/components/common/Loading/Loading.tsx
@@ -1,0 +1,12 @@
+import { LoadingIcon } from '~images/svg';
+import * as S from './Loading.styled';
+
+const Loading = () => {
+  return (
+    <S.Container>
+      <LoadingIcon />
+    </S.Container>
+  );
+};
+
+export default Loading;

--- a/src/components/common/Loading/index.ts
+++ b/src/components/common/Loading/index.ts
@@ -1,0 +1,3 @@
+import Loading from './Loading';
+
+export default Loading;

--- a/src/images/svg/index.ts
+++ b/src/images/svg/index.ts
@@ -13,3 +13,4 @@ export { ReactComponent as EditIcon } from './edit.svg';
 export { ReactComponent as WarningIcon } from './warning.svg';
 export { ReactComponent as DiceIcon } from './dice.svg';
 export { ReactComponent as CheckIcon } from './check.svg';
+export { ReactComponent as LoadingIcon } from './loading.svg';

--- a/src/images/svg/loading.svg
+++ b/src/images/svg/loading.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 48 48"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M24 4v4m10-1.32l-2 3.464M41.32 14l-3.464 2M44 24h-4m1.32 10l-3.464-2M34 41.32l-2-3.464M24 44v-4m-10 1.32l2-3.464M6.68 34l3.464-2M4 24h4M6.68 14l3.464 2M14 6.68l2 3.464"/></svg>


### PR DESCRIPTION
## PR 설명
본 PR에서는 로딩 스피너 컴포넌트를 구현하였습니다.
- 로딩 스피너는 항상 부모 요소를 중심으로 상하좌우 기준 정중앙에 위치하게 됩니다.

## 참고 자료
![_2024_05_17_14_27_47_922-ezgif com-video-to-gif-converter](https://github.com/wzrabbit/boj-totamjung/assets/87642422/90fe1b17-9ea1-4dcd-a0e7-09c48e5bae31)
