### PR TITLE
[FEAT] 공통 필드셋 컴포넌트 구현

### DIFF
--- a/src/components/common/Fieldset/Fieldset.stories.tsx
+++ b/src/components/common/Fieldset/Fieldset.stories.tsx
@@ -1,0 +1,139 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Fieldset from './Fieldset';
+import Input from '../Input';
+
+/**
+ * `Fieldset`는 어느 하나의 주제에 대해 사용자가 원하는 옵션을 선택할 수 있도록 해주는 컴포넌트입니다. 각 옵션에는 평범하게 `string`을 사용하거나, `ReactNode`와 같은 컴포넌트를 사용할 수 있습니다.
+ */
+const meta = {
+  title: 'common/Fieldset',
+  component: Fieldset,
+} satisfies Meta<typeof Fieldset>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const GRAPE_IMAGE_SRC =
+  'https://images.unsplash.com/photo-1599819177626-b50f9dd21c9b?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D';
+
+const options = [
+  {
+    label: '사과',
+    value: 'apple',
+  },
+  {
+    label: '배',
+    value: 'pear',
+  },
+  {
+    label: '파인애플',
+    value: 'pineapple',
+  },
+  {
+    label: '수박',
+    value: 'watermelon',
+  },
+];
+
+const optionsWithImages = [
+  ...options,
+  {
+    label: <img src={GRAPE_IMAGE_SRC} width="120px" alt="포도" />,
+    value: 'grape',
+  },
+  {
+    label: (
+      <Input
+        type="text"
+        textAlign="left"
+        width="200px"
+        placeholder="직접 입력..."
+        ariaLabel="좋아하는 과일 직접 입력"
+        value=""
+        hasError={false}
+        onChange={() => {}}
+      />
+    ),
+    value: 'other',
+  },
+];
+
+const randomOptions = Array.from({ length: 20 }).map(() => {
+  const randomValue = crypto.randomUUID();
+
+  return { label: randomValue, value: randomValue };
+});
+
+export const Default: Story = {
+  args: {
+    legend: '좋아하는 과일',
+    name: 'favoriteFruit',
+    options,
+    checkedValue: 'apple',
+    onChange: (value: string) => {
+      alert(`onChange('${value}')`);
+    },
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    legend: '좋아하는 과일',
+    name: 'favoriteFruit',
+    options,
+    checkedValue: 'apple',
+    isVertical: true,
+    onChange: (value: string) => {
+      alert(`onChange('${value}')`);
+    },
+  },
+};
+
+/**
+ * `isVertical` 옵션이 `true`로 설정되지 않았더라도, 옵션이 요소를 벗어나는 경우에는 다음 줄에 이어서 옵션들이 정렬됩니다.
+ */
+export const TooManyOptions: Story = {
+  args: {
+    legend: '매우 많은 옵션',
+    name: 'tooManyOptions',
+    options: randomOptions,
+    checkedValue: randomOptions[0].value,
+    onChange: (value: string) => {
+      alert(`onChange('${value}')`);
+    },
+  },
+};
+
+/**
+ * 필요할 경우, `string` 타입의 레이블을 사용하는 대신, 컴포넌트를 사용하여 사용자에게 더 다양한 옵션을 제공할 수도 있습니다.
+ */
+export const ComponentOptions: Story = {
+  args: {
+    legend: '좋아하는 과일',
+    name: 'favoriteFruit',
+    options: optionsWithImages,
+    checkedValue: 'apple',
+    isVertical: true,
+    onChange: (value: string) => {
+      alert(`onChange('${value}')`);
+    },
+  },
+};
+
+/**
+ * 다른 `Fieldset`의 옵션에 따라 일부 `Fieldset`을 비활성화시킬 수도 있습니다.
+ */
+
+export const Disabled: Story = {
+  args: {
+    legend: '좋아하는 과일',
+    name: 'favoriteFruit',
+    options,
+    checkedValue: 'apple',
+    disabled: true,
+    onChange: (value: string) => {
+      alert(`onChange('${value}')`);
+    },
+  },
+};

--- a/src/components/common/Fieldset/Fieldset.styled.ts
+++ b/src/components/common/Fieldset/Fieldset.styled.ts
@@ -1,0 +1,32 @@
+import { styled } from 'styled-components';
+
+export const Fieldset = styled.fieldset`
+  width: 100%;
+  height: 100%;
+
+  user-select: none;
+
+  &:disabled {
+    opacity: 0.6;
+  }
+`;
+
+export const Legend = styled.legend`
+  color: ${({ theme }) => theme.color.WHITE};
+  margin-bottom: 6px;
+`;
+
+export const OptionsContainer = styled.div<{ $isVertical: boolean }>`
+  display: flex;
+  align-content: flex-start;
+  flex-wrap: wrap;
+  flex-direction: ${({ $isVertical }) => ($isVertical ? 'column' : 'row')};
+  row-gap: 6px;
+  column-gap: 10px;
+`;
+
+export const Label = styled.label`
+  display: flex;
+  align-items: center;
+  column-gap: 4px;
+`;

