### PR TITLE
[FEAT] 테마 저장/불러오기 서비스워커 구현

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -21,6 +21,10 @@ import {
   saveHiderOptions,
 } from '~domains/dataHandlers/hiderOptionsDataHandler';
 import { initializeDataOnFirstInstall } from '~domains/dataHandlers/dataInitializer';
+import {
+  fetchFontNo,
+  saveFontNo,
+} from '~domains/dataHandlers/fontNoDataHandler';
 import { updateAllLegacyData } from '~domains/dataHandlers/legacyDataUpdater';
 
 chrome.runtime.onInstalled.addListener(({ reason }) => {
@@ -122,6 +126,21 @@ chrome.runtime.onMessage.addListener(
 
     if (command === COMMANDS.SAVE_HIDER_OPTIONS) {
       saveHiderOptions(message);
+    }
+
+    if (command === COMMANDS.FETCH_FONT_NO) {
+      fetchFontNo().then((result) => {
+        sendResponse(result);
+      });
+    }
+
+    if (command === COMMANDS.SAVE_FONT_NO) {
+      if (!('fontNo' in message)) {
+        return;
+      }
+
+      const { fontNo } = message;
+      saveFontNo(fontNo);
     }
 
     return true;

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -26,6 +26,7 @@ export const STORAGE_KEY = {
   HIDER_OPTIONS: 'hiderOptions',
   RANDOM_DEFENSE_HISTORY: 'randomDefenseHistory',
   IS_TIER_HIDDEN: 'isTierHidden',
+  FONT_NO: 'fontNo',
   DATA_VERSION: 'dataVersion',
 };
 

--- a/src/constants/defaultValues.ts
+++ b/src/constants/defaultValues.ts
@@ -47,3 +47,5 @@ export const DEFAULT_TOTAMJUNG_THEME = 'none';
 export const DEFAULT_IS_TIER_HIDDEN = false;
 
 export const DEFAULT_RANDOM_DEFENSE_HISTORY = [];
+
+export const DEFAULT_FONT_NO = 0;

--- a/src/domains/dataHandlers/converters/legacyToLatestFontNo.ts
+++ b/src/domains/dataHandlers/converters/legacyToLatestFontNo.ts
@@ -1,0 +1,23 @@
+import { isObject } from '~types/typeGuards';
+import { isLegacyFontNo } from '../validators/fontNoValidator';
+
+export const convertLegacyToLatestFontNoBySettings = (
+  settings: unknown,
+): number => {
+  if (!isObject(settings) || !('font' in settings)) {
+    return 0;
+  }
+
+  const legacyFontNo = settings.font;
+
+  if (!isLegacyFontNo(legacyFontNo)) {
+    return 0;
+  }
+
+  if (legacyFontNo === 'none') {
+    return 0;
+  }
+
+  const fontNo = Number(legacyFontNo.split('-')[1]);
+  return fontNo;
+};

--- a/src/domains/dataHandlers/fontNoDataHandler.ts
+++ b/src/domains/dataHandlers/fontNoDataHandler.ts
@@ -1,0 +1,22 @@
+import { STORAGE_KEY } from '~constants/commands';
+import { sanitizeFontNo } from './sanitizers/fontNoSanitizer';
+import { isFontNo } from './validators/fontNoValidator';
+
+export const fetchFontNo = async () => {
+  const data = await chrome.storage.local.get(STORAGE_KEY.FONT_NO);
+  const fontNo = data[STORAGE_KEY.FONT_NO];
+
+  return {
+    [STORAGE_KEY.FONT_NO]: sanitizeFontNo(fontNo),
+  };
+};
+
+export const saveFontNo = (fontNo: unknown) => {
+  if (!isFontNo(fontNo)) {
+    return;
+  }
+
+  chrome.storage.local.set({
+    [STORAGE_KEY.FONT_NO]: fontNo,
+  });
+};

--- a/src/domains/dataHandlers/legacyDataUpdater.test.ts
+++ b/src/domains/dataHandlers/legacyDataUpdater.test.ts
@@ -2,9 +2,9 @@ import { STORAGE_KEY } from '~constants/commands';
 import { updateAllLegacyData } from './legacyDataUpdater';
 import {
   DEFAULT_CHECKED_ALGORITHM_IDS,
+  DEFAULT_FONT_NO,
   DEFAULT_HIDER_OPTIONS,
   DEFAULT_IS_TIER_HIDDEN,
-  DEFAULT_LEGACY_QUICK_SLOTS_RESPONSE,
   DEFAULT_QUICK_SLOTS_RESPONSE,
   DEFAULT_RANDOM_DEFENSE_HISTORY,
   DEFAULT_TOTAMJUNG_THEME,
@@ -212,6 +212,7 @@ describe('Test #1 - 구버전 데이터를 최신 버전 데이터로 변환하�
         },
       ],
       totamjungTheme: 'none',
+      fontNo: 19,
     };
 
     jest.clearAllMocks();
@@ -398,6 +399,7 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
         },
       ],
       totamjungTheme: 'none',
