### PR TITLE
[FEAT] 퀵슬롯 저장/불러오기 서비스워커 로직 구현

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -3,6 +3,10 @@ import { COMMANDS } from '~constants/commands';
 import { fetchCheckedAlgorithmIds } from '~domains/algorithm/fetchCheckedAlgorithmIds';
 import { saveCheckedAlgorithmIds } from '~domains/algorithm/saveCheckedAlgorithmIds';
 import {
+  fetchQuickSlots,
+  saveQuickSlots,
+} from '~domains/randomDefense/quickSlotsDataHandler';
+import {
   fetchRandomDefenseHistory,
   saveRandomDefenseHistory,
 } from '~domains/randomDefense/randomDefenseHistoryDataHandler';
@@ -47,6 +51,26 @@ chrome.runtime.onMessage.addListener(
       const { randomDefenseHistory, isHidden } = message;
 
       saveRandomDefenseHistory(randomDefenseHistory, isHidden);
+    }
+
+    if (command === COMMANDS.FETCH_QUICK_SLOTS) {
+      fetchQuickSlots().then((result) => {
+        sendResponse(result);
+      });
+    }
+
+    if (command === COMMANDS.SAVE_QUICK_SLOTS) {
+      if (
+        !('selectedSlotNo' in message) ||
+        !('slots' in message) ||
+        !('hotkey' in message)
+      ) {
+        return;
+      }
+
+      const { selectedSlotNo, slots, hotkey } = message;
+
+      saveQuickSlots(selectedSlotNo, slots, hotkey);
     }
 
     return true;

--- a/src/domains/randomDefense/quickSlotsDataHandler.test.ts
+++ b/src/domains/randomDefense/quickSlotsDataHandler.test.ts
@@ -1,0 +1,86 @@
+import {
+  MAX_CUSTOM_QUERY_LENGTH,
+  TITLE_MAX_LENGTH,
+} from '~constants/randomDefense';
+import { LEGACY_SYNC_STORAGE_KEY, SYNC_STORAGE_KEY } from '~constants/commands';
+import { fetchQuickSlots, saveQuickSlots } from './quickSlotsDataHandler';
+import type { QuickSlotsResponse } from '~types/randomDefense';
+
+const EMPTY_VALID_QUICK_SLOTS = {
+  1: { isEmpty: true },
+  2: { isEmpty: true },
+  3: { isEmpty: true },
+  4: { isEmpty: true },
+  5: { isEmpty: true },
+  6: { isEmpty: true },
+  7: { isEmpty: true },
+  8: { isEmpty: true },
+  9: { isEmpty: true },
+  0: { isEmpty: true },
+} as const;
+
+const EMPTY_VALID_QUICK_SLOTS_RESPONSE = {
+  hotkey: 'Alt',
+  selectedSlotNo: 1,
+  slots: EMPTY_VALID_QUICK_SLOTS,
+};
+
+const validQuickSlots: QuickSlotsResponse = {
+  slots: {
+    1: {
+      isEmpty: true,
+    },
+    2: {
+      isEmpty: false,
+      title: '골드 랜덤 디펜스',
+      query: '(*0&s?false|!*0) o?true *11..15',
+    },
+    3: {
+      isEmpty: false,
+      title: 'Math',
+      query: '#math',
+    },
+    4: {
+      isEmpty: false,
+      title: 'a'.repeat(TITLE_MAX_LENGTH),
+      query: 'b'.repeat(MAX_CUSTOM_QUERY_LENGTH),
+    },
+    5: {
+      isEmpty: false,
+      title: 'a',
+      query: 'b',
+    },
+    6: {
+      isEmpty: true,
+    },
+    7: {
+      isEmpty: false,
+      title: '   연습   1 ',
+      query: '★※? _쿼리 !@#$%^&*() aZ0[]{} ',
+    },
+    8: {
+      isEmpty: false,
+      title: 'Прогулка в прекрасную погоду',
+      query:
+        'Я люблю читать книги по вечерам, \'"но погода сегодня прекрасная, давайте пойдем на прогулку. Мы можем пройтись по парку и насладиться свежим воздухом, а затем вернуться домой и выпить чашечку горячего чая. Как ты на это смотришь',
+    },
+    9: {
+      isEmpty: false,
+      title: '美好的天气散步',
+      query:
+        '我喜欢在晚上读书，但今天天气很好，我们去散步吧。我们可以在公园里走走，享受新鲜的空气，然后回家喝一杯热茶。你觉得怎么样',
+    },
+    0: {
+      isEmpty: false,
+      title: '      .',
+      query: '.         ',
+    },
+  },
+  selectedSlotNo: 9,
+  hotkey: 'Alt',
+};
+
+const validLegacyQuickSlots = {
+  ...validQuickSlots.slots,
+  selectedNo: validQuickSlots.selectedSlotNo,
+};

