### PR TITLE
[FEAT] "간편 입력" 모드로 추첨 생성 시, 문제해결 경고 문제가 포함되지 않도록 쿼리 수정

### DIFF
--- a/src/domains/randomDefense/randomDefenseQueryGenerator.test.ts
+++ b/src/domains/randomDefense/randomDefenseQueryGenerator.test.ts
@@ -16,7 +16,7 @@ describe('#Test 1 - 쿼리 생성 테스트', () => {
         algorithmIds: [],
         customQuery: '',
       },
-      '(*0&s?false|!*0) o?true ~@test_user s#100..500 *10..16',
+      '(*0&s?false|!*0) o?true w?false ~@test_user s#100..500 *10..16',
     ],
     [
       {
@@ -31,7 +31,7 @@ describe('#Test 1 - 쿼리 생성 테스트', () => {
         algorithmIds: [],
         customQuery: '',
       },
-      '(*0&s?false|!*0) o?true *11..15',
+      '(*0&s?false|!*0) o?true w?false *11..15',
     ],
     [
       {
@@ -46,7 +46,7 @@ describe('#Test 1 - 쿼리 생성 테스트', () => {
         algorithmIds: [7],
         customQuery: '',
       },
-      '(*0&s?false|!*0) o?true ~@silverlove1234 s#200.. *6..10 (#greedy)',
+      '(*0&s?false|!*0) o?true w?false ~@silverlove1234 s#200.. *6..10 (#greedy)',
     ],
     [
       {
@@ -61,7 +61,7 @@ describe('#Test 1 - 쿼리 생성 테스트', () => {
         algorithmIds: [],
         customQuery: 'foobar 1234',
       },
-      '(*0&s?false|!*0) o?true ~@ChoGosu *0',
+      '(*0&s?false|!*0) o?true w?false ~@ChoGosu *0',
     ],
     [
       {
@@ -76,7 +76,7 @@ describe('#Test 1 - 쿼리 생성 테스트', () => {
         algorithmIds: [4, 9, 16],
         customQuery: '',
       },
-      '(*0&s?false|!*0) o?true s#..10000 *1..30 (#graphs&#graph_traversal&#bfs)',
+      '(*0&s?false|!*0) o?true w?false s#..10000 *1..30 (#graphs&#graph_traversal&#bfs)',
     ],
     [
       {
@@ -91,7 +91,7 @@ describe('#Test 1 - 쿼리 생성 테스트', () => {
         algorithmIds: [1, 14],
         customQuery: '',
       },
-      '(*0&s?false|!*0) o?true s#0.. *1..30 (-#math-#geometry)',
+      '(*0&s?false|!*0) o?true w?false s#0.. *1..30 (-#math-#geometry)',
     ],
   ];
 

--- a/src/domains/randomDefense/randomDefenseQueryGenerator.ts
+++ b/src/domains/randomDefense/randomDefenseQueryGenerator.ts
@@ -43,7 +43,7 @@ export const generateRandomDefenseQuery = (
       )})`
     : '';
 
-  return `(*0&s?false|!*0) o?true ${handleBanQuery}${solvedRangeQuery}${difficultyRangeQuery}${algorithmNamesQuery}`.trim();
+  return `(*0&s?false|!*0) o?true w?false ${handleBanQuery}${solvedRangeQuery}${difficultyRangeQuery}${algorithmNamesQuery}`.trim();
 };
 
 const generateAlgorithmTags = (algorithmIds: number[]) => {


### PR DESCRIPTION
## PR 설명
본 PR에서는 문제 무작위 추첨(랜덤 디펜스) 메뉴에서 "간편 입력" 모드로 추첨을 생성할 경우, "문제해결 경고" 문제가 포함되지 않도록 생성되는 쿼리를 수정했습니다.
- "문제해결 경고" 문제는 "Not Ratable" 문제와는 난이도를 지니지만, 맞았더라도 레이팅이 영향을 주지 않으며, **지문, 데이터, 제한조건 등에 문제가 있어 원활한 문제해결이 어려울 수도 있는** 문제들입니다. 물론, 문제 자체에는 하자가 없는 경우도 있습니다. 예를 들면, **특정 문제와 완전히 동일**한 경우 한쪽 문제에 "문제해결 경고" 가 붙습니다. 하지만, 전자의 디메리트가 크므로 이러한 문제들은 추첨에서 제외하고자 합니다.
- 사용자는 원할 경우 "직접 입력" 모드를 이용해 문제해결 경고 문제들도 추첨에 포함하도록 설정할 수 있습니다.
- "문제해결 경고" 가 없는 문제들만 검색하도록 하는 조건은 solved.ac 검색 쿼리로는 `w?false` 입니다.

## 참고 자료
- 쿼리 변경 이후 추첨을 생성했을 때의 모습입니다.
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/538acbf4-e264-4044-87db-50387c2ce283)