+      fontNo: 3,
     };
 
     jest.clearAllMocks();
@@ -463,6 +465,7 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
       quickSlots: DEFAULT_QUICK_SLOTS_RESPONSE,
       randomDefenseHistory: DEFAULT_RANDOM_DEFENSE_HISTORY,
       totamjungTheme: DEFAULT_TOTAMJUNG_THEME,
+      fontNo: DEFAULT_FONT_NO,
     };
 
     jest.clearAllMocks();
@@ -495,6 +498,7 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
       [STORAGE_KEY.HIDER_OPTIONS]: DEFAULT_HIDER_OPTIONS,
       [STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: DEFAULT_RANDOM_DEFENSE_HISTORY,
       [STORAGE_KEY.IS_TIER_HIDDEN]: DEFAULT_IS_TIER_HIDDEN,
+      [STORAGE_KEY.FONT_NO]: DEFAULT_FONT_NO,
       [STORAGE_KEY.DATA_VERSION]: 'v1.2',
     });
   });

--- a/src/domains/dataHandlers/legacyDataUpdater.ts
+++ b/src/domains/dataHandlers/legacyDataUpdater.ts
@@ -11,6 +11,7 @@ import { convertLegacyToLatestQuickSlots } from './converters/legacyToLatestQuic
 import { convertLegacyToLatestRandomDefenseHistory } from './converters/legacyToLatestRandomDefenseHistory';
 import { convertLegacyToLatestHiderOptions } from './converters/legacyToLatestHiderOptionsConverter';
 import { convertLegacyToLatestTotamjungTheme } from './converters/legacyToLatestTotamjungThemeConverter';
