### PR TITLE
[FEAT] 공용 원형 프로그레스 바 컴포넌트 바 구현

### DIFF
--- a/src/components/common/CircleProgressBar/CircleProgressBar.stories.tsx
+++ b/src/components/common/CircleProgressBar/CircleProgressBar.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CircleProgressBar from './CircleProgressBar';
+
+/**
+ * `CircleProgressBar`는 진행 상황을 시각적으로 보여주는 컴포넌트입니다.
+ */
+const meta = {
+  title: 'CircleProgressBar',
+  component: CircleProgressBar,
+  argTypes: {
+    progress: {
+      control: {
+        type: 'range',
+        min: 0,
+        max: 100,
+      },
+    },
+  },
+} satisfies Meta<typeof CircleProgressBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    size: 45,
+    progress: 65,
+    color: '#ffe091',
+    trackColor: '#362b28',
+  },
+};

--- a/src/components/common/CircleProgressBar/CircleProgressBar.styled.ts
+++ b/src/components/common/CircleProgressBar/CircleProgressBar.styled.ts
@@ -1,0 +1,15 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div<{ $width: number; $height: number }>`
+  width: ${({ $width }) => `${$width}px`};
+  height: ${({ $height }) => `${$height}px`};
+
+  & > svg {
+    width: 100%;
+    height: 100%;
+  }
+`;
+
+export const CircleProgressBar = styled.svg`
+  transform: rotate(-90deg);
+`;

--- a/src/components/common/CircleProgressBar/CircleProgressBar.tsx
+++ b/src/components/common/CircleProgressBar/CircleProgressBar.tsx
@@ -1,0 +1,44 @@
+import * as S from './CircleProgressBar.styled';
+
+interface CircleProgressBar {
+  size: number;
+  progress: number;
+  color: string;
+  trackColor: string;
+}
+
+const CircleProgressBar = (props: CircleProgressBar) => {
+  const { size, progress, color, trackColor } = props;
+  const strokeWidth = size / 8;
+  const center = size / 2;
+  const radius = (size - strokeWidth * 2) / 2;
+  const round = 2 * Math.PI * radius;
+  const dashOffset = (round * (100 - progress)) / 100;
+
+  return (
+    <S.Container $width={size} $height={size}>
+      <S.CircleProgressBar>
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          strokeWidth={strokeWidth}
+          stroke={trackColor}
+          fill="none"
+        />
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          strokeWidth={strokeWidth}
+          stroke={color}
+          strokeDasharray={round}
+          strokeDashoffset={dashOffset}
+          fill="none"
+        />
+      </S.CircleProgressBar>
+    </S.Container>
+  );
+};
+
+export default CircleProgressBar;

--- a/src/components/common/CircleProgressBar/index.ts
+++ b/src/components/common/CircleProgressBar/index.ts
@@ -1,0 +1,3 @@
+import CircleProgressBar from './CircleProgressBar';
+
+export default CircleProgressBar;


### PR DESCRIPTION
## PR 내용
본 PR에서는 공용 원형 프로그레스 바 컴포넌트를 구현했습니다. -- `<CircleProgressBar />`
- 색상 및 트랙의 색상을 설정할 수 있습니다.
- 크기를 설정할 수 있습니다.

## 참고 자료
아래의 블로그의 발상을 참고하여 svg + 원주율 공식을 사용해 구현했습니다.
- https://wit.nts-corp.com/2021/04/23/6338

컴포넌트 및 스토리북에서의 스크린샷입니다.
![image](https://github.com/user-attachments/assets/2b7fcf5e-b8c0-4791-aa04-7ed372e52a58)