--- a/src/domains/randomDefense/quickSlotsDataHandler.test.ts
+++ b/src/domains/randomDefense/quickSlotsDataHandler.test.ts
@@ -98,3 +98,227 @@ describe('Test #1 - 퀵슬롯 정보 불러오기', () => {
     expect(await fetchQuickSlots()).toEqual(validQuickSlots);
   });
 });
+
+describe('Test #2 - 유효하지 않은 퀵슬롯 정보를 불러올 경우 대응하기', () => {
+  test('유효하지 않은 퀵슬롯이지만, 복구가 가능한 형태인 경우 데이터를 보존하고 유효하지 않은 퀵슬롯만을 초기화하여 반환해야 한다.', async () => {
+    const partiallyInvalidQuickSlots = {
+      slots: {
+        ...validQuickSlots.slots,
+        2: {
+          isEmpty: false,
+        },
+        3: {},
+        4: '뭘 봐',
+        5: {
+          isEmpty: false,
+          title: 'a'.repeat(TITLE_MAX_LENGTH + 1),
+          query: 'b'.repeat(MAX_CUSTOM_QUERY_LENGTH + 1),
+        },
+        7: {
+          title: '',
+          query: 'tier:g5..g1',
+        },
+        8: {
+          title: 'Empty Query',
+          query: '   ',
+        },
+      },
+      selectedSlotNo: 3,
+      hotkey: 'Alt',
+    };
+
+    const expectedResult = {
+      slots: {
+        1: {
+          isEmpty: true,
+        },
+        2: {
+          isEmpty: true,
+        },
+        3: {
+          isEmpty: true,
+        },
+        4: {
+          isEmpty: true,
+        },
+        5: {
+          isEmpty: true,
+        },
+        6: {
+          isEmpty: true,
+        },
+        7: {
+          isEmpty: true,
+        },
+        8: {
+          isEmpty: true,
+        },
+        9: {
+          isEmpty: false,
+          title: '美好的天气散步',
+          query:
+            '我喜欢在晚上读书，但今天天气很好，我们去散步吧。我们可以在公园里走走，享受新鲜的空气，然后回家喝一杯热茶。你觉得怎么样',
+        },
+        0: {
+          isEmpty: false,
+          title: '      .',
+          query: '.         ',
+        },
+      },
+      selectedSlotNo: 3,
+      hotkey: 'Alt',
+    };
+
+    jest
+      .spyOn(chrome.storage.sync, 'get')
+      .mockImplementation(async (_, callback) => {
+        callback({
+          [SYNC_STORAGE_KEY.QUICK_SLOTS]: partiallyInvalidQuickSlots,
+        });
+      });
+
+    expect(await fetchQuickSlots()).toEqual(expectedResult);
+  });
+
+  test('단축키, 선택된 슬롯이 누락되었더라도 복구가 가능한 형태인 경우 데이터를 보존하여 반환해야 한다.', async () => {
+    const partiallyInvalidQuickSlots = {
+      slots: {
+        1: {
+          isEmpty: false,
+          title: 'Silver RD',
+          query: '*6..10 solvable:true',
+        },
+        2: {
+          isEmpty: false,
+          title: '',
+          query:
+            '제목만 잘못된 경우로, 쿼리는 유지되고 제목만 복구되어야 합니다.',
+        },
+        3: {},
+        4: {},
+        5: {},
+        6: {},
+        7: {},
+        8: {},
+        9: {},
+        0: {},
+      },
+      hotkey: '뭘봐',
+    };
+
+    const expectedResult = {
+      slots: {
+        1: {
+          isEmpty: false,
+          title: 'Silver RD',
+          query: '*6..10 solvable:true',
+        },
+        2: {
+          isEmpty: false,
+          title: '추첨 2',
+          query:
+            '제목만 잘못된 경우로, 쿼리는 유지되고 제목만 복구되어야 합니다.',
+        },
+        3: {
+          isEmpty: true,
+        },
+        4: {
+          isEmpty: true,
+        },
+        5: {
+          isEmpty: true,
+        },
+        6: {
+          isEmpty: true,
+        },
+        7: {
+          isEmpty: true,
+        },
+        8: {
+          isEmpty: true,
+        },
+        9: {
+          isEmpty: true,
+        },
+        0: {
+          isEmpty: true,
+        },
+      },
+      selectedSlotNo: 1,
+      hotkey: 'Alt',
+    };
+
+    jest
+      .spyOn(chrome.storage.sync, 'get')
+      .mockImplementation(async (_, callback) => {
+        callback({
+          [SYNC_STORAGE_KEY.QUICK_SLOTS]: partiallyInvalidQuickSlots,
+        });
+      });
+
+    expect(await fetchQuickSlots()).toEqual(expectedResult);
+  });
+
+  test('슬롯이 있는 자리를 찾을 수 없는 경우, 복구가 불가능한 것으로 판정하고, 초기 데이터를 반환해야 한다.', async () => {
+    const invalidQuickSlots = {
+      slots: {
+        1: {},
+        2: {},
+        3: {},
+        4: {},
+        5: {
+          isEmpty: false,
+          title: '이 데이터는 보존되지 말아야 합니다',
+          query: '8번 슬롯이 누락되어 있습니다',
+        },
+        6: {},
+        7: {},
+        9: {},
+        0: {},
+      },
+      hotkey: 'F2',
+      selectedSlotNo: 7,
+    };
+
+    jest
+      .spyOn(chrome.storage.sync, 'get')
+      .mockImplementation(async (_, callback) => {
+        callback({
+          [SYNC_STORAGE_KEY.QUICK_SLOTS]: invalidQuickSlots,
+        });
+      });
+
+    expect(await fetchQuickSlots()).toEqual(EMPTY_VALID_QUICK_SLOTS_RESPONSE);
+  });
+
+  test('slots 프로퍼티를 찾을 수 없는 경우, 복구가 불가능한 것으로 판정하고, 초기 데이터를 반환해야 한다.', async () => {
+    const invalidQuickSlots = {
+      hotkey: 'F2',
+      selectedSlotNo: 7,
+    };
+
+    jest
+      .spyOn(chrome.storage.sync, 'get')
+      .mockImplementation(async (_, callback) => {
+        callback({
+          [SYNC_STORAGE_KEY.QUICK_SLOTS]: invalidQuickSlots,
+        });
+      });
+
+    expect(await fetchQuickSlots()).toEqual(EMPTY_VALID_QUICK_SLOTS_RESPONSE);
+  });
+
+  test('데이터가 오브젝트 형태가 아닌 경우, 복구가 불가능한 것으로 판정하고, 초기 데이터를 반환해야 한다.', async () => {
+    const invalidQuickSlots = 'quick slots';
+
+    jest
+      .spyOn(chrome.storage.sync, 'get')
+      .mockImplementation(async (_, callback) => {
+        callback({
+          [SYNC_STORAGE_KEY.QUICK_SLOTS]: invalidQuickSlots,
+        });
+      });
+
+    expect(await fetchQuickSlots()).toEqual(EMPTY_VALID_QUICK_SLOTS_RESPONSE);
+  });
+});