+import { convertLegacyToLatestFontNoBySettings } from './converters/legacyToLatestFontNo';
 
 export const updateAllLegacyData = async () => {
   const { dataVersion } = await chrome.storage.local.get(
@@ -50,6 +51,9 @@ export const updateAllLegacyData = async () => {
   const isTierHidden = sanitizeIsTierHidden(
     legacySyncData[STORAGE_KEY.IS_TIER_HIDDEN],
   );
+  const fontNo = convertLegacyToLatestFontNoBySettings(
+    legacySyncData[LEGACY_SYNC_STORAGE_KEY.SETTINGS],
+  );
 
   chrome.storage.local.set({
     [STORAGE_KEY.CHECKED_ALGORITHM_IDS]: checkedAlgorithmIds,
@@ -58,6 +62,7 @@ export const updateAllLegacyData = async () => {
     [STORAGE_KEY.HIDER_OPTIONS]: hiderOptions,
     [STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: randomDefenseHistory,
     [STORAGE_KEY.IS_TIER_HIDDEN]: isTierHidden,
+    [STORAGE_KEY.FONT_NO]: fontNo,
     [STORAGE_KEY.DATA_VERSION]: 'v1.2',
   });
 };

--- a/src/domains/dataHandlers/sanitizers/fontNoSanitizer.ts
+++ b/src/domains/dataHandlers/sanitizers/fontNoSanitizer.ts
@@ -1,0 +1,7 @@
+export const sanitizeFontNo = (fontNo: unknown) => {
+  if (typeof fontNo === 'number' && !isNaN(fontNo) && fontNo % 1 === 0) {
+    return fontNo;
+  }
+
+  return 0;
+};

--- a/src/domains/dataHandlers/sanitizers/hiderOptionsSanitizer.ts
+++ b/src/domains/dataHandlers/sanitizers/hiderOptionsSanitizer.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_HIDER_OPTIONS } from '~constants/defaultValues';
 import { isHiderOptionsResponse } from '../validators/hiderOptionsValidator';
+
 export const hiderOptionsSanitizer = (hiderOptions: unknown) => {
   return isHiderOptionsResponse(hiderOptions)
     ? hiderOptions

--- a/src/domains/dataHandlers/validators/fontNoValidator.ts
+++ b/src/domains/dataHandlers/validators/fontNoValidator.ts
@@ -1,12 +1,31 @@
 import { isObject } from '~types/typeGuards';
-import { FontNoResponse } from '~types/font';
+import {
+  FontNoResponse,
+  LegacyFontNo,
+  LegacyFontNoResponse,
+} from '~types/font';
+
+const LEGACY_FONT_REGEX = /^(none|font-\d{1,2})$/;
+
+export const isFontNo = (data: unknown): data is number => {
+  return typeof data === 'number' && !isNaN(data) && data % 1 === 0;
+};
 
 export const isFontNoResponse = (data: unknown): data is FontNoResponse => {
+  return isObject(data) && 'fontNo' in data && isFontNo(data.fontNo);
+};
+
+export const isLegacyFontNo = (data: unknown): data is LegacyFontNo => {
+  return typeof data === 'string' && LEGACY_FONT_REGEX.test(data);
+};
+
+export const isLegacyFontNoResponse = (
+  data: unknown,
+): data is LegacyFontNoResponse => {
   return (
     isObject(data) &&
-    'fontNo' in data &&
-    typeof data.fontNo === 'number' &&
-    !isNaN(data.fontNo) &&
-    data.fontNo % 1 === 0
+    'font' in data &&
+    typeof data.font === 'string' &&
+    LEGACY_FONT_REGEX.test(data.font)
   );
 };

--- a/src/types/font.ts
+++ b/src/types/font.ts
@@ -1,3 +1,9 @@
 export interface FontNoResponse {
   fontNo: number;
 }
+
+export type LegacyFontNo = 'none' | `font-${number}`;
+
+export interface LegacyFontNoResponse {
+  font: LegacyFontNo;
+}


### PR DESCRIPTION
## PR 내용
본 PR에서는 사용자가 선택한 테마에 대한 데이터를 저장하고 불러오기 위한 서비스워커 로직을 구현하였습니다.
- 데이터가 올바르지 않다면 초기화 후 기본값을 반환합니다. 기본값은 `0`으로, 이는 `설정하지 않음`에 대응됩니다.
- 구버전 데이터를 업데이트하는 모듈인 `legacyDataUpdater.ts`에 구버전 폰트 데이터를 최신 버전의 폰트 데이터로 변환하는 로직을 구현했습니다.
- 이 PR부터는, 저장 및 불러오는 위치는 항상 `chrome.storage.local`입니다.

## 서비스 워커 명세
### 폰트 정보 불러오기 ⬇️
- 커맨드: `fetchFontNo`
- 요청 메시지 예시
```ts
{
  command: 'fetchfontNo'
}
```
- 응답 메시지 예시
```ts
{
  fontNo: 3
}
```

### 퀵슬롯 정보 저장하기 ⬆️
- 커맨드: `saveFontNo`
- 요청 메시지 예시
```ts
{
  command: 'saveFontNo',
  fontNo: 3
}
```