### PR TITLE
[FEAT] 좌측 토스트 컴포넌트 구현

### DIFF
--- a/src/components/LeftSlideToast/LeftSlideToast.stories.tsx
+++ b/src/components/LeftSlideToast/LeftSlideToast.stories.tsx
@@ -1,0 +1,181 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import LeftSlideToast from './LeftSlideToast';
+import { CopyIcon } from '~images/svg';
+
+/**
+ * `LeftSlideToast`는 사용자에게 특정 내용을 알리기 위한, 좌측에서 등장하는 토스트입니다.
+ */
+const meta = {
+  title: 'LeftSlideToast',
+  component: LeftSlideToast,
+  argTypes: {
+    progress: {
+      control: {
+        type: 'range',
+        min: 0,
+        max: 100,
+      },
+    },
+  },
+} satisfies Meta<typeof LeftSlideToast>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: '160px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    mainIconSrc: chrome.runtime.getURL('dice.png'),
+    theme: 'none',
+    progress: 65,
+    title: '테스트 제목입니다.',
+    descriptions:
+      '그리고 여기에는 지금 무슨 일이 일어났는지에 대한 설명이 있을 거에요.',
+    open: true,
+    onClose: () => {
+      alert('onClose()');
+    },
+  },
+};
+
+export const SvgIcon: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: '160px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    mainIconSrc: <CopyIcon />,
+    theme: 'none',
+    progress: 65,
+    title: '테스트 제목입니다.',
+    descriptions:
+      '그리고 여기에는 지금 무슨 일이 일어났는지에 대한 설명이 있을 거에요.',
+    open: true,
+    onClose: () => {
+      alert('onClose()');
+    },
+  },
+};
+
+export const TotamjungTheme: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: '160px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    mainIconSrc: chrome.runtime.getURL('dice.png'),
+    theme: 'totamjung',
+    progress: 65,
+    title: '테스트 제목입니다.',
+    descriptions:
+      '그리고 여기에는 지금 무슨 일이 일어났는지에 대한 설명이 있을 거에요.',
+    open: true,
+    onClose: () => {
+      alert('onClose()');
+    },
+  },
+};
+
+export const TotamjungThemeWithSvgIcon: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: '160px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    mainIconSrc: <CopyIcon />,
+    theme: 'totamjung',
+    progress: 65,
+    title: '테스트 제목입니다.',
+    descriptions:
+      '그리고 여기에는 지금 무슨 일이 일어났는지에 대한 설명이 있을 거에요.',
+    open: true,
+    onClose: () => {
+      alert('onClose()');
+    },
+  },
+};
+
+export const MultipleDescriptions: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: '160px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    mainIconSrc: chrome.runtime.getURL('dice.png'),
+    theme: 'none',
+    progress: 65,
+    title: '필요할 경우 여러 개의 설명을 사용할 수도 있습니다.',
+    descriptions: [
+      '이건 첫 번째 설명이고요,',
+      '이건 두 번째 설명입니다. 설명을 여러 개 사용할 경우에는 배열을 사용해 주세요.',
+    ],
+    open: true,
+    onClose: () => {
+      alert('onClose()');
+    },
+  },
+};
+
+export const NoDescription: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: '150px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    mainIconSrc: chrome.runtime.getURL('dice.png'),
+    theme: 'none',
+    progress: 65,
+    title: '설명이 필요 없다고요? 그럼 메시지만 간결하게 전달해도 문제 없죠.',
+    open: true,
+    onClose: () => {
+      alert('onClose()');
+    },
+  },
+};
+
+/**
+ * 설명이 너무 길어 Toast의 크기를 벗어나는 경우에는, Toast가 위쪽으로 자동 조정됩니다.
+ */
+export const VeryLongDescription: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: '300px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    mainIconSrc: chrome.runtime.getURL('dice.png'),
+    theme: 'none',
+    progress: 65,
+    title: '매우 긴 설명',
+    descriptions:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum vestibulum. Cras venenatis euismod malesuada. Nulla facilisi. Curabitur facilisis, libero a pretium auctor, sapien erat tincidunt nulla, vitae vestibulum elit leo at odio. Donec vehicula mauris ut nisi hendrerit, ac dictum libero consequat. Integer euismod neque eu magna facilisis, in suscipit sem sagittis.',
+    open: true,
+    onClose: () => {
+      alert('onClose()');
+    },
+  },
+};