--- a/src/domains/randomDefense/quickSlotsDataHandler.test.ts
+++ b/src/domains/randomDefense/quickSlotsDataHandler.test.ts
@@ -432,3 +432,16 @@ describe('Test #3 - 구버전 퀵슬롯 정보를 불러오는 경우를 대응�
     expect(await fetchQuickSlots()).toEqual(EMPTY_VALID_QUICK_SLOTS_RESPONSE);
   });
 });
+
+describe('Test #4 - 퀵슬롯 정보 저장하기', () => {
+  test('유효한 형태의 퀵슬롯을 저장해야 할 경우, 모든 데이터가 온전하게 저장되어야 한다.', async () => {
+    jest.spyOn(chrome.storage.sync, 'set').mockImplementation(() => {});
+    const { selectedSlotNo, slots, hotkey } = validQuickSlots;
+
+    saveQuickSlots(selectedSlotNo, slots, hotkey);
+
+    expect(chrome.storage.sync.set).toHaveBeenCalledWith({
+      quickSlots: validQuickSlots,
+    });
+  });
+});

--- a/src/domains/randomDefense/quickSlotsDataHandler.test.ts
+++ b/src/domains/randomDefense/quickSlotsDataHandler.test.ts
@@ -84,3 +84,17 @@ const validLegacyQuickSlots = {
   ...validQuickSlots.slots,
   selectedNo: validQuickSlots.selectedSlotNo,
 };
