### PR TITLE
[FIX] `options.html`에 Pretendard 폰트가 적용이 안 되는 문제를 해결

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -2,15 +2,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Oxanium:wght@200..800&family=Do+Hyeon&display=swap"
       rel="stylesheet"
-    />
-
-    <link
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
     />
     <title>토탐정</title>
   </head>


### PR DESCRIPTION
## PR 설명
토탐정의 설정 페이지가 될 `options.html`에 `<link>`를 잘못 사용하여 Pretendard 폰트가 적용되지 않는 문제가 있었습니다. 본 PR에서는 이 문제를 해결했습니다.
스토리북에 명시된 `<link>` 는 올바르므로 별도로 수정할 필요가 없습니다.