--- a/src/components/common/Fieldset/Fieldset.tsx
+++ b/src/components/common/Fieldset/Fieldset.tsx
@@ -1,0 +1,59 @@
+import * as S from './Fieldset.styled';
+import Radio from '~components/common/Radio';
+import Text from '~components/common/Text';
+import type { ReactNode } from 'react';
+
+interface FieldsetProps {
+  legend: string;
+  name: string;
+  options: Option[];
+  checkedValue: string;
+  disabled?: boolean;
+  isVertical?: boolean;
+  onChange: (value: string) => void;
+}
+
+interface Option {
+  label: string | ReactNode;
+  value: string;
+}
+
+const Fieldset = (props: FieldsetProps) => {
+  const {
+    legend,
+    name,
+    options,
+    checkedValue,
+    disabled,
+    isVertical,
+    onChange,
+  } = props;
+
+  return (
+    <S.Fieldset disabled={disabled}>
+      <S.Legend>{legend}</S.Legend>
+      <S.OptionsContainer $isVertical={isVertical}>
+        {options.map(({ label, value }) => (
+          <S.Label key={value}>
+            <Radio
+              name={name}
+              value={value}
+              checked={value === checkedValue}
+              disabled={disabled}
+              onChange={onChange}
+            />
+            {typeof label === 'string' ? (
+              <Text type="semiPrimary" fontSize="16px">
+                {label}
+              </Text>
+            ) : (
+              label
+            )}
+          </S.Label>
+        ))}
+      </S.OptionsContainer>
+    </S.Fieldset>
+  );
+};
+
+export default Fieldset;

--- a/src/components/common/Fieldset/index.ts
+++ b/src/components/common/Fieldset/index.ts
@@ -1,0 +1,3 @@
+import Fieldset from './Fieldset';
+
+export default Fieldset;