--- a/src/components/LeftSlideToast/LeftSlideToast.styled.ts
+++ b/src/components/LeftSlideToast/LeftSlideToast.styled.ts
@@ -1,0 +1,140 @@
+import { styled, css } from 'styled-components';
+import type { TotamjungTheme } from '~types/totamjungTheme';
+
+export const Container = styled.div<{
+  $open: boolean;
+  $totamjungTheme: TotamjungTheme;
+}>`
+  display: flex;
+  column-gap: 10px;
+  position: fixed;
+  left: 30px;
+  bottom: 30px;
+
+  width: 380px;
+  min-height: 120px;
+  padding: 10px;
+
+  border-radius: 10px;
+
+  ${({ theme, $totamjungTheme }) =>
+    $totamjungTheme === 'totamjung'
+      ? css`
+          border: 2px solid ${theme.color.LIGHTER_BROWN};
+          background-color: ${theme.color.DARK_BROWN};
+          box-shadow: 0 0 20px ${theme.color.LIGHTER_BROWN};
+        `
+      : css`
+          border: 2px solid ${theme.color.BOJ_BLUE};
+          background-color: ${theme.color.BOJ_BLUE};
+        `}
+
+  transform: ${({ $open }) => ($open ? 'translateX(0)' : 'translateX(-450px)')};
+  transition: transform cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.3s;
+`;
+
+export const LeftIconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 66px;
+`;
+
+export const IconImage = styled.img<{ $totamjungTheme: TotamjungTheme }>`
+  width: 40px;
+
+  filter: ${({ theme, $totamjungTheme }) =>
+    $totamjungTheme === 'totamjung'
+      ? theme.filter.LIGHTEST_BROWN_FILTER
+      : theme.filter.WHITE_FILTER};
+  user-select: none;
+`;
+
+export const IconWrapper = styled.div<{ $totamjungTheme: TotamjungTheme }>`
+  &,
+  & > svg {
+    width: 48px;
+    height: 48px;
+
+    color: ${({ theme, $totamjungTheme }) =>
+      $totamjungTheme === 'totamjung'
+        ? theme.color.LIGHTEST_BROWN
+        : theme.color.WHITE};
+  }
+`;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: 6px;
+
+  width: 264px;
+`;
+
+export const Title = styled.p<{ $totamjungTheme: TotamjungTheme }>`
+  font-size: 16px;
+  font-weight: 700;
+  word-break: break-all;
+  color: ${({ theme, $totamjungTheme }) =>
+    $totamjungTheme === 'totamjung' ? theme.color.BEIGE : theme.color.WHITE};
+`;
+
+export const DescriptionList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  row-gap: 4px;
+`;
+
+export const DescriptionContainer = styled.li<{
+  $totamjungTheme: TotamjungTheme;
+}>`
+  display: flex;
+  column-gap: 3px;
+
+  min-height: 17px;
+
+  line-height: 17px;
+
+  & > svg {
+    flex-shrink: 0;
+
+    width: 17px;
+    height: 17px;
+    color: ${({ theme, $totamjungTheme }) =>
+      $totamjungTheme === 'totamjung'
+        ? theme.color.LIGHTEST_BROWN
+        : theme.color.WHITE};
+  }
+`;
+
+export const Description = styled.p`
+  font-size: 14px;
+  word-break: break-all;
+  color: ${({ theme }) => theme.color.WHITE};
+`;
+
+export const RightControlPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: space-between;
+
+  width: 32px;
+`;
+
+export const CloseButton = styled.button<{ $totamjungTheme: TotamjungTheme }>`
+  width: 30px;
+  height: 30px;
+
+  background: none;
+
+  & > svg {
+    width: 30px;
+    height: 30px;
+    color: ${({ theme, $totamjungTheme }) =>
+      $totamjungTheme === 'totamjung'
+        ? theme.color.LIGHTEST_BROWN
+        : theme.color.WHITE};
+  }
+`;

