### PR TITLE
[FEAT] 추첨 생성 메뉴와 퀵슬롯 메뉴를 연결하는 컴포넌트를 구현

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -15,7 +15,9 @@
     runtime: {
       sendMessage: ({ command, message }, callback) => {
         if (command === 'fetchCheckedAlgorithmIds') {
-          callback({ checkedIds: [1, 2, 4, 8, 16, 32, 64] });
+          return {
+            checkedIds: [1, 2, 3],
+          };
         }
 
         if (command === 'fetchRandomDefenseHistory') {

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -18,7 +18,7 @@
   var chrome = {
     runtime: {
       sendMessage: async ({ command, message }, callback) => {
-        await sleep(2000);
+        await delay(2000);
 
         if (command === 'fetchCheckedAlgorithmIds') {
           return {

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -11,9 +11,15 @@
 />
 
 <script>
+  const delay = (milliseconds) => {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+  };
+
   var chrome = {
     runtime: {
-      sendMessage: ({ command, message }, callback) => {
+      sendMessage: async ({ command, message }, callback) => {
+        await sleep(2000);
+
         if (command === 'fetchCheckedAlgorithmIds') {
           return {
             checkedIds: [1, 2, 3],

--- a/src/components/QuickSlotMenu/QuickSlotMenu.stories.tsx
+++ b/src/components/QuickSlotMenu/QuickSlotMenu.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import QuickSlotMenu from './QuickSlotMenu';
+import type { QuickSlotsResponse } from '~types/randomDefense';
 
 /**
  * `QuickSlotMenu`는 추첨 생성 폼을 통해 생성된 연습 쿼리들을 관리할 수 있는 메뉴 형태의 컴포넌트입니다.
@@ -14,6 +15,51 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const quickSlotsResponse: QuickSlotsResponse = {
+  selectedSlotNo: 2,
+  hotkey: 'Alt',
+  slots: {
+    1: { isEmpty: true },
+    2: {
+      isEmpty: false,
+      title: '골드 랜덤 디펜스',
+      query: '*11..15 s#3000.. solvable:true',
+    },
+    3: { isEmpty: true },
+    4: {
+      isEmpty: false,
+      title: '외국어 문제 풀어보기',
+      query: '*5..20 !lang:ko solvable:true',
+    },
+    5: { isEmpty: true },
+    6: { isEmpty: true },
+    7: { isEmpty: true },
+    8: {
+      isEmpty: false,
+      title: '이추첨의이름은정확히삼십글자이며이렇게하는이유는테스트를위함',
+      query:
+        '*1..30 (-#rope-#bayes-#knuth-#dancing_links-#differential_cryptanalysis-#discrete_sqrt-#lgv-#green-#stoer_wagner-#multipoint_evaluation-#lte-#geometric_boolean_operations-#a_star-#discrete_kth_root)',
+    },
+    9: { isEmpty: true },
+    0: { isEmpty: true },
+  },
+};
+
 export const Default: Story = {
-  args: {},
+  args: {
+    quickSlotsInfo: quickSlotsResponse,
+    isLoaded: true,
+    onHotkeyChange: (hotkey) => {
+      alert(`onHotkeyChange('${hotkey}')`);
+    },
+    onSlotChange: (title: string, query: string) => {
+      alert(`onSlotChange('${title}', '${query}')`);
+    },
+    onSlotDelete: () => {
+      alert(`onSlotDelete()`);
+    },
+    onSlotNoChange: (slotNo) => {
+      alert(`onSlotNoChange(${slotNo})`);
+    },
+  },
 };

--- a/src/components/QuickSlotMenu/QuickSlotMenu.styled.ts
+++ b/src/components/QuickSlotMenu/QuickSlotMenu.styled.ts
@@ -3,6 +3,7 @@ import { styled } from 'styled-components';
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
+  position: relative;
 
   width: 100%;
   height: 100%;

--- a/src/components/QuickSlotMenu/QuickSlotMenu.tsx
+++ b/src/components/QuickSlotMenu/QuickSlotMenu.tsx
@@ -6,28 +6,40 @@ import HotkeySwitcher from './HotkeySwitcher';
 import IconButton from '~components/common/IconButton';
 import useQuickSlotMenu from '~hooks/randomDefense/useQuickSlotMenu';
 import SlotEditModal from './SlotEditModal';
+import Loading from '~components/common/Loading';
 import { CopyIcon, EditIcon, TrashIcon } from '~images/svg';
+import type { QuickSlotsResponse, SlotNo, Hotkey } from '~types/randomDefense';
 import { theme } from '~styles/theme';
 
-const QuickSlotMenu = () => {
+interface QuickSlotMenuProps {
+  quickSlotsInfo: QuickSlotsResponse;
+  isLoaded: boolean;
+  onHotkeyChange: (hotkey: Hotkey) => void;
+  onSlotChange: (title: string, query: string) => void;
+  onSlotDelete: () => void;
+  onSlotNoChange: (slotNo: SlotNo) => void;
+}
+
+const QuickSlotMenu = (props: QuickSlotMenuProps) => {
+  const { isLoaded } = props;
+
   const {
     slot,
     selectedSlotNo,
-    occupiedSlotNos,
     hotkey,
+    occupiedSlotNos,
     shouldEditModalShow,
-    isLoaded,
     setSelectedSlotNo,
     switchHotkey,
     openEditModal,
     closeEditModal,
     updateSlot,
     deleteSlot,
-  } = useQuickSlotMenu();
+  } = useQuickSlotMenu(props);
 
   return (
     <NamedFrame width="650px" height="168px" padding="10px" title="퀵 슬롯">
-      {isLoaded && (
+      {isLoaded ? (
         <S.Container>
           <S.SlotNoPanel>
             <SlotPagination
@@ -80,6 +92,8 @@ const QuickSlotMenu = () => {
             />
           </S.SlotControlPanel>
         </S.Container>
+      ) : (
+        <Loading />
       )}
       <SlotEditModal
         title={slot.isEmpty ? '' : slot.title}

--- a/src/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.stories.tsx
+++ b/src/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     selectedSlotNo: 1,
-    isLoading: false,
+    isLoaded: true,
     onClick: () => {
       alert('onClick()');
     },
@@ -30,7 +30,7 @@ export const Default: Story = {
 export const Loading: Story = {
   args: {
     selectedSlotNo: 1,
-    isLoading: true,
+    isLoaded: false,
     onClick: () => {
       alert('onClick()');
     },

--- a/src/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.stories.tsx
+++ b/src/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.stories.tsx
@@ -17,6 +17,20 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     selectedSlotNo: 1,
+    isLoading: false,
+    onClick: () => {
+      alert('onClick()');
+    },
+  },
+};
+
+/**
+ * 아직 슬롯의 번호를 부모 컴포넌트에서 불러오지 못해, 로딩 중일 경우에 보여주는 UI입니다. 버튼은 비활성화 되어 있습니다.
+ */
+export const Loading: Story = {
+  args: {
+    selectedSlotNo: 1,
+    isLoading: true,
     onClick: () => {
       alert('onClick()');
     },

--- a/src/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.styled.ts
+++ b/src/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.styled.ts
@@ -9,6 +9,10 @@ export const Button = styled.button`
   background: none;
 
   user-select: none;
+
+  &:disabled {
+    opacity: 0.6;
+  }
 `;
 
 const buttonSide = css`
@@ -36,7 +40,7 @@ export const UpperSide = styled.div`
   transform: translateY(-10px);
   z-index: 1;
 
-  ${Button}:active > & {
+  ${Button}:not([disabled]):active > & {
     transform: translateY(-4px);
   }
 `;

--- a/src/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.tsx
+++ b/src/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.tsx
@@ -5,17 +5,19 @@ import * as S from './RandomDefenseCreateButton.styled';
 
 interface RandomDefenseCreateButtonProps {
   selectedSlotNo: SlotNo;
+  isLoaded: boolean;
   onClick: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
 const RandomDefenseCreateButton = (props: RandomDefenseCreateButtonProps) => {
-  const { selectedSlotNo, onClick } = props;
+  const { selectedSlotNo, isLoaded, onClick } = props;
 
   return (
     <S.Button
       type="button"
       aria-label={`${selectedSlotNo}번 슬롯에 추첨 생성하기`}
       onClick={onClick}
+      disabled={!isLoaded}
     >
       <S.UpperSide>
         <S.DiceIconWrapper>
@@ -23,7 +25,9 @@ const RandomDefenseCreateButton = (props: RandomDefenseCreateButtonProps) => {
         </S.DiceIconWrapper>
         <S.TextContainer>
           <S.TitleText>추첨 생성</S.TitleText>
-          <S.SlotNoText>{`슬롯 번호 − ${selectedSlotNo}`}</S.SlotNoText>
+          <S.SlotNoText>
+            {isLoaded ? `슬롯 번호 − ${selectedSlotNo}` : '로딩 중...'}
+          </S.SlotNoText>
         </S.TextContainer>
       </S.UpperSide>
       <S.LowerSide />

--- a/src/components/RandomDefenseCreateMenu/RandomDefenseCreateMenu.stories.tsx
+++ b/src/components/RandomDefenseCreateMenu/RandomDefenseCreateMenu.stories.tsx
@@ -17,6 +17,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     selectedSlotNo: 1,
+    isLoaded: true,
     onSubmit: (randomDefenseFormData) => {
       alert(
         `이 알림창이 떴다는 것은 검증 결과 [성공]을 의미합니다. 이제 부모로부터 전달받은 아래의 함수를 실행해, 본격적인 추첨 생성 작업을 시작하겠죠.\n\nonSubmit(${JSON.stringify(

--- a/src/components/RandomDefenseCreateMenu/RandomDefenseCreateMenu.styled.ts
+++ b/src/components/RandomDefenseCreateMenu/RandomDefenseCreateMenu.styled.ts
@@ -10,6 +10,8 @@ export const Form = styled.form`
   width: 100%;
   height: 100%;
   padding-top: 6px;
+
+  z-index: 1;
 `;
 
 export const ErrorTextWrapper = styled.div`

--- a/src/components/RandomDefenseCreateMenu/RandomDefenseCreateMenu.tsx
+++ b/src/components/RandomDefenseCreateMenu/RandomDefenseCreateMenu.tsx
@@ -11,15 +11,16 @@ import SearchOperatorSelect from './SearchOperatorSelect';
 import AlgorithmSearchInput from './AlgorithmSearchInput';
 import useRandomDefenseCreateMenu from '~hooks/randomDefense/useRandomDefenseCreateMenu';
 import * as S from './RandomDefenseCreateMenu.styled';
-import type { Slot, SlotNo } from '~types/randomDefense';
+import type { SlotNo } from '~types/randomDefense';
 
 interface RandomDefenseCreateMenuProps {
   selectedSlotNo: SlotNo;
-  onSubmit: (generatedSlot: Omit<Slot, 'isEmpty'>) => void;
+  isLoaded: boolean;
+  onSubmit: (title: string, query: string) => void;
 }
 
 const RandomDefenseCreateMenu = (props: RandomDefenseCreateMenuProps) => {
-  const { selectedSlotNo, onSubmit } = props;
+  const { selectedSlotNo, isLoaded, onSubmit } = props;
   const {
     mode,
     title,
@@ -197,6 +198,7 @@ const RandomDefenseCreateMenu = (props: RandomDefenseCreateMenuProps) => {
         )}
         <S.RandomDefenseCreateButtonWrapper>
           <RandomDefenseCreateButton
+            isLoaded={isLoaded}
             selectedSlotNo={selectedSlotNo}
             onClick={submitRandomDefense}
           />

--- a/src/components/RandomDefenseManageMenu/RandomDefenseManageMenu.stories.tsx
+++ b/src/components/RandomDefenseManageMenu/RandomDefenseManageMenu.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import RandomDefenseManageMenu from './RandomDefenseManageMenu';
+
+/**
+ * `RandomDefenseManageMenu`는 추첨 생성 메뉴와 슬롯 관리 메뉴를 결합한 통합 메뉴로, 두 컴포넌트가 공통의 슬롯 메뉴를 공유할 수 있도록 고안된, 징검다리와 같은 컴포넌트입니다.
+ */
+const meta = {
+  title: 'RandomDefenseManageMenu',
+  component: RandomDefenseManageMenu,
+  argTypes: {},
+} satisfies Meta<typeof RandomDefenseManageMenu>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/RandomDefenseManageMenu/RandomDefenseManageMenu.styled.ts
+++ b/src/components/RandomDefenseManageMenu/RandomDefenseManageMenu.styled.ts
@@ -1,0 +1,10 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: 12px;
+
+  width: 650px;
+  height: auto;
+`;

--- a/src/components/RandomDefenseManageMenu/RandomDefenseManageMenu.tsx
+++ b/src/components/RandomDefenseManageMenu/RandomDefenseManageMenu.tsx
@@ -1,0 +1,38 @@
+import RandomDefenseCreateMenu from '~components/RandomDefenseCreateMenu';
+import QuickSlotMenu from '~components/QuickSlotMenu';
+import useRandomDefenseManageMenu from '~hooks/useRandomDefenseMangeMenu';
+import * as S from './RandomDefenseManageMenu.styled';
+
+const RandomDefenseManageMenu = () => {
+  const {
+    slots,
+    selectedSlotNo,
+    hotkey,
+    isLoaded,
+    setSelectedSlotNo,
+    setHotkey,
+    updateSlot,
+    deleteSlot,
+  } = useRandomDefenseManageMenu();
+  const quickSlotsInfo = { slots, selectedSlotNo, hotkey };
+
+  return (
+    <S.Container>
+      <RandomDefenseCreateMenu
+        isLoaded={isLoaded}
+        selectedSlotNo={selectedSlotNo}
+        onSubmit={updateSlot}
+      />
+      <QuickSlotMenu
+        quickSlotsInfo={quickSlotsInfo}
+        isLoaded={isLoaded}
+        onHotkeyChange={setHotkey}
+        onSlotChange={updateSlot}
+        onSlotDelete={deleteSlot}
+        onSlotNoChange={setSelectedSlotNo}
+      />
+    </S.Container>
+  );
+};
+
+export default RandomDefenseManageMenu;

--- a/src/hooks/algorithm/useAlgorithmPool.ts
+++ b/src/hooks/algorithm/useAlgorithmPool.ts
@@ -10,13 +10,17 @@ const useAlgorithmPool = () => {
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
-    chrome.runtime.sendMessage(
-      { command: COMMANDS.FETCH_CHECKED_ALGORITHM_IDS },
-      (response) => {
-        setCheckedIds(() => response.checkedIds);
-        setIsLoaded(() => true);
-      },
-    );
+    const fetchAlgorithmPool = async () => {
+      const response = await chrome.runtime.sendMessage({
+        command: COMMANDS.FETCH_CHECKED_ALGORITHM_IDS,
+      });
+
+      console.log('ok response', response);
+      setCheckedIds(() => response.checkedIds);
+      setIsLoaded(() => true);
+    };
+
+    fetchAlgorithmPool();
   }, []);
 
   useEffect(() => {

--- a/src/hooks/algorithm/useAlgorithmPool.ts
+++ b/src/hooks/algorithm/useAlgorithmPool.ts
@@ -15,7 +15,6 @@ const useAlgorithmPool = () => {
         command: COMMANDS.FETCH_CHECKED_ALGORITHM_IDS,
       });
 
-      console.log('ok response', response);
       setCheckedIds(() => response.checkedIds);
       setIsLoaded(() => true);
     };

--- a/src/hooks/randomDefense/useQuickSlotMenu.ts
+++ b/src/hooks/randomDefense/useQuickSlotMenu.ts
@@ -1,64 +1,35 @@
-import { useState, useEffect } from 'react';
-import { isQuickSlotsResponse } from '~types/typeGuards';
-import { COMMANDS } from '~constants/commands';
-import type { QuickSlots, SlotNo, Hotkey } from '~types/randomDefense';
+import { useState } from 'react';
+import type { SlotNo, Hotkey, QuickSlotsResponse } from '~types/randomDefense';
 
-const emptySlots: QuickSlots = {
-  1: { isEmpty: true },
-  2: { isEmpty: true },
-  3: { isEmpty: true },
-  4: { isEmpty: true },
-  5: { isEmpty: true },
-  6: { isEmpty: true },
-  7: { isEmpty: true },
-  8: { isEmpty: true },
-  9: { isEmpty: true },
-  0: { isEmpty: true },
-};
+interface UseQuickSlotMenuParams {
+  quickSlotsInfo: QuickSlotsResponse;
+  isLoaded: boolean;
+  onHotkeyChange: (hotkey: Hotkey) => void;
+  onSlotChange: (title: string, query: string) => void;
+  onSlotDelete: () => void;
+  onSlotNoChange: (slotNo: SlotNo) => void;
+}
 
 const SLOT_NOS: SlotNo[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
 
-const useQuickSlotMenu = () => {
-  const [slots, setSlots] = useState<QuickSlots>(emptySlots);
-  const [selectedSlotNo, setSelectedSlotNo] = useState<SlotNo>(1);
-  const [hotkey, setHotkey] = useState<Hotkey>('Alt');
-  const [isLoaded, setIsLoaded] = useState(false);
+const useQuickSlotMenu = (params: UseQuickSlotMenuParams) => {
+  const {
+    quickSlotsInfo,
+    isLoaded,
+    onHotkeyChange,
+    onSlotChange,
+    onSlotDelete,
+    onSlotNoChange,
+  } = params;
+  const { selectedSlotNo, slots, hotkey } = quickSlotsInfo;
   const [shouldEditModalShow, setShouldEditModalShow] = useState(false);
 
-  useEffect(() => {
-    const fetchQuickSlots = async () => {
-      const response = await chrome.runtime.sendMessage({
-        command: COMMANDS.FETCH_QUICK_SLOTS,
-      });
-
-      if (!isQuickSlotsResponse(response)) {
-        return;
-      }
-
-      setSlots(response.slots);
-      setSelectedSlotNo(response.selectedSlotNo);
-      setHotkey(response.hotkey);
-      setIsLoaded(true);
-    };
-
-    fetchQuickSlots();
-  }, []);
-
-  useEffect(() => {
+  const switchHotkey = () => {
     if (!isLoaded) {
       return;
     }
 
-    chrome.runtime.sendMessage({
-      command: COMMANDS.SAVE_QUICK_SLOTS,
-      slots,
-      selectedSlotNo,
-      hotkey,
-    });
-  }, [slots, selectedSlotNo, hotkey]);
-
-  const switchHotkey = () => {
-    setHotkey((prev) => (prev === 'Alt' ? 'F2' : 'Alt'));
+    onHotkeyChange(hotkey === 'Alt' ? 'F2' : 'Alt');
   };
 
   const getOccupiedSlotNos = () => {
@@ -82,24 +53,30 @@ const useQuickSlotMenu = () => {
   };
 
   const updateSlot = (title: string, query: string) => {
+    if (!isLoaded) {
+      return;
+    }
+
     const finalTitle = title.trim() === '' ? `추첨 ${selectedSlotNo}` : title;
 
-    setSlots((prev) => ({
-      ...prev,
-      [selectedSlotNo]: { isEmpty: false, title: finalTitle, query },
-    }));
+    onSlotChange(finalTitle, query);
     closeEditModal();
   };
 
   const deleteSlot = () => {
+    if (!isLoaded) {
+      return;
+    }
+
     if (
       confirm(`${selectedSlotNo}번 슬롯에 저장되어 있는 쿼리를 삭제할까요?`)
     ) {
-      setSlots((prev) => ({
-        ...prev,
-        [selectedSlotNo]: { isEmpty: true },
-      }));
+      onSlotDelete();
     }
+  };
+
+  const setSelectedSlotNo = (slotNo: SlotNo) => {
+    onSlotNoChange(slotNo);
   };
 
   const slot = slots[selectedSlotNo];
@@ -107,16 +84,15 @@ const useQuickSlotMenu = () => {
   return {
     slot,
     selectedSlotNo,
-    occupiedSlotNos: getOccupiedSlotNos(),
     hotkey,
+    occupiedSlotNos: getOccupiedSlotNos(),
     shouldEditModalShow,
-    isLoaded,
-    setSelectedSlotNo,
     switchHotkey,
     openEditModal,
     closeEditModal,
     updateSlot,
     deleteSlot,
+    setSelectedSlotNo,
   };
 };
 

--- a/src/hooks/randomDefense/useRandomDefenseCreateMenu.ts
+++ b/src/hooks/randomDefense/useRandomDefenseCreateMenu.ts
@@ -4,7 +4,6 @@ import { validateRandomDefenseFormData } from '~domains/randomDefense/randomDefe
 import type { ChangeEventHandler, MouseEventHandler } from 'react';
 import type {
   RandomDefenseFormData,
-  Slot,
   SlotNo,
   TierWithoutNotRatable,
 } from '~types/randomDefense';
@@ -12,7 +11,7 @@ import { generateRandomDefenseQuery } from '~domains/randomDefense/randomDefense
 
 interface UseRandomDefenseCreateMenuParams {
   selectedSlotNo: SlotNo;
-  onSubmit: (slot: Omit<Slot, 'isEmpty'>) => void;
+  onSubmit: (title: string, query: string) => void;
 }
 
 const initialRandomDefenseFormData: RandomDefenseFormData = {
@@ -119,15 +118,13 @@ const useRandomDefenseCreateMenu = (
     );
 
     if (validationResult.isValid) {
-      const generatedSlot = {
-        title:
-          randomDefenseFormData.title.trim() === ''
-            ? `추첨 ${selectedSlotNo}`
-            : randomDefenseFormData.title,
-        query: generateRandomDefenseQuery(randomDefenseFormData),
-      };
+      const title =
+        randomDefenseFormData.title.trim() === ''
+          ? `추첨 ${selectedSlotNo}`
+          : randomDefenseFormData.title;
+      const query = generateRandomDefenseQuery(randomDefenseFormData);
 
-      onSubmit(generatedSlot);
+      onSubmit(title, query);
       setErrorMessage('');
       setErrorElementName(undefined);
       return;

--- a/src/hooks/useRandomDefenseMangeMenu.ts
+++ b/src/hooks/useRandomDefenseMangeMenu.ts
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react';
+import { isQuickSlotsResponse } from '~types/typeGuards';
+import { COMMANDS } from '~constants/commands';
+import type { QuickSlots, SlotNo, Hotkey } from '~types/randomDefense';
+
+const emptySlots: QuickSlots = {
+  1: { isEmpty: true },
+  2: { isEmpty: true },
+  3: { isEmpty: true },
+  4: { isEmpty: true },
+  5: { isEmpty: true },
+  6: { isEmpty: true },
+  7: { isEmpty: true },
+  8: { isEmpty: true },
+  9: { isEmpty: true },
+  0: { isEmpty: true },
+};
+
+const useRandomDefenseManageMenu = () => {
+  const [slots, setSlots] = useState<QuickSlots>(emptySlots);
+  const [selectedSlotNo, setSelectedSlotNo] = useState<SlotNo>(1);
+  const [hotkey, setHotkey] = useState<Hotkey>('Alt');
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const fetchQuickSlots = async () => {
+      const response = await chrome.runtime.sendMessage({
+        command: COMMANDS.FETCH_QUICK_SLOTS,
+      });
+
+      if (!isQuickSlotsResponse(response)) {
+        return;
+      }
+
+      setSlots(response.slots);
+      setSelectedSlotNo(response.selectedSlotNo);
+      setHotkey(response.hotkey);
+      setIsLoaded(true);
+    };
+
+    fetchQuickSlots();
+  }, []);
+
+  useEffect(() => {
+    if (!isLoaded) {
+      return;
+    }
+
+    chrome.runtime.sendMessage({
+      command: COMMANDS.SAVE_QUICK_SLOTS,
+      slots,
+      selectedSlotNo,
+      hotkey,
+    });
+  }, [slots, selectedSlotNo, hotkey]);
+
+  const updateSlot = (title: string, query: string) => {
+    setSlots((prev) => ({
+      ...prev,
+      [selectedSlotNo]: { isEmpty: false, title, query },
+    }));
+  };
+
+  const deleteSlot = () => {
+    setSlots((prev) => ({
+      ...prev,
+      [selectedSlotNo]: { isEmpty: true },
+    }));
+  };
+
+  return {
+    slots,
+    selectedSlotNo,
+    hotkey,
+    isLoaded,
+    setSelectedSlotNo,
+    setHotkey,
+    updateSlot,
+    deleteSlot,
+  };
+};
+
+export default useRandomDefenseManageMenu;


### PR DESCRIPTION
## PR 설명
본 PR에서는 추첨 생성 메뉴인 `<RandomDefenseCreateMenu>`와 퀵슬롯 메뉴인 `<QuickSlotMenu>`를 연결하는 부모 컴포넌트를 구현하였습니다 -- `<RandomDefenseManageMenu>`

두 핵심 메뉴는 슬롯의 정보를 공유하는 것이 필수적입니다.
- `<RandomDefenseCreateMenu>`의 경우 현재 선택된 슬롯의 번호를 알아야 슬롯에 쿼리를 생성하는 것이 가능하며, UI로도 사용자가 쉽게 알 수 있도록 현재 번호를 보여주어야 합니다.
- `<QuickSlotMenu>` 의 경우 `<RandomDefenseCreateMenu>`에서 생성하는 슬롯을 인식하고 업데이트하는 것이 필요합니다.

이에 따라, 슬롯의 데이터를 두 컴포넌트가 서로 공유할 수 있도록 본 컴포넌트를 구현하였으며, Context API의 사용도 고민하였으나 depth가 적기 때문에 전통적인 prop drilling 방식으로도 문제가 없다고 판단하여 컴포넌트를 사용하여 두 컴포넌트를 이어 주었습니다.

슬롯의 정보를 이제 본 컴포넌트에서 관리하므로, chrome API를 이용해 storage에 접근하는 로직은 모두 본 컴포넌트가 담당하며, 그 대신 각자의 핵심 컴포넌트가 맡을 수 있는 모달 제어, 폼 검증 등은 핵심 컴포넌트가 그대로 맡아 관리하도록 구현하였습니다.

본 컴포넌트를 구현한 것 외에도, 두 핵심 컴포넌트의 로딩 UI를 간단하게 구현하였습니다. 이 로딩 UI는 추후 더 자연스럽게 변경될 수도 있습니다. (특히 `<QuickSlotMenu>`)

## 참고 자료
- 두 컴포넌트를 결합시킨 모습
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/6cba84f2-00a9-4305-b85f-f3ad9a584308)


- `<RandomDefenseCreateMenu>` 의 로딩 중 UI
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/aa384503-f9b3-4f92-9bce-86b3a81d5b0e)

- `<QuickSlotMenu>` 의 로딩 중 UI
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/ee3cf093-97bc-4ada-8cb8-528fd5619ba9)