--- a/src/components/common/Radio/Radio.stories.tsx
+++ b/src/components/common/Radio/Radio.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   title: 'common/Radio',
   component: Radio,
   argTypes: {
-    isChecked: {
+    checked: {
       description: '라디오의 체크 여부를 의미합니다.',
     },
     onChange: {
@@ -27,20 +27,34 @@ type Story = StoryObj<typeof meta>;
  */
 export const Checked: Story = {
   args: {
-    name: 'option-name',
-    isChecked: true,
-    onChange: () => {
-      alert('onChange()');
+    name: 'optionName',
+    value: 'optionValue',
+    checked: true,
+    onChange: (value) => {
+      alert(`onChange('${value}')`);
     },
   },
 };
 
 export const NotChecked: Story = {
   args: {
-    name: 'option-name',
-    isChecked: false,
-    onChange: () => {
-      alert('onChange()');
+    name: 'optionName',
+    value: 'optionValue',
+    checked: false,
+    onChange: (value) => {
+      alert(`onChange('${value}')`);
+    },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    name: 'optionName',
+    value: 'optionValue',
+    checked: false,
+    disabled: true,
+    onChange: (value) => {
+      alert(`onChange('${value}')`);
     },
   },
 };

--- a/src/components/common/Radio/Radio.styled.ts
+++ b/src/components/common/Radio/Radio.styled.ts
@@ -1,7 +1,16 @@
 import { styled, css } from 'styled-components';
 
-export const FakeVisualRadio = styled.div<{ $isChecked: boolean }>`
+export const Label = styled.label`
+  width: 16px;
+  height: 16px;
+`;
+
+export const FakeVisualRadio = styled.div<{
+  $checked: boolean;
+  $disabled: boolean;
+}>`
   display: inline-block;
+  flex-shrink: 0;
   position: relative;
 
   width: 16px;
@@ -11,10 +20,10 @@ export const FakeVisualRadio = styled.div<{ $isChecked: boolean }>`
 
   border-radius: 8px;
   transition: 0.15s;
-  cursor: pointer;
+  cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
 
-  ${({ theme, $isChecked }) =>
-    $isChecked
+  ${({ theme, $checked }) =>
+    $checked
       ? css`
           box-shadow: 0 0 8px ${theme.color.GOLD};
           background-color: ${theme.color.GOLD};

--- a/src/components/common/Radio/Radio.tsx
+++ b/src/components/common/Radio/Radio.tsx
@@ -1,19 +1,40 @@
 import * as S from './Radio.styled';
 
-interface RadioProps {
+type RadioProps = RadioWithValue | RadioWithoutValue;
+
+interface RadioWithValue {
   name: string;
-  isChecked: boolean;
+  value: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (value: string) => void;
+}
+
+interface RadioWithoutValue {
+  name: string;
+  checked: boolean;
+  disabled?: boolean;
   onChange: () => void;
 }
 
 const Radio = (props: RadioProps) => {
-  const { name, isChecked, onChange } = props;
+  const { checked, disabled } = props;
 
   return (
-    <label>
-      <S.FakeVisualRadio $isChecked={isChecked} />
-      <S.Radio name={name} checked={isChecked} onChange={onChange} />
-    </label>
+    <S.Label>
+      <S.Radio
+        {...props}
+        onChange={() => {
+          if ('value' in props) {
+            props.onChange(props.value);
+            return;
+          }
+
+          props.onChange();
+        }}
+      />
+      <S.FakeVisualRadio $checked={checked} $disabled={disabled} />
+    </S.Label>
   );
 };
 

--- a/src/components/common/Text/Text.styled.ts
+++ b/src/components/common/Text/Text.styled.ts
@@ -1,7 +1,7 @@
 import { styled, css } from 'styled-components';
 
 export const Text = styled.p<{
-  $type: 'primary' | 'normal' | 'code';
+  $type: 'primary' | 'semiPrimary' | 'normal' | 'code';
   $fontSize: '16px' | '14px' | '13px';
 }>`
   font-size: ${({ $fontSize }) => $fontSize};
@@ -11,6 +11,12 @@ export const Text = styled.p<{
       return css`
         color: ${theme.color.GOLD};
         font-weight: 600;
+      `;
+    }
+
+    if ($type === 'semiPrimary') {
+      return css`
+        color: ${theme.color.LEMON};
       `;
     }
 

--- a/src/components/common/Text/Text.tsx
+++ b/src/components/common/Text/Text.tsx
@@ -2,7 +2,7 @@ import type { PropsWithChildren } from 'react';
 import * as S from './Text.styled';
 
 interface TextProps {
-  type: 'primary' | 'normal' | 'code';
+  type: 'primary' | 'semiPrimary' | 'normal' | 'code';
   fontSize: '16px' | '14px' | '13px';
 }
 

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -38,6 +38,10 @@ const GlobalStyle = createGlobalStyle`
   ul, ol, li {
     list-style: none;
   }
+
+  fieldset {
+    border: 0;
+  }
   
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {


### PR DESCRIPTION
## PR 설명
본 PR에서는 여러 개의 옵션 중 하나를 고를 수 있는 `<Fieldset>` 공통 컴포넌트를 구현하였습니다.
- 예상 사용처는 설정 페이지의 여러 옵션 메뉴들입니다.
- label에는 문자열, 또는 컴포넌트가 올 수 있습니다. 이는 세부적인 옵션을 제공하는 경우 문자열만으로는 구현이 어렵기 때문입니다.

본 컴포넌트를 위한 부가적인 작업으로, `<Text>`, `<Radio>` 컴포넌트의 기능도 일부 수정하였습니다.
- `<Text>`: `type` 속성에 이제 `semiPrimary` 값을 사용할 수 있습니다. `primary`보다는 덜 강조된 디자인이며, `<Fieldset>`의 label이 현재 사용처입니다.
- `<Radio>`: `value` 속성을 추가하였으며, 사용처에 따라 이 속성은 생략할 수도 있습니다. 생략할 경우 `onChange` 함수의 타입은 `() => void`가 되며, `value`가 주어진다면 `onChange` 함수의 타입은 `(value: string) => void`가 됩니다.


## 참고 자료
###  `<Fieldset>` 의 모습 (Storybook)
- 별도의 설정을 하지 않았을 때의 모습입니다.
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/0eebb964-bd77-4076-afca-09a76c567f6d)

- `isVertical` 옵션을 `true`로 준 경우의 모습입니다. 이 경우, label의 내용과 상관없이 한 줄에 하나씩 옵션이 렌더링됩니다.
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/83f737f6-2f48-42fc-9bbc-eb4d06dadc5a)

- 컴포넌트를 조합하여 사용했을 때의 모습입니다.
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/6b568edc-0288-4cf7-888c-dc5714cd7667)

- 비활성화된 경우의 모습입니다.
![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/879e3051-eb03-446c-afd5-a9cc1b5ecc91)

### 구버전에서의 해당 컴포넌트에 대응되는 UI입니다.

![image](https://github.com/wzrabbit/boj-totamjung/assets/87642422/9343da60-fa56-4c90-b8b9-38d8f6bf7942)