--- a/src/components/LeftSlideToast/LeftSlideToast.tsx
+++ b/src/components/LeftSlideToast/LeftSlideToast.tsx
@@ -1,0 +1,78 @@
+import * as S from './LeftSlideToast.styled';
+import { CheckIcon, CloseIcon } from '~images/svg';
+import type { SVGProps } from 'react';
+import { TotamjungTheme } from '~types/totamjungTheme';
+import CircleProgressBar from '~components/common/CircleProgressBar';
+
+interface LeftSlideToastProps {
+  mainIconSrc: string | SVGProps<SVGSVGElement>;
+  theme: TotamjungTheme;
+  progress: number;
+  title: string;
+  descriptions?: string | string[];
+  open: boolean;
+  onClose: () => void;
+}
+
+const COLORS = {
+  WHITE: 'white',
+  SKY_BLUE: '#1c8cd1',
+  BROWN: '#331911',
+  LIGHT_BROWN: '#a17362',
+};
+
+const LeftSlideToast = (props: LeftSlideToastProps) => {
+  const { mainIconSrc, theme, progress, title, descriptions, open, onClose } =
+    props;
+  const listedDescriptions = Array.isArray(descriptions)
+    ? descriptions
+    : [descriptions];
+
+  return (
+    <S.Container $open={open} $totamjungTheme={theme}>
+      <S.LeftIconWrapper>
+        {mainIconSrc &&
+          (typeof mainIconSrc === 'string' ? (
+            <S.IconImage src={mainIconSrc} $totamjungTheme={theme} alt="" />
+          ) : (
+            <S.IconWrapper $totamjungTheme={theme}>{mainIconSrc}</S.IconWrapper>
+          ))}
+      </S.LeftIconWrapper>
+      <S.ContentContainer>
+        <S.Title aria-live="assertive" $totamjungTheme={theme}>
+          {title}
+        </S.Title>
+        {descriptions && (
+          <S.DescriptionList>
+            {listedDescriptions.map((description, index) => (
+              <S.DescriptionContainer key={index} $totamjungTheme={theme}>
+                <CheckIcon />
+                <S.Description key={index} $totamjungTheme={theme}>
+                  {description}
+                </S.Description>
+              </S.DescriptionContainer>
+            ))}
+          </S.DescriptionList>
+        )}
+      </S.ContentContainer>
+      <S.RightControlPanel>
+        <S.CloseButton
+          type="button"
+          aria-label="토스트 닫기"
+          $totamjungTheme={theme}
+          onClick={onClose}
+        >
+          <CloseIcon />
+        </S.CloseButton>
+        <CircleProgressBar
+          size={32}
+          progress={progress}
+          color={theme === 'totamjung' ? COLORS.LIGHT_BROWN : COLORS.WHITE}
+          trackColor={theme === 'totamjung' ? COLORS.BROWN : COLORS.SKY_BLUE}
+        />
+      </S.RightControlPanel>
+    </S.Container>
+  );
+};
+
+export default LeftSlideToast;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -123,6 +123,12 @@ export const theme = {
       'brightness(0) saturate(100%) invert(49%) sepia(26%) saturate(568%) hue-rotate(330deg) brightness(93%) contrast(86%)',
     ORANGE_FILTER:
       'brightness(0) saturate(100%) invert(49%) sepia(34%) saturate(983%) hue-rotate(339deg) brightness(115%) contrast(101%)',
+    GOLD_FILTER:
+      'brightness(0) saturate(100%) invert(77%) sepia(25%) saturate(571%) hue-rotate(1deg) brightness(89%) contrast(91%);',
+    WHITE_FILTER:
+      'brightness(0) saturate(100%) invert(100%) sepia(0%) saturate(0%) hue-rotate(342deg) brightness(102%) contrast(102%)',
+    LIGHTEST_BROWN_FILTER:
+      'brightness(0) saturate(100%) invert(52%) sepia(15%) saturate(936%) hue-rotate(330deg) brightness(89%) contrast(88%);',
   },
 };
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -25,6 +25,7 @@ export const theme = {
     ORANGE: '#ff8533',
     DARK_ORANGE: '#bb4b00',
     ORANGE_TRANSPARENT: '#ff853340',
+    BEIGE: '#c8aaa0',
   },
 
   solvedAcTier: {

--- a/src/types/algorithm.ts
+++ b/src/types/algorithm.ts
@@ -1,4 +1,5 @@
-import { RatedTier } from '~types/tierHider';
+import type { IsoString } from '~types/utils';
+import type { RatedTier } from '~types/tierHider';
 
 export interface Algorithm {
   id: number;
@@ -37,4 +38,17 @@ export interface LegacyHiderOptions {
   lock: 'click' | 'always';
   predict: 'click' | 'always';
   theme: 'yes' | 'no';
+}
+
+export interface CheckedAlgorithmIdsResponse {
+  checkedIds: number[];
+}
+
+export interface Timer {
+  problemId: number;
+  expiresAt: IsoString;
+}
+
+export interface TimersResponse {
+  timers: Timer[];
 }


### PR DESCRIPTION
## PR 설명
본 PR에서는 좌측 토스트 컴포넌트를 구현하였습니다. -- `<LeftSlideToast>`
- 이 컴포넌트는 열려 있을 시 좌측 하단에서 우측 방향으로 나타나며, 토스트가 닫힐 경우 그 반대 방향으로 사라집니다.
- 아이콘을 prop으로 받으며, 이 아이콘은 SVG 컴포넌트 형태의 아이콘 / `string` 타입의 src 형태 두 가지를 모두 사용할 수 있습니다.
- 토스트에 표시할 제목 외에도, 필요에 따라 부가적인 설명을 위한 내용을 작성할 수 있습니다. 내용이 너무 긴 경우에는 토스트의 길이가 내용에 맞춰 세로로 늘어납니다.
- 원형 프로그레스 바가 채워져 있는 비율을 prop으로 받습니다. 이는 토스트가 닫히기까지 얼마나 남았는지를 시각적으로 표시하기 위함입니다.
    - 타이머 등의 실질적인 로직은 이 컴포넌트에서 다루지 않습니다.
- 기존 버전 (`~v1.1.*`)과 달리, 이 컴포넌트의 테마는 스타일시트 파일이 아닌 prop을 통하여 받는 테마 값으로 결정됩니다. 추후 content script의 모든 컴포넌트를 제어할 수 있는 테마 상태를 별도로 둘 것입니다.

## 참고 자료

컴포넌트의 모습입니다.

![image](https://github.com/user-attachments/assets/00fa69db-e132-4bb6-a68d-51b2f2457124)

컴포넌트가 등장하고 사라지는 모습입니다.

![_2024_07_31_23_09_46_875-ezgif com-video-to-gif-converter (1)](https://github.com/user-attachments/assets/2b460c28-0da7-478d-8193-795367e00051)
