### PR TITLE
[FEAT] 티어 드롭다운 컴포넌트 구현

### DIFF
--- a/src/components/TierDropdown/TierDropdown.stories.tsx
+++ b/src/components/TierDropdown/TierDropdown.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TierDropdown from './TierDropdown';
+
+/**
+ * `TierDropdown`은 사용자에게 solved.ac 티어 하나를 선택할 수 있는 기능을 제공하는 드롭다운 형태의 컴포넌트입니다.
+ */
+const meta = {
+  title: 'TierDropdown',
+  component: TierDropdown,
+} satisfies Meta<typeof TierDropdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: '150px', height: '200px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    selectedTier: 1,
+  },
+};

--- a/src/components/TierDropdown/TierDropdown.styled.ts
+++ b/src/components/TierDropdown/TierDropdown.styled.ts
@@ -1,0 +1,138 @@
+import { styled, css } from 'styled-components';
+import type { RatedTier } from '~types/tierHider';
+
+export const Container = styled.div`
+  overflow: visible;
+  position: relative;
+
+  width: 134px;
+  height: 32px;
+
+  pointer-events: none;
+  z-index: 1;
+  user-select: none;
+`;
+
+export const Button = styled.button<{ $isActivated: boolean }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  column-gap: 4px;
+
+  width: 134px;
+  height: 32px;
+  padding: 6px;
+
+  border: 1.5px solid ${({ theme }) => theme.color.LIGHT_BROWN};
+  border-radius: 4px;
+  background-color: ${({ theme }) => theme.color.DARK_BROWN};
+
+  transition: 0.2s;
+  pointer-events: auto;
+
+  ${({ theme, $isActivated }) =>
+    $isActivated
+      ? css`
+          border: 1.5px solid ${theme.color.LEMON};
+          box-shadow: 0 0 12px ${theme.color.GOLD}70;
+        `
+      : css`
+          border: 1.5px solid ${theme.color.BROWN};
+        `}
+`;
+
+export const TierBadge = styled.img`
+  width: 12px;
+  height: auto;
+`;
+
+export const TierText = styled.p<{ $tier: RatedTier; $isBold: boolean }>`
+  font-size: 14px;
+  color: ${({ theme, $tier }) => theme.solvedAcTier[$tier]};
+  font-weight: ${({ $isBold }) => ($isBold ? 700 : 400)};
+
+  transition: font-weight 0.1s;
+`;
+
+export const ArrowDownTriangleIconWrapper = styled.div`
+  width: 16px;
+  height: 16px;
+
+  & > svg {
+    width: 100%;
+    height: 100%;
+
+    color: ${({ theme }) => theme.color.GOLD};
+  }
+`;
+
+export const List = styled.ul<{ $isOpen: boolean }>`
+  display: ${({ $isOpen }) => ($isOpen ? 'flex' : 'none')};
+  overflow-y: scroll;
+  flex-direction: column;
+  position: absolute;
+
+  width: 150px;
+  height: 172px;
+  margin: 4px 0 0 -8px;
+
+  border: 1.5px solid ${({ theme }) => theme.color.LEMON};
+  box-shadow: 0 0 12px ${({ theme }) => theme.color.GOLD}70;
+  border-radius: 4px;
+  background-color: ${({ theme }) => theme.color.DARK_BROWN};
+
+  scrollbar-width: none;
+
+  transform-origin: top;
+  pointer-events: auto;
+  animation: zoomIn 0.2s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  @keyframes zoomIn {
+    from {
+      transform: scale(0.7);
+    }
+    to {
+      transform: scale(1);
+    }
+  }
+`;
+
+export const ListItem = styled.li`
+  padding: 2px;
+`;
+
+export const ListButton = styled.button`
+  display: flex;
+  align-items: center;
+  column-gap: 6px;
+
+  width: 100%;
+  height: 30px;
+  padding: 0 10px;
+
+  border-radius: 4px;
+  background-color: ${({ theme }) => theme.color.DARK_BROWN};
+
+  transition: 0.15s;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.color.BROWN};
+  }
+`;
+
+export const CheckIconWrapper = styled.div`
+  width: 16px;
+  height: 16px;
+  margin-left: auto;
+
+  & > svg {
+    width: 16px;
+    height: 16px;
+
+    color: ${({ theme }) => theme.color.GOLD};
+  }
+`;

--- a/src/components/TierDropdown/TierDropdown.tsx
+++ b/src/components/TierDropdown/TierDropdown.tsx
@@ -1,0 +1,106 @@
+import * as S from './TierDropdown.styled';
+import { CheckIcon, ArrowDownTriangleIcon } from '~images/svg';
+import { solvedAcNumericTierIcons } from '~images/svg/tier';
+import useTierDropdown from '~hooks/tierHider/useTierDropdown';
+import type { RatedTier } from '~types/tierHider';
+
+interface TierDropdownProps {
+  selectedTier: RatedTier;
+  onChange: (tier: RatedTier) => void;
+}
+
+const RATED_TIERS: RatedTier[] = [
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+  23, 24, 25, 26, 27, 28, 29, 30,
+];
+
+const RATED_TIER_NAMES: Record<RatedTier, string> = {
+  1: 'Bronze V',
+  2: 'Bronze IV',
+  3: 'Bronze III',
+  4: 'Bronze II',
+  5: 'Bronze I',
+  6: 'Silver V',
+  7: 'Silver IV',
+  8: 'Silver III',
+  9: 'Silver II',
+  10: 'Silver I',
+  11: 'Gold V',
+  12: 'Gold IV',
+  13: 'Gold III',
+  14: 'Gold II',
+  15: 'Gold I',
+  16: 'Platinum V',
+  17: 'Platinum IV',
+  18: 'Platinum III',
+  19: 'Platinum II',
+  20: 'Platinum I',
+  21: 'Diamond V',
+  22: 'Diamond IV',
+  23: 'Diamond III',
+  24: 'Diamond II',
+  25: 'Diamond I',
+  26: 'Ruby V',
+  27: 'Ruby IV',
+  28: 'Ruby III',
+  29: 'Ruby II',
+  30: 'Ruby I',
+};
+
+const TierDropdown = (props: TierDropdownProps) => {
+  const { selectedTier: initSelectedTier, onChange } = props;
+  const {
+    selectedTier,
+    updateSelectedTier,
+    isDropdownOpen,
+    openDropdown,
+    containerRef,
+  } = useTierDropdown({
+    initSelectedTier,
+    onChange,
+  });
+
+  return (
+    <S.Container ref={containerRef}>
+      <S.Button
+        type="button"
+        aria-label="난이도 경고 시작 티어 변경하기"
+        $isActivated={isDropdownOpen}
+        onClick={openDropdown}
+      >
+        <S.TierBadge src={solvedAcNumericTierIcons[selectedTier]} alt="" />
+        <S.TierText $tier={selectedTier} $isBold={true}>
+          {RATED_TIER_NAMES[selectedTier]}
+        </S.TierText>
+        <S.ArrowDownTriangleIconWrapper>
+          <ArrowDownTriangleIcon />
+        </S.ArrowDownTriangleIconWrapper>
+      </S.Button>
+      <S.List $isOpen={isDropdownOpen}>
+        {RATED_TIERS.map((tier) => (
+          <S.ListItem key={tier}>
+            <S.ListButton
+              type="button"
+              aria-label={`${RATED_TIER_NAMES[tier]}를 경고 시작 티어로 설정하기`}
+              onClick={() => {
+                updateSelectedTier(tier);
+              }}
+            >
+              <S.TierBadge src={solvedAcNumericTierIcons[tier]} alt="" />
+              <S.TierText $tier={tier} $isBold={tier === selectedTier}>
+                {RATED_TIER_NAMES[tier]}
+              </S.TierText>
+              {tier === selectedTier && (
+                <S.CheckIconWrapper>
+                  <CheckIcon />
+                </S.CheckIconWrapper>
+              )}
+            </S.ListButton>
+          </S.ListItem>
+        ))}
+      </S.List>
+    </S.Container>
+  );
+};
+
+export default TierDropdown;

--- a/src/components/TierDropdown/index.ts
+++ b/src/components/TierDropdown/index.ts
@@ -1,0 +1,3 @@
+import TierDropdown from './TierDropdown';
+
+export default TierDropdown;

--- a/src/hooks/tierHider/useTierDropdown.ts
+++ b/src/hooks/tierHider/useTierDropdown.ts
@@ -1,0 +1,62 @@
+import { useState, useEffect, useRef } from 'react';
+import type { RatedTier } from '~types/tierHider';
+
+interface UseTierDropdownProps {
+  initSelectedTier: RatedTier;
+  onChange: (tier: RatedTier) => void;
+}
+
+const useTierDropdown = (params: UseTierDropdownProps) => {
+  const { initSelectedTier, onChange } = params;
+  const [selectedTier, setSelectedTier] = useState<RatedTier>(initSelectedTier);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setSelectedTier(initSelectedTier);
+  }, [initSelectedTier]);
+
+  useEffect(() => {
+    const containerElement = containerRef.current;
+
+    if (!containerElement) {
+      return;
+    }
+
+    const closeDropdownIfNotFocused = (event: globalThis.MouseEvent) => {
+      if (
+        event.target instanceof Node &&
+        event.target !== containerElement &&
+        !containerElement.contains(event.target)
+      ) {
+        setIsDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener('click', closeDropdownIfNotFocused);
+
+    return () => {
+      document.removeEventListener('click', closeDropdownIfNotFocused);
+    };
+  }, [containerRef]);
+
+  const openDropdown = () => {
+    setIsDropdownOpen(true);
+  };
+
+  const updateSelectedTier = (tier: RatedTier) => {
+    setSelectedTier(tier);
+    setIsDropdownOpen(false);
+    onChange(tier);
+  };
+
+  return {
+    selectedTier,
+    isDropdownOpen,
+    updateSelectedTier,
+    openDropdown,
+    containerRef,
+  };
+};
+
+export default useTierDropdown;

--- a/src/images/svg/arrow-down-triangle.svg
+++ b/src/images/svg/arrow-down-triangle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M7 9a1 1 0 0 0-.707 1.707l5 5a1 1 0 0 0 1.414 0l5-5A1 1 0 0 0 17 9z" clip-rule="evenodd"/></svg>

--- a/src/images/svg/index.ts
+++ b/src/images/svg/index.ts
@@ -14,3 +14,4 @@ export { ReactComponent as WarningIcon } from './warning.svg';
 export { ReactComponent as DiceIcon } from './dice.svg';
 export { ReactComponent as CheckIcon } from './check.svg';
 export { ReactComponent as LoadingIcon } from './loading.svg';
+export { ReactComponent as ArrowDownTriangleIcon } from './arrow-down-triangle.svg';

--- a/src/types/tierHider.ts
+++ b/src/types/tierHider.ts
@@ -1,0 +1,3 @@
+import type { solvedAcNumericTierIcons } from '~images/svg/tier';
+
+export type RatedTier = Exclude<keyof typeof solvedAcNumericTierIcons, 0 | 31>;


### PR DESCRIPTION
## 관련 이슈
- #63 

## PR 설명
본 PR에서는 `Bronze V` 부터 `Ruby I` 티어까지의 난이도 중 하나를 고를 수 있는 티어 드롭다운 컴포넌트를 구현하였습니다. -- `<TierDropdown>`
- 현재 예상되는 사용처는 티어 가리개 기능입니다. 자세한 사항은 상단의 관련 이슈를 참고하시기 바랍니다.

## 참고 자료
- 메뉴가 닫혀있을 때의 모습입니다.
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/5d970c0e-8fba-4544-9d3d-34c9c8de0bb6)

- 메뉴가 열려있을 때의 모습입니다.
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/c07cc059-4eba-4dde-9083-6fb267c0c0be)
