### PR TITLE
[FIX] 게시글 페이지에서 이미 맞춘 문제임에도 티어 가리개가 티어를 가리는 문제를 해결

### DIFF
--- a/src/domains/tierHider/normalToWarnTierChanger.ts
+++ b/src/domains/tierHider/normalToWarnTierChanger.ts
@@ -34,11 +34,17 @@ const TIER_TEXT_CSS_SELECTOR =
 const BOJ_EXTENDED_PROBLEM_LINK_BOX_CSS_SELECTOR =
   ".problem-link-style-box:not(.result-ac):not([data-tier='0'])";
 
-export const changeNormalToWarnTier = (warnTier: RatedTier) => {
+export const changeNormalToWarnTier = (
+  warnTier: RatedTier,
+  shouldWarnHighTier: boolean,
+) => {
   changeBoardBlockquoteBadgeTier(warnTier);
-  changeRegularBadgeTier(warnTier);
-  changeTierText(warnTier);
-  changeBojExtendedProblemLinkBox(warnTier);
+
+  if (shouldWarnHighTier) {
+    changeRegularBadgeTier(warnTier);
+    changeTierText(warnTier);
+    changeBojExtendedProblemLinkBox(warnTier);
+  }
 };
 
 const changeBoardBlockquoteBadgeTier = async (warnTier: RatedTier) => {

--- a/src/hooks/widget/useWidget.ts
+++ b/src/hooks/widget/useWidget.ts
@@ -60,8 +60,8 @@ const useWidget = (params: UseWidgetParams) => {
         warnTier,
       } = hiderOptionsResponse;
 
-      if (shouldHideTier && shouldWarnHighTier) {
-        changeNormalToWarnTier(warnTier);
+      if (shouldHideTier) {
+        changeNormalToWarnTier(warnTier, shouldWarnHighTier);
       }
 
       if (algorithmHiderUsage === 'always') {


### PR DESCRIPTION
## 관련 PR
- #75 

## PR 설명
본 PR에서는, 티어 가리개가 이미 맞춘 문제의 티어를 가리는 문제를 해결했습니다.  정확한 내용은 아래와 같습니다.
- 티어 가리개가 켜져 있고, 난이도 경고가 꺼져 있을 경우, 게시판의 게시글 페이지에서 `<blockquote>` 내부에 있는 티어가 이미 맞춘 문제임에도 **숨겨진 티어**로 보이게 됩니다.
- 난이도 경고가 꺼져 있을 경우, 난이도 경고를 씌우는 함수를 아예 실행하지 않았는데, 이 로직 중에는 이미 문제를 맞춘 경우 티어를 공개된 상태의 티어로 되돌리는 기능이 있었기에 발생한 문제였으며, 난이도 경고를 씌우는 함수에 옵션을 추가하여 해결했습니다.

## 참고 자료
![image](https://github.com/user-attachments/assets/ad971495-1cd3-4962-acf9-d61cb5e82a83)