+
+describe('Test #1 - 퀵슬롯 정보 불러오기', () => {
+  test('올바른 퀵슬롯이 저장되어 있다면, 이를 그대로 불러온 값을 반환해야 한다.', async () => {
+    jest
+      .spyOn(chrome.storage.sync, 'get')
+      .mockImplementation(async (_, callback) => {
+        callback({
+          [SYNC_STORAGE_KEY.QUICK_SLOTS]: validQuickSlots,
+        });
+      });
+
+    expect(await fetchQuickSlots()).toEqual(validQuickSlots);
+  });
+});

--- a/src/domains/randomDefense/quickSlotsDataHandler.ts
+++ b/src/domains/randomDefense/quickSlotsDataHandler.ts
@@ -139,3 +139,29 @@ const convertLegacyToLatestQuickSlots = (
     hotkey: 'Alt',
   };
 };
+
+export const fetchQuickSlots = () => {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(
+      [SYNC_STORAGE_KEY.QUICK_SLOTS, LEGACY_SYNC_STORAGE_KEY.QUICK_SLOTS],
+      (data: Record<string, unknown>) => {
+        const rawQuickSlots = data[SYNC_STORAGE_KEY.QUICK_SLOTS];
+        const rawLegacyQuickSlots = data[LEGACY_SYNC_STORAGE_KEY.QUICK_SLOTS];
+
+        if (!rawQuickSlots && rawLegacyQuickSlots) {
+          const sanitizedLegacyQuickSlots =
+            sanitizeLegacyQuickSlots(rawLegacyQuickSlots);
+          const sanitizedQuickSlots = convertLegacyToLatestQuickSlots(
+            sanitizedLegacyQuickSlots,
+          );
+
+          resolve(sanitizedQuickSlots);
+          return;
+        }
+
+        const sanitizedQuickSlots = sanitizeQuickSlots(rawQuickSlots);
+        resolve(sanitizedQuickSlots);
+      },
+    );
+  });
+};

--- a/src/domains/randomDefense/quickSlotsDataHandler.ts
+++ b/src/domains/randomDefense/quickSlotsDataHandler.ts
@@ -1,0 +1,45 @@
+import { LEGACY_SYNC_STORAGE_KEY, SYNC_STORAGE_KEY } from '~constants/commands';
+import { TITLE_MAX_LENGTH } from '~constants/randomDefense';
+import {
+  isSlot,
+  isRepairableQuickSlotsResponse,
+  isRepairableLegacyQuickSlotsResponse,
+  isHotkey,
+  isSlotNo,
+  isQuickSlotsResponse,
+  isLegacyQuickSlotsResponse,
+} from '~types/typeGuards';
+import { MAX_CUSTOM_QUERY_LENGTH } from '~constants/randomDefense';
+import type {
+  QuickSlotsResponse,
+  LegacyQuickSlotsResponse,
+  Slot,
+  SlotNo,
+  QuickSlots,
+} from '~types/randomDefense';
+
+const EMPTY_VALID_QUICK_SLOTS: QuickSlots = {
+  1: { isEmpty: true },
+  2: { isEmpty: true },
+  3: { isEmpty: true },
+  4: { isEmpty: true },
+  5: { isEmpty: true },
+  6: { isEmpty: true },
+  7: { isEmpty: true },
+  8: { isEmpty: true },
+  9: { isEmpty: true },
+  0: { isEmpty: true },
+} as const;
+
+const EMPTY_VALID_QUICK_SLOTS_RESPONSE: QuickSlotsResponse = {
+  hotkey: 'Alt',
+  selectedSlotNo: 1,
+  slots: EMPTY_VALID_QUICK_SLOTS,
+};
+
+const EMPTY_VALID_LEGACY_QUICK_SLOTS_RESPONSE: LegacyQuickSlotsResponse = {
+  selectedNo: 1,
+  ...EMPTY_VALID_QUICK_SLOTS,
+};
+
+const SLOT_NOS: SlotNo[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];

