### PR TITLE
[FEAT] 설정 메뉴 제목 컴포넌트 구현

### DIFF
--- a/src/components/MenuTitle/MenuTitle.stories.tsx
+++ b/src/components/MenuTitle/MenuTitle.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CopyIcon } from '~images/svg';
+import MenuTitle from './MenuTitle';
+
+/**
+ * `MenuTitle`는 설정 페이지의 메뉴의 역할을 나타나는 데 사용할 수 있는 제목 컴포넌트입니다.
+ */
+const meta = {
+  title: 'MenuTitle',
+  component: MenuTitle,
+  argTypes: {},
+} satisfies Meta<typeof MenuTitle>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * svg 이미지를 아이콘으로 사용할 경우, 해당 아이콘의 색이 주황색으로 고정됨에 유의하세요.
+ */
+export const SvgTitle: Story = {
+  args: {
+    iconSrc: <CopyIcon />,
+    title: 'SVG 아이콘',
+  },
+};
+
+/**
+ * `string` 타입의 src를 사용하는 png, jpg 등의 이미지를 아이콘으로 사용할 경우, 이미지에 주황색 필터가 씌워짐에 유의하세요. 이 필터가 씌워지면 해당 아이콘은 단색 이미지가 되므로, 색상이 하나인 이미지를 사용하여야 합니다.
+ */
+export const PngTitle: Story = {
+  args: {
+    iconSrc: './dice.png',
+    title: 'PNG 아이콘',
+  },
+};

--- a/src/components/MenuTitle/MenuTitle.styled.ts
+++ b/src/components/MenuTitle/MenuTitle.styled.ts
@@ -1,0 +1,67 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+
+  width: auto;
+  max-width: 100%;
+
+  user-select: none;
+`;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  width: 100%;
+  column-gap: 6px;
+
+  font-family: 'Do Hyeon', Pretendard;
+`;
+
+export const IconImage = styled.img`
+  flex-shrink: 0;
+
+  width: auto;
+  height: 30px;
+
+  filter: ${({ theme }) => theme.filter.ORANGE_FILTER};
+  object-fit: contain;
+`;
+
+export const IconWrapper = styled.div`
+  flex-shrink: 0;
+
+  width: 30px;
+  height: 30px;
+
+  & > svg {
+    width: 100%;
+    height: 100%;
+
+    color: ${({ theme }) => theme.color.ORANGE};
+  }
+`;
+
+export const Title = styled.h2`
+  display: inline-block;
+  overflow: hidden;
+
+  font-size: 26px;
+  color: ${({ theme }) => theme.color.ORANGE};
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const Underline = styled.div`
+  position: relative;
+  bottom: 10px;
+
+  width: calc(100% + 6px);
+  margin-left: -3px;
+  height: 10px;
+  border-radius: 5px;
+  background-color: ${({ theme }) => theme.color.ORANGE_TRANSPARENT};
+
+  z-index: -1;
+`;

--- a/src/components/MenuTitle/MenuTitle.tsx
+++ b/src/components/MenuTitle/MenuTitle.tsx
@@ -1,0 +1,28 @@
+import type { SVGProps } from 'react';
+import * as S from './MenuTitle.styled';
+
+interface MenuTitleProps {
+  iconSrc: string | SVGProps<SVGSVGElement>;
+  title: string;
+}
+
+const MenuTitle = (props: MenuTitleProps) => {
+  const { iconSrc, title } = props;
+
+  return (
+    <S.Container>
+      <S.ContentContainer>
+        {iconSrc &&
+          (typeof iconSrc === 'string' ? (
+            <S.IconImage src={iconSrc} alt={title} />
+          ) : (
+            <S.IconWrapper>{iconSrc}</S.IconWrapper>
+          ))}
+        <S.Title>{title}</S.Title>
+      </S.ContentContainer>
+      <S.Underline />
+    </S.Container>
+  );
+};
+
+export default MenuTitle;

--- a/src/components/MenuTitle/index.ts
+++ b/src/components/MenuTitle/index.ts
@@ -1,0 +1,3 @@
+import MenuTitle from './MenuTitle';
+
+export default MenuTitle;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -24,6 +24,7 @@ export const theme = {
     BLACK_TRANSPARENT: '#00000050',
     ORANGE: '#ff8533',
     DARK_ORANGE: '#bb4b00',
+    ORANGE_TRANSPARENT: '#ff853340',
   },
 
   solvedAcTier: {
@@ -119,6 +120,8 @@ export const theme = {
       'brightness(0) saturate(100%) invert(29%) sepia(66%) saturate(1717%) hue-rotate(179deg) brightness(101%) contrast(101%)',
     LIGHT_BROWN_FILTER:
       'brightness(0) saturate(100%) invert(49%) sepia(26%) saturate(568%) hue-rotate(330deg) brightness(93%) contrast(86%)',
+    ORANGE_FILTER:
+      'brightness(0) saturate(100%) invert(49%) sepia(34%) saturate(983%) hue-rotate(339deg) brightness(115%) contrast(101%)',
   },
 };
 


### PR DESCRIPTION
## PR 설명
본 PR에서는 설정 페이지에서 사용될, 메뉴 제목 컴포넌트를 구현하였습니다. -- `<MenuTitle>`
- 제목에는 아이콘을 사용하여야 하며, 아이콘의 경우 문자열 형태의 `src`를 사용하거나, 컴포넌트 형태로 사용할 수 있습니다.

## 참고 자료
- `<MenuTitle>` 의 모습입니다.

![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/8f5d7e4b-f835-4f82-9938-11c2737f6334)

- 구버전에서의 설정 메뉴 제목이 차지하던 위치입니다.

![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/a13879f7-0b5f-4250-aac4-22769efc4a64)
