### PR TITLE
[FEAT] 가리개 관련 필드셋 저장/불러오기 관련 서비스워커 로직 구현

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -118,7 +118,7 @@
           };
         }
 
-        if (command === 'fetchTotmajungTheme') {
+        if (command === 'fetchTotamjungTheme') {
           return 'none';
         }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -14,6 +14,10 @@ import {
   fetchTotamjungTheme,
   saveTotamjungTheme,
 } from '~domains/totamjungTheme/totamjungThemeDataHandler';
+import {
+  fetchHiderOptions,
+  saveHiderOptions,
+} from '~domains/algorithm/hiderOptionsDataHandler';
 
 chrome.runtime.onMessage.addListener(
   (message: unknown, sender, sendResponse) => {
@@ -93,6 +97,16 @@ chrome.runtime.onMessage.addListener(
       }
 
       saveTotamjungTheme(message.totamjungTheme);
+    }
+
+    if (command === COMMANDS.FETCH_HIDER_OPTIONS) {
+      fetchHiderOptions().then((result) => {
+        sendResponse(result);
+      });
+    }
+
+    if (command === COMMANDS.SAVE_HIDER_OPTIONS) {
+      saveHiderOptions(message);
     }
 
     return true;

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -33,6 +33,8 @@ export const LEGACY_SYNC_STORAGE_KEY = {
   CHECKED_ALGORITHM_IDS: 'algorithm',
   QUICK_SLOTS: 'query',
   TOTAMJUNG_THEME: 'theme',
+  TIMER: 'timer',
+  SETTINGS: 'settings',
 } as const;
 
 export const LEGACY_LOCAL_STORAGE_KEY = {

--- a/src/domains/algorithm/hiderOptionsDataHandler.test.ts
+++ b/src/domains/algorithm/hiderOptionsDataHandler.test.ts
@@ -1,0 +1,309 @@
+import { LEGACY_SYNC_STORAGE_KEY, SYNC_STORAGE_KEY } from '~constants/commands';
+import { fetchHiderOptions, saveHiderOptions } from './hiderOptionsDataHandler';
+import type {
+  LegacyHiderOptions,
+  LegacyTimer,
+  HiderOptionsResponse,
+} from '~types/algorithm';
+
+const DEFAULT_HIDER_OPTIONS = {
+  problemTagLockDuration: {
+    hours: 0,
+    minutes: 20,
+  },
+  shouldHideTier: false,
+  shouldWarnHighTier: false,
+  warnTier: 1,
+  algorithmHiderUsage: 'click',
+  problemTagLockUsage: 'click',
+} as const;
+
+describe('Test #1 - 가리개 관련 설정 불러오기', () => {
+  describe('올바른 가리개 설정이 저장되어 있다면, 이를 그대로 불러온 값을 반환해야 한다.', () => {
+    const testcases = [
+      DEFAULT_HIDER_OPTIONS,
+      {
+        problemTagLockDuration: {
+          hours: 12,
+          minutes: 0,
+        },
+        shouldHideTier: true,
+        shouldWarnHighTier: true,
+        warnTier: 30,
+        algorithmHiderUsage: 'always',
+        problemTagLockUsage: 'auto',
+      },
+      {
+        problemTagLockDuration: {
+          hours: 99,
+          minutes: 59,
+        },
+        shouldHideTier: false,
+        shouldWarnHighTier: true,
+        warnTier: 12,
+        algorithmHiderUsage: 'click',
+        problemTagLockUsage: 'auto',
+      },
+    ];
+
+    test.each(testcases)('#%#', async (hiderOptions) => {
+      jest
+        .spyOn(chrome.storage.sync, 'get')
+        .mockImplementation(async (_, callback) => {
+          callback({ [SYNC_STORAGE_KEY.HIDER_OPTIONS]: hiderOptions });
+        });
+
+      expect(await fetchHiderOptions()).toEqual(hiderOptions);
+    });
+  });
+});
+
+describe('Test #2 - 유효하지 않은 가리개 관련 설정 데이터를 불러왔을 때 대응하기', () => {
+  describe('조금이라도 데이터가 잘못된 경우, 초기 데이터를 반환해야 한다.', () => {
+    const testcases = [
+      undefined,
+      'Invalid Data',
+      {
+        ...DEFAULT_HIDER_OPTIONS,
+        problemTagLockDuration: {
+          hours: 0,
+          minutes: 234,
+        },
+      },
+      {
+        ...DEFAULT_HIDER_OPTIONS,
+        warnTier: 31,
+      },
+      {
+        ...DEFAULT_HIDER_OPTIONS,
+        problemTagLockDuration: {
+          hours: 0,
+          minutes: '40',
+        },
+      },
+      {
+        ...DEFAULT_HIDER_OPTIONS,
+        algorithmHiderUsage: 'fooBar',
+        problemTagLockUsage: '',
+      },
+      {
+        problemTagLockDuration: {
+          hours: 0.5,
+          minutes: 1,
+        },
+        shouldHideTier: true,
+        shouldWarnHighTier: true,
+        warnTier: 9,
+        algorithmHiderUsage: 'click',
+        problemTagLockUsage: 'click',
+      },
+      {},
+    ];
+
+    test.each(testcases)('#%#', async (hiderOptions) => {
+      jest
+        .spyOn(chrome.storage.sync, 'get')
+        .mockImplementation(async (_, callback) => {
+          callback({ [SYNC_STORAGE_KEY.HIDER_OPTIONS]: hiderOptions });
+        });
+
+      expect(await fetchHiderOptions()).toEqual(DEFAULT_HIDER_OPTIONS);
+    });
+  });
+});
+
+describe('Test #3 - 구버전 가리개 관련 설정을 불러왔을 때 대응하기', () => {
+  test('구버전 타이머 데이터만 존재할 경우, 초기 데이터를 반환하되 타이머 데이터는 복구하여 반환해야 한다.', async () => {
+    const timer: LegacyTimer = {
+      expire: 1719291653435,
+      hour: '8',
+      minute: '30',
+      problem: 1000,
+    };
+
+    const expected = {
+      ...DEFAULT_HIDER_OPTIONS,
+      problemTagLockDuration: {
+        hours: 8,
+        minutes: 30,
+      },
+    };
+
+    jest
+      .spyOn(chrome.storage.sync, 'get')
+      .mockImplementation(async (_, callback) => {
+        callback({ [LEGACY_SYNC_STORAGE_KEY.TIMER]: timer });
+      });
+
+    expect(await fetchHiderOptions()).toEqual(expected);
+  });
+
+  test('일반 설정 데이터만 존재할 경우, 초기 데이터를 반환하되 설정 데이터는 복구하여 반환해야 한다.', async () => {
+    const hiderOptions: LegacyHiderOptions = {
+      font: 'font-16',
+      lock: 'always',
+      predict: 'always',
+      theme: 'yes',
+    };
+
+    const expected = {
+      ...DEFAULT_HIDER_OPTIONS,
+      algorithmHiderUsage: 'always',
+      problemTagLockUsage: 'auto',
+    };
+
+    jest
+      .spyOn(chrome.storage.sync, 'get')
+      .mockImplementation(async (_, callback) => {
+        callback({ [LEGACY_SYNC_STORAGE_KEY.SETTINGS]: hiderOptions });
+      });
+
+    expect(await fetchHiderOptions()).toEqual(expected);
+  });
+
+  test('두 설정 데이터 모두 존재할 경우, 초기 데이터에 복구 가능한 데이터들을 포함하여 반환해야 한다', async () => {
+    const timer: LegacyTimer = {
+      expire: 1719291651100,
+      hour: '3',
+      minute: '05',
+      problem: 30000,
+    };
+
+    const hiderOptions: LegacyHiderOptions = {
+      font: 'none',
+      lock: 'click',
+      predict: 'always',
+      theme: 'no',
+    };
+
+    const expected = {
+      ...DEFAULT_HIDER_OPTIONS,
+      problemTagLockDuration: {
+        hours: 3,
+        minutes: 5,
+      },
+      algorithmHiderUsage: 'always',
+      problemTagLockUsage: 'click',
+    };
+
+    jest
+      .spyOn(chrome.storage.sync, 'get')
+      .mockImplementation(async (_, callback) => {
+        callback({
+          [LEGACY_SYNC_STORAGE_KEY.TIMER]: timer,
+          [LEGACY_SYNC_STORAGE_KEY.SETTINGS]: hiderOptions,
+        });
+      });
+
+    expect(await fetchHiderOptions()).toEqual(expected);
+  });
+
+  test('구버전 타이머 데이터만 존재하나 유효하지 않은 데이터라면 복구를 진행하지 않고 초기 데이터를 반환하여야 한다.', async () => {
+    const timer = {
+      hour: '15',
+      minute: '30',
+      problem: 1000,
+    };
+
+    const hiderOptions = {
+      font: 'none',
+      lock: 'A molla!!',
+      predict: true,
+      theme: 1,
+    };
+
+    jest
+      .spyOn(chrome.storage.sync, 'get')
+      .mockImplementation(async (_, callback) => {
+        callback({
+          [LEGACY_SYNC_STORAGE_KEY.TIMER]: timer,
+          [LEGACY_SYNC_STORAGE_KEY.SETTINGS]: hiderOptions,
+        });
+      });
+
+    expect(await fetchHiderOptions()).toEqual(DEFAULT_HIDER_OPTIONS);
+  });
+
+  test('구버전 데이터가 존재하더라도 최신 버전의 데이터가 존재하면 구버전 데이터를 무시하고 최신 버전의 데이터를 불러와 반환하여야 한다.', async () => {
+    const timer: LegacyTimer = {
+      expire: 1439292659998,
+      hour: '3',
+      minute: '0',
+      problem: 25000,
+    };
+
+    const legacyHiderOptions: LegacyHiderOptions = {
+      font: 'font-1',
+      lock: 'click',
+      predict: 'click',
+      theme: 'no',
+    };
+
+    const hiderOptions: HiderOptionsResponse = {
+      problemTagLockDuration: {
+        hours: 1,
+        minutes: 15,
+      },
+      shouldHideTier: true,
+      shouldWarnHighTier: false,
+      warnTier: 17,
+      algorithmHiderUsage: 'always',
+      problemTagLockUsage: 'auto',
+    };
+
+    jest
+      .spyOn(chrome.storage.sync, 'get')
+      .mockImplementation(async (_, callback) => {
+        callback({
+          [LEGACY_SYNC_STORAGE_KEY.TIMER]: timer,
+          [LEGACY_SYNC_STORAGE_KEY.SETTINGS]: legacyHiderOptions,
+          [SYNC_STORAGE_KEY.HIDER_OPTIONS]: hiderOptions,
+        });
+      });
+
+    expect(await fetchHiderOptions()).toEqual(hiderOptions);
+  });
+});
+
+describe('Test #4 - 가리개 관련 설정 저장하기', () => {
+  test('올바른 가리개 설정이 저장되어 있다면, 이를 그대로 불러온 값을 반환해야 한다.', () => {
+    const hiderOptions = {
+      problemTagLockDuration: {
+        hours: 40,
+        minutes: 50,
+      },
+      shouldHideTier: true,
+      shouldWarnHighTier: false,
+      warnTier: 29,
+      algorithmHiderUsage: 'always',
+      problemTagLockUsage: 'auto',
+    };
+
+    jest.spyOn(chrome.storage.sync, 'set').mockImplementation(() => {});
+    saveHiderOptions(hiderOptions);
+
+    expect(chrome.storage.sync.set).toHaveBeenCalledWith({
+      [SYNC_STORAGE_KEY.HIDER_OPTIONS]: hiderOptions,
+    });
+  });
+});
+
+describe('Test #5 - 유효하지 않은 가리개 관련 설정 데이터를 저장해야 할 때 대응하기', () => {
+  test('저장해야 하는 설정 데이터가 유효한 데이터가 아니라면, 저장을 진행하지 않아야 한다.', () => {
+    const hiderOptions = {
+      problemTagLockDuration: {
+        hours: -1,
+        minutes: 50,
+      },
+      shouldWarnHighTier: false,
+      warnTier: 29,
+    };
+
+    jest.clearAllMocks();
+    jest.spyOn(chrome.storage.sync, 'set').mockImplementation(() => {});
+
+    saveHiderOptions(hiderOptions);
+
+    expect(chrome.storage.sync.set).not.toHaveBeenCalled();
+  });
+});

--- a/src/domains/algorithm/hiderOptionsDataHandler.ts
+++ b/src/domains/algorithm/hiderOptionsDataHandler.ts
@@ -1,0 +1,109 @@
+import { LEGACY_SYNC_STORAGE_KEY, SYNC_STORAGE_KEY } from '~constants/commands';
+import { HiderOptionsResponse } from '~types/algorithm';
+import {
+  isHiderOptionsResponse,
+  isLegacyTimer,
+  isLegacyHiderSettings,
+} from '~types/typeGuards';
+
+const DEFAULT_HIDER_OPTIONS = {
+  problemTagLockDuration: {
+    hours: 0,
+    minutes: 20,
+  },
+  shouldHideTier: false,
+  shouldWarnHighTier: false,
+  warnTier: 1,
+  algorithmHiderUsage: 'click',
+  problemTagLockUsage: 'click',
+} as const;
+
+interface HiderSettingsUsage {
+  algorithmHiderUsage: 'click' | 'always';
+  problemTagLockUsage: 'click' | 'auto';
+}
+
+const generateLatestHiderOptionsByLegacyData = (
+  legacyTimer: unknown,
+  legacyHiderSettings: unknown,
+): HiderOptionsResponse => {
+  const duration = isLegacyTimer(legacyTimer)
+    ? { hours: Number(legacyTimer.hour), minutes: Number(legacyTimer.minute) }
+    : { hours: 0, minutes: 20 };
+  const hiderSettings: HiderSettingsUsage = isLegacyHiderSettings(
+    legacyHiderSettings,
+  )
+    ? {
+        algorithmHiderUsage: legacyHiderSettings.predict,
+        problemTagLockUsage:
+          legacyHiderSettings.lock === 'always' ? 'auto' : 'click',
+      }
+    : {
+        algorithmHiderUsage: 'click',
+        problemTagLockUsage: 'click',
+      };
+
+  return {
+    ...DEFAULT_HIDER_OPTIONS,
+    problemTagLockDuration: duration,
+    ...hiderSettings,
+  };
+};
+
+export const fetchHiderOptions = async () => {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(
+      [
+        SYNC_STORAGE_KEY.HIDER_OPTIONS,
+        LEGACY_SYNC_STORAGE_KEY.TIMER,
+        LEGACY_SYNC_STORAGE_KEY.SETTINGS,
+      ],
+      (data: Record<string, unknown>) => {
+        const hiderOptions = data[SYNC_STORAGE_KEY.HIDER_OPTIONS];
+        const legacyTimer = data[LEGACY_SYNC_STORAGE_KEY.TIMER];
+        const legacyHiderSettings = data[LEGACY_SYNC_STORAGE_KEY.SETTINGS];
+
+        const isLegacy = !hiderOptions && (legacyTimer || legacyHiderSettings);
+
+        if (isLegacy) {
+          console.log(
+            'legacy',
+            generateLatestHiderOptionsByLegacyData(
+              legacyTimer,
+              legacyHiderSettings,
+            ),
+          );
+          resolve(
+            generateLatestHiderOptionsByLegacyData(
+              legacyTimer,
+              legacyHiderSettings,
+            ),
+          );
+          return;
+        }
+
+        console.log(
+          'normal',
+          isHiderOptionsResponse(hiderOptions)
+            ? hiderOptions
+            : DEFAULT_HIDER_OPTIONS,
+        );
+        resolve(
+          isHiderOptionsResponse(hiderOptions)
+            ? hiderOptions
+            : DEFAULT_HIDER_OPTIONS,
+        );
+      },
+    );
+  });
+};
+
+export const saveHiderOptions = (hiderOptions: unknown) => {
+  if (!isHiderOptionsResponse(hiderOptions)) {
+    return;
+  }
+
+  chrome.storage.sync.set({
+    [SYNC_STORAGE_KEY.HIDER_OPTIONS]: hiderOptions,
+  });
+};

--- a/src/domains/algorithm/hiderOptionsDataHandler.ts
+++ b/src/domains/algorithm/hiderOptionsDataHandler.ts
@@ -66,13 +66,6 @@ export const fetchHiderOptions = async () => {
         const isLegacy = !hiderOptions && (legacyTimer || legacyHiderSettings);
 
         if (isLegacy) {
-          console.log(
-            'legacy',
-            generateLatestHiderOptionsByLegacyData(
-              legacyTimer,
-              legacyHiderSettings,
-            ),
-          );
           resolve(
             generateLatestHiderOptionsByLegacyData(
               legacyTimer,
@@ -82,12 +75,6 @@ export const fetchHiderOptions = async () => {
           return;
         }
 
-        console.log(
-          'normal',
-          isHiderOptionsResponse(hiderOptions)
-            ? hiderOptions
-            : DEFAULT_HIDER_OPTIONS,
-        );
         resolve(
           isHiderOptionsResponse(hiderOptions)
             ? hiderOptions

--- a/src/types/algorithm.ts
+++ b/src/types/algorithm.ts
@@ -24,3 +24,17 @@ export interface HiderOptionsResponse {
   algorithmHiderUsage: 'click' | 'always';
   problemTagLockUsage: 'click' | 'auto';
 }
+
+export interface LegacyTimer {
+  expire: number;
+  hour: string;
+  minute: string;
+  problem: number;
+}
+
+export interface LegacyHiderSettings {
+  font: `font-${number}` | 'none';
+  lock: 'click' | 'always';
+  predict: 'click' | 'always';
+  theme: 'yes' | 'no';
+}

--- a/src/types/algorithm.ts
+++ b/src/types/algorithm.ts
@@ -32,7 +32,7 @@ export interface LegacyTimer {
   problem: number;
 }
 
-export interface LegacyHiderSettings {
+export interface LegacyHiderOptions {
   font: `font-${number}` | 'none';
   lock: 'click' | 'always';
   predict: 'click' | 'always';

--- a/src/types/typeGuards.ts
+++ b/src/types/typeGuards.ts
@@ -15,8 +15,16 @@ import type { TotamjungThemeResponse } from '~types/totamjungTheme';
 import { solvedAcNumericTierIcons } from '~images/svg/tier';
 import type { IsoString } from '~types/utils';
 import type { Tier, TierWithoutNotRatable } from '~types/randomDefense';
-import type { HiderOptionsResponse } from '~types/algorithm';
+import type {
+  HiderOptionsResponse,
+  LegacyTimer,
+  LegacyHiderSettings,
+} from '~types/algorithm';
 import type { RatedTier } from '~types/tierHider';
+import {
+  isNumericString,
+  isNumericStringAllowsLeadingZeroes,
+} from '~utils/numericStringChecker';
 
 export const isObject = (data: unknown): data is object => {
   return typeof data === 'object' && data !== null;
@@ -288,5 +296,25 @@ export const isHiderOptionsResponse = (
     ['click', 'always'].includes(data.algorithmHiderUsage) &&
     typeof data.problemTagLockUsage === 'string' &&
     ['click', 'auto'].includes(data.problemTagLockUsage)
+  );
+};
+
+export const isLegacyTimer = (data: unknown): data is LegacyTimer => {
+  return (
+    isObject(data) &&
+    'expire' in data &&
+    'hour' in data &&
+    'minute' in data &&
+    'problem' in data &&
+    typeof data.expire === 'number' &&
+    typeof data.hour === 'string' &&
+    typeof data.minute === 'string' &&
+    typeof data.problem === 'number' &&
+    data.hour.length >= 1 &&
+    data.hour.length <= 2 &&
+    isNumericStringAllowsLeadingZeroes(data.hour) &&
+    data.minute.length >= 1 &&
+    data.minute.length <= 2 &&
+    isNumericStringAllowsLeadingZeroes(data.minute)
   );
 };

--- a/src/types/typeGuards.ts
+++ b/src/types/typeGuards.ts
@@ -18,7 +18,7 @@ import type { Tier, TierWithoutNotRatable } from '~types/randomDefense';
 import type {
   HiderOptionsResponse,
   LegacyTimer,
-  LegacyHiderSettings,
+  LegacyHiderOptions,
 } from '~types/algorithm';
 import type { RatedTier } from '~types/tierHider';
 import {
@@ -321,7 +321,7 @@ export const isLegacyTimer = (data: unknown): data is LegacyTimer => {
 
 export const isLegacyHiderSettings = (
   data: unknown,
-): data is LegacyHiderSettings => {
+): data is LegacyHiderOptions => {
   if (
     !(
       isObject(data) &&

--- a/src/types/typeGuards.ts
+++ b/src/types/typeGuards.ts
@@ -318,3 +318,47 @@ export const isLegacyTimer = (data: unknown): data is LegacyTimer => {
     isNumericStringAllowsLeadingZeroes(data.minute)
   );
 };
+
+export const isLegacyHiderSettings = (
+  data: unknown,
+): data is LegacyHiderSettings => {
+  if (
+    !(
+      isObject(data) &&
+      'font' in data &&
+      'lock' in data &&
+      'predict' in data &&
+      'theme' in data &&
+      typeof data.font === 'string' &&
+      typeof data.lock === 'string' &&
+      typeof data.predict === 'string' &&
+      typeof data.theme === 'string' &&
+      typeof data.lock === 'string' &&
+      ['click', 'always'].includes(data.lock) &&
+      typeof data.predict === 'string' &&
+      ['click', 'always'].includes(data.predict) &&
+      typeof data.theme === 'string' &&
+      ['yes', 'no'].includes(data.theme)
+    )
+  ) {
+    return false;
+  }
+
+  if (data.font === 'none') {
+    return true;
+  }
+
+  if (!/^font-\d+$/.test(data.font)) {
+    return false;
+  }
+
+  const fontNoString = data.font.split('-')[1];
+
+  if (!isNumericString(fontNoString)) {
+    return false;
+  }
+
+  const fontNo = Number(fontNoString);
+
+  return fontNo >= 1 && fontNo <= 19;
+};

--- a/src/types/typeGuards.ts
+++ b/src/types/typeGuards.ts
@@ -276,26 +276,41 @@ export const isRatedTier = (data: unknown): data is RatedTier => {
 export const isHiderOptionsResponse = (
   data: unknown,
 ): data is HiderOptionsResponse => {
+  if (
+    !(
+      isObject(data) &&
+      'problemTagLockDuration' in data &&
+      'shouldHideTier' in data &&
+      'shouldWarnHighTier' in data &&
+      'warnTier' in data &&
+      'algorithmHiderUsage' in data &&
+      'problemTagLockUsage' in data &&
+      isObject(data.problemTagLockDuration) &&
+      'hours' in data.problemTagLockDuration &&
+      'minutes' in data.problemTagLockDuration &&
+      typeof data.problemTagLockDuration.hours === 'number' &&
+      typeof data.problemTagLockDuration.minutes === 'number' &&
+      typeof data.shouldHideTier === 'boolean' &&
+      typeof data.shouldWarnHighTier === 'boolean' &&
+      isRatedTier(data.warnTier) &&
+      typeof data.algorithmHiderUsage === 'string' &&
+      ['click', 'always'].includes(data.algorithmHiderUsage) &&
+      typeof data.problemTagLockUsage === 'string' &&
+      ['click', 'auto'].includes(data.problemTagLockUsage)
+    )
+  ) {
+    return false;
+  }
+
+  const { hours, minutes } = data.problemTagLockDuration;
+
   return (
-    isObject(data) &&
-    'problemTagLockDuration' in data &&
-    'shouldHideTier' in data &&
-    'shouldWarnHighTier' in data &&
-    'warnTier' in data &&
-    'algorithmHiderUsage' in data &&
-    'problemTagLockUsage' in data &&
-    isObject(data.problemTagLockDuration) &&
-    'hours' in data.problemTagLockDuration &&
-    'minutes' in data.problemTagLockDuration &&
-    typeof data.problemTagLockDuration.hours === 'number' &&
-    typeof data.problemTagLockDuration.minutes === 'number' &&
-    typeof data.shouldHideTier === 'boolean' &&
-    typeof data.shouldWarnHighTier === 'boolean' &&
-    isRatedTier(data.warnTier) &&
-    typeof data.algorithmHiderUsage === 'string' &&
-    ['click', 'always'].includes(data.algorithmHiderUsage) &&
-    typeof data.problemTagLockUsage === 'string' &&
-    ['click', 'auto'].includes(data.problemTagLockUsage)
+    hours >= 0 &&
+    hours < 100 &&
+    minutes >= 0 &&
+    minutes < 60 &&
+    hours % 1 === 0 &&
+    minutes % 1 === 0
   );
 };
 

--- a/src/utils/numericStringChecker.ts
+++ b/src/utils/numericStringChecker.ts
@@ -1,0 +1,7 @@
+export const isNumericString = (data: string) => {
+  return /^[1-9]\d*$/.test(data);
+};
+
+export const isNumericStringAllowsLeadingZeroes = (data: string) => {
+  return /^\d+$/.test(data);
+};


### PR DESCRIPTION
## PR 내용
본 PR에서는 가리개 관련 필드셋에 대응하는 데이터를 저장/불러오는 로직을 구현하였습니다.
- 데이터가 올바르지 않으면 데이터를 초깃값으로 초기화합니다.
- `v1.1.*` 버전에서 `v1.2` 이상으로 업데이트하는 사용자를 위해 구버전의 데이터 형식을 처리하는 기능이 포함되어 있습니다.

## 서비스 워커 명세
### 퀵슬롯 정보 불러오기 ⬇️
- 커맨드: `fetchHiderOptions`
- 데이터의 저장소 위치: `chrome.sync.storage`
- 요청 메시지 예시
```ts
{
  command: 'fetchHiderOptions',
}
```
- 응답 메시지 예시
```ts
{
  problemTagLockDuration: {
    hours: 1,
    minutes: 30,
  },
  shouldHideTier: true,
  shouldWarnHighTier: true,
  warnTier: 16,
  algorithmHiderUsage: 'always',
  problemTagLockUsage: 'click'
}
```

### 퀵슬롯 정보 저장하기 ⬆️
- 커맨드: `saveHiderOptions`
- 데이터의 저장소 위치: `chrome.sync.storage`
- 요청 메시지 예시
```ts
{
  command: 'saveHiderOptions',
  problemTagLockDuration: {
    hours: 1,
    minutes: 30,
  },
  shouldHideTier: true,
  shouldWarnHighTier: true,
  warnTier: 16,
  algorithmHiderUsage: 'always',
  problemTagLockUsage: 'click'
}
```