--- a/src/domains/randomDefense/quickSlotsDataHandler.ts
+++ b/src/domains/randomDefense/quickSlotsDataHandler.ts
@@ -43,3 +43,99 @@ const EMPTY_VALID_LEGACY_QUICK_SLOTS_RESPONSE: LegacyQuickSlotsResponse = {
 };
 
 const SLOT_NOS: SlotNo[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+
+const sanitizeSlot = (slot: unknown, slotNo: SlotNo): Slot => {
+  if (!isSlot(slot)) {
+    return { isEmpty: true };
+  }
+
+  if (
+    !slot.isEmpty &&
+    (slot.query.trim() === '' || slot.query.length > MAX_CUSTOM_QUERY_LENGTH)
+  ) {
+    return { isEmpty: true };
+  }
+
+  if (
+    !slot.isEmpty &&
+    (slot.title.trim() === '' || slot.title.length > TITLE_MAX_LENGTH)
+  ) {
+    return {
+      ...slot,
+      isEmpty: false,
+      title: `추첨 ${slotNo}`,
+    };
+  }
+
+  return slot;
+};
+
+const sanitizeQuickSlots = (quickSlots: unknown): QuickSlotsResponse => {
+  if (!isRepairableQuickSlotsResponse(quickSlots)) {
+    return EMPTY_VALID_QUICK_SLOTS_RESPONSE;
+  }
+
+  const hotkey =
+    'hotkey' in quickSlots && isHotkey(quickSlots.hotkey)
+      ? quickSlots.hotkey
+      : 'Alt';
+  const selectedSlotNo =
+    'selectedSlotNo' in quickSlots && isSlotNo(quickSlots.selectedSlotNo)
+      ? quickSlots.selectedSlotNo
+      : 1;
+
+  const sanitizedQuickSlots = {
+    ...quickSlots,
+    hotkey,
+    selectedSlotNo,
+  };
+
+  SLOT_NOS.forEach((slotNo) => {
+    const slot = sanitizedQuickSlots.slots[slotNo];
+    sanitizedQuickSlots.slots[slotNo] = sanitizeSlot(slot, slotNo);
+  });
+
+  return isQuickSlotsResponse(sanitizedQuickSlots)
+    ? sanitizedQuickSlots
+    : EMPTY_VALID_QUICK_SLOTS_RESPONSE;
+};
+
+const sanitizeLegacyQuickSlots = (
+  legacyQuickSlots: unknown,
+): LegacyQuickSlotsResponse => {
+  if (!isRepairableLegacyQuickSlotsResponse(legacyQuickSlots)) {
+    return EMPTY_VALID_LEGACY_QUICK_SLOTS_RESPONSE;
+  }
+
+  const { selectedNo, ...slots } = legacyQuickSlots;
+
+  const sanitizedSlotNo = isSlotNo(selectedNo)
+    ? legacyQuickSlots.selectedNo
+    : 1;
+
+  const sanitizedLegacyQuickSlots = {
+    ...slots,
+    selectedNo: sanitizedSlotNo,
+  };
+
+  SLOT_NOS.forEach((slotNo) => {
+    const slot = sanitizedLegacyQuickSlots[slotNo];
+    sanitizedLegacyQuickSlots[slotNo] = sanitizeSlot(slot, slotNo);
+  });
+
+  return isLegacyQuickSlotsResponse(sanitizedLegacyQuickSlots)
+    ? sanitizedLegacyQuickSlots
+    : EMPTY_VALID_LEGACY_QUICK_SLOTS_RESPONSE;
+};
+
+const convertLegacyToLatestQuickSlots = (
+  legacyQuickSlots: LegacyQuickSlotsResponse,
+): QuickSlotsResponse => {
+  const { selectedNo, ...legacyQuickSlotsWithoutSelectedNo } = legacyQuickSlots;
+
+  return {
+    selectedSlotNo: selectedNo,
+    slots: legacyQuickSlotsWithoutSelectedNo,
+    hotkey: 'Alt',
+  };
+};

--- a/src/domains/randomDefense/quickSlotsDataHandler.ts
+++ b/src/domains/randomDefense/quickSlotsDataHandler.ts
@@ -165,3 +165,21 @@ export const fetchQuickSlots = () => {
     );
   });
 };
+
+export const saveQuickSlots = (
+  selectedSlotNo: unknown,
+  slots: unknown,
+  hotkey: unknown,
+) => {
+  const quickSlotsData = { selectedSlotNo, slots, hotkey };
+
+  if (!isRepairableQuickSlotsResponse(quickSlotsData)) {
+    return;
+  }
+
+  const sanitizedQuickSlots = sanitizeQuickSlots(quickSlotsData);
+
+  chrome.storage.sync.set({
+    [SYNC_STORAGE_KEY.QUICK_SLOTS]: sanitizedQuickSlots,
+  });
+};

--- a/src/types/randomDefense.ts
+++ b/src/types/randomDefense.ts
@@ -68,6 +68,10 @@ export interface QuickSlotsResponse {
   slots: QuickSlots;
 }
 
+export type LegacyQuickSlotsResponse = {
+  selectedNo: SlotNo;
+} & QuickSlots;
+
 interface SlotValidVerdict {
   isValid: true;
 }
@@ -107,4 +111,32 @@ interface RandomDefenseFormDataInvalidVerdict {
   isValid: false;
   errorMessage: string;
   focusElementName?: string;
+}
+
+/**
+ * RepairableLegacyQuickSlotsResponse 타입은, LegacyQuickSlotsResponse보다 넓은 범위의 타입으로써, 구버전의 퀵슬롯 데이터의 형식이 유효하지 않더라도 복구할 수 있는 타입을 의미합니다.
+ * LegacyQuickSlotsResponse가 아니지만, RepairableLegacyQuickSlotsResponse에 부합하는 경우, 잘못된 데이터만 초기화하는 식으로 복구가 진행됩니다.
+ */
+export interface RepairableLegacyQuickSlotsResponse {
+  1: unknown;
+  2: unknown;
+  3: unknown;
+  4: unknown;
+  5: unknown;
+  6: unknown;
+  7: unknown;
+  8: unknown;
+  9: unknown;
+  0: unknown;
+  selectedNo?: unknown;
+}
+
+/**
+ * RepairableQuickSlotsResponse 타입은, QuickSlotsResponse보다 넓은 범위의 타입으로써, 퀵슬롯 데이터의 형식이 유효하지 않더라도 복구할 수 있는 타입을 의미합니다.
+ * QuickSlotsResponse가 아니지만, RepairableQuickSlotsResponse에 부합하는 경우, 잘못된 데이터만 초기화하는 식으로 복구가 진행됩니다.
+ */
+export interface RepairableQuickSlotsResponse {
+  slots: Omit<RepairableLegacyQuickSlotsResponse, 'selectedNo'>;
+  hotkey?: unknown;
+  selectedSlotNo?: unknown;
 }


### PR DESCRIPTION
## PR 내용
본 PR에서는 편리한 랜덤 디펜스를 위해 사용자가 생성한 추첨의 쿼리를 저장할 수 있는 퀵슬롯을 저장/불러오는 로직을 구현하였습니다.
- 데이터가 일부 올바르지 않더라도 복구할 수 있는 형태이면 복구가 가능한 쿼리에 한해 복구 후 저장합니다. 복구가 가능한 형식이 아닌 경우에는 데이터를 완전히 초기화합니다.
- `v1.1.*` 버전에서 `v1.2` 이상으로 업데이트하는 사용자를 위해 구버전의 데이터 형식을 처리하는 기능이 포함되어 있습니다.

## 서비스 워커 명세
### 퀵슬롯 정보 불러오기 ⬇️
- 커맨드: `fetchQuickSlots`
- 데이터의 저장소 위치: `chrome.sync.storage`
- 요청 메시지 예시
```ts
{
  command: 'fetchQuickSlots',
}
```
- 응답 메시지 예시
```ts
{
  slots: {
    1: {
      isEmpty: false,
      title: '골드 랜덤 디펜스',
      query: '(*0&s?false|!*0) o?true *11..15',
    },
    2: {
      isEmpty: false,
      title: 'Custom Query',
      query: 'solvable:true tier:s5..g3 lang:ko solved:100..',
    },
    3: { isEmpty: true },
    4: { isEmpty: true },
    5: { isEmpty: true },
    6: { isEmpty: true },
    7: { isEmpty: true },
    8: { isEmpty: true },
    9: { isEmpty: true },
    0: { isEmpty: true },
  },
  selectedSlotNo: 1,
  hotkey: 'Alt',
}
```

### 퀵슬롯 정보 저장하기 ⬆️
- 커맨드: `saveQuickSlots`
- 데이터의 저장소 위치: `chrome.sync.storage`
- 요청 메시지 예시
```ts
{
  command: 'saveQuickSlots',
  slots: {
    1: {
      isEmpty: false,
      title: '골드 랜덤 디펜스',
      query: '(*0&s?false|!*0) o?true *11..15',
    },
    2: {
      isEmpty: false,
      title: 'Custom Query',
      query: 'solvable:true tier:s5..g3 lang:ko solved:100..',
    },
    3: { isEmpty: true },
    4: { isEmpty: true },
    5: { isEmpty: true },
    6: { isEmpty: true },
    7: { isEmpty: true },
    8: { isEmpty: true },
    9: { isEmpty: true },
    0: { isEmpty: true },
  },
  selectedSlotNo: 1,
  hotkey: 'Alt',
}
```