### PR TITLE
[FEAT] 무작위 문제 추첨 기능을 구현

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -34,6 +34,7 @@ import {
   removeSingleTimerByProblemId,
 } from '~domains/dataHandlers/timersDataHandler';
 import { isUserSolvedProblem } from '~domains/tierHider/userSolvedChecker';
+import { getRandomDefenseResult } from '~domains/randomDefense/randomDefenseProblemChooser';
 
 chrome.runtime.onInstalled.addListener(({ reason }) => {
   if (reason === 'install') {
@@ -223,6 +224,16 @@ chrome.runtime.onMessage.addListener(
       const { handle, problemId } = message;
 
       isUserSolvedProblem(handle, problemId).then((result) => {
+        sendResponse(result);
+      });
+    }
+
+    if (command === COMMANDS.GET_RANDOM_DEFENSE_RESULT) {
+      if (!('query' in message) || typeof message.query !== 'string') {
+        return;
+      }
+
+      getRandomDefenseResult(message.query).then((result) => {
         sendResponse(result);
       });
     }

--- a/src/background.ts
+++ b/src/background.ts
@@ -9,6 +9,7 @@ import {
   saveQuickSlots,
 } from '~domains/dataHandlers/quickSlotsDataHandler';
 import {
+  appendRandomDefenseInfoToHistory,
   fetchRandomDefenseHistory,
   saveRandomDefenseHistory,
 } from '~domains/dataHandlers/randomDefenseHistoryDataHandler';
@@ -236,6 +237,14 @@ chrome.runtime.onMessage.addListener(
       getRandomDefenseResult(message.query).then((result) => {
         sendResponse(result);
       });
+    }
+
+    if (command === COMMANDS.APPEND_RANDOM_DEFENSE_HISTORY_INFO) {
+      if (!('randomDefenseHistoryInfo' in message)) {
+        return;
+      }
+
+      appendRandomDefenseInfoToHistory(message.randomDefenseHistoryInfo);
     }
 
     return true;

--- a/src/components/Widget/Widget.tsx
+++ b/src/components/Widget/Widget.tsx
@@ -18,6 +18,7 @@ const Widget = (props: WidgetProps) => {
     isExpanded,
     isScrollingToTop,
     hasUnknownAlgorithms,
+    isRandomDefenseButtonDisabled,
     isInspectButtonDisabled,
     isLockButtonDisabled,
     shouldShowInspectIcon,
@@ -27,6 +28,7 @@ const Widget = (props: WidgetProps) => {
     toggleWidgetOpen,
     openOptionsPage,
     toggleTotamjungTheme,
+    performRandomDefenseByClick,
     showInspectResultUsingPopup,
     toggleTimer,
   } = useWidget(props);
@@ -77,7 +79,13 @@ const Widget = (props: WidgetProps) => {
               </S.DropdownMenuButton>
             </S.DropdownMenuItem>
             <S.DropdownMenuItem>
-              <S.DropdownMenuButton type="button" $widgetTheme={theme}>
+              <S.DropdownMenuButton
+                type="button"
+                $widgetTheme={theme}
+                aria-label="무작위 문제 추첨하기"
+                disabled={isRandomDefenseButtonDisabled}
+                onClick={performRandomDefenseByClick}
+              >
                 <S.DropdownButtonIcon src={chrome.runtime.getURL('dice.png')} />
               </S.DropdownMenuButton>
             </S.DropdownMenuItem>

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -18,6 +18,7 @@ export const COMMANDS = {
   ADD_SINGLE_TIMER: 'addSingleTimer',
   REMOVE_SINGLE_TIMER: 'removeSingleTimer',
   IS_USER_SOLVED_PROBLEM: 'isUserSolvedProblem',
+  GET_RANDOM_DEFENSE_RESULT: 'getRandomDefenseResult',
 } as const;
 
 /**

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -19,6 +19,7 @@ export const COMMANDS = {
   REMOVE_SINGLE_TIMER: 'removeSingleTimer',
   IS_USER_SOLVED_PROBLEM: 'isUserSolvedProblem',
   GET_RANDOM_DEFENSE_RESULT: 'getRandomDefenseResult',
+  APPEND_RANDOM_DEFENSE_HISTORY_INFO: 'appendRandomDefenseHistoryInfo',
 } as const;
 
 /**

--- a/src/domains/dataHandlers/randomDefenseHistoryDataHandler.ts
+++ b/src/domains/dataHandlers/randomDefenseHistoryDataHandler.ts
@@ -1,7 +1,7 @@
 import { STORAGE_KEY } from '~constants/commands';
 import { sanitizeRandomDefenseHistory } from './sanitizers/randomDefenseHistorySanitizer';
 import { sanitizeIsTierHidden } from './sanitizers/isTierHiddenSanitizer';
-import { RandomDefenseHistoryInfo } from '~types/randomDefense';
+import type { RandomDefenseHistoryInfo } from '~types/randomDefense';
 
 const getSortedRandomDefenseHistory = (
   randomDefenseHistory: RandomDefenseHistoryInfo[],
@@ -49,4 +49,15 @@ export const saveRandomDefenseHistory = (
     [STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: sortedRandomDefenseHistory,
     [STORAGE_KEY.IS_TIER_HIDDEN]: isHidden,
   });
+};
+
+export const appendRandomDefenseInfoToHistory = async (
+  randomDefenseHistoryInfo: unknown,
+) => {
+  const { randomDefenseHistory, isHidden } = await fetchRandomDefenseHistory();
+
+  saveRandomDefenseHistory(
+    [...randomDefenseHistory, randomDefenseHistoryInfo],
+    isHidden,
+  );
 };

--- a/src/domains/dataHandlers/validators/RandomDefenseResultResponseValidator.ts
+++ b/src/domains/dataHandlers/validators/RandomDefenseResultResponseValidator.ts
@@ -1,0 +1,42 @@
+import { isObject } from '~types/typeGuards';
+import { isSolvedAcSearchProblemInfo } from './solvedAcSearchProblemResponseValidator';
+import type { RandomDefenseResultResponse } from '~types/randomDefense';
+
+export const isRandomDefenseResultResponse = (
+  data: unknown,
+): data is RandomDefenseResultResponse => {
+  if (
+    !(isObject(data) && 'success' in data && typeof data.success === 'boolean')
+  ) {
+    return false;
+  }
+
+  const { success } = data;
+
+  if (success) {
+    return (
+      'problemInfo' in data && isSolvedAcSearchProblemInfo(data.problemInfo)
+    );
+  }
+
+  if ('statusCode' in data && typeof data.statusCode !== 'number') {
+    return false;
+  }
+
+  if (!('errorMessage' in data) || typeof data.errorMessage !== 'string') {
+    return false;
+  }
+
+  if (!('errorDescriptions' in data)) {
+    return true;
+  }
+  const { errorDescriptions } = data;
+
+  return (
+    typeof errorDescriptions === 'string' ||
+    (Array.isArray(errorDescriptions) &&
+      errorDescriptions.every(
+        (errorDescription) => typeof errorDescription === 'string',
+      ))
+  );
+};

--- a/src/domains/randomDefense/randomDefenseProblemChooser.ts
+++ b/src/domains/randomDefense/randomDefenseProblemChooser.ts
@@ -6,7 +6,9 @@ export const getRandomDefenseResult = async (
 ): Promise<RandomDefenseResultResponse> => {
   try {
     const response = await fetch(
-      `https://solved.ac/api/v3/search/problem?query=${query}&sort=random`,
+      `https://solved.ac/api/v3/search/problem?query=${encodeURIComponent(
+        query,
+      )}&sort=random`,
     );
 
     if (!response.ok) {

--- a/src/domains/randomDefense/randomDefenseProblemChooser.ts
+++ b/src/domains/randomDefense/randomDefenseProblemChooser.ts
@@ -1,0 +1,99 @@
+import { isSolvedAcSearchProblemResponse } from '~domains/dataHandlers/validators/solvedAcSearchProblemResponseValidator';
+import { RandomDefenseResultResponse } from '~types/randomDefense';
+
+export const getRandomDefenseResult = async (
+  query: string,
+): Promise<RandomDefenseResultResponse> => {
+  try {
+    const response = await fetch(
+      `https://solved.ac/api/v3/search/problem?query=${query}&sort=random`,
+    );
+
+    if (!response.ok) {
+      if (response.status === 400) {
+        return {
+          success: false,
+          errorMessage: '문제 추첨 중 에러가 발생했습니다.',
+          errorDescriptions: [
+            '추첨 생성 시 작성하신 쿼리가 잘못된 것 같습니다.',
+            '추첨 생성 시 사용하셨던 쿼리가 과도하게 길 경우 이 문제가 발생할 수 있습니다.',
+          ],
+        };
+      }
+
+      if (response.status === 429) {
+        return {
+          success: false,
+          errorMessage: '문제 추첨 중 에러가 발생했습니다.',
+          errorDescriptions: [
+            '짧은 시간에 너무 많은 횟수를 추첨하였습니다. 이 문제는 보통 수 분 후에 다시 시도할 경우 해결됩니다.',
+            '이 문제는 솔브드 API에 짧은 시간 안에 너무 많은 횟수를 요청할 때 발생합니다.',
+            '만약, 토탐정의 추첨 기능을 과도하게 많이 사용한 것이 아님에도 문제가 발생한다면, 토탐정의 다른 기능에서의 요청, 혹은 다른 확장 프로그램에서의 요청이 원인일 수도 있습니다.',
+          ],
+        };
+      }
+
+      if (response.status >= 500) {
+        return {
+          success: false,
+          errorMessage: '문제 추첨 중 에러가 발생했습니다.',
+          errorDescriptions: [
+            '먼저, 새로고침 후 문제 추첨을 다시 시도해 보세요.',
+            '수차례 시도에도 불구하고 이 문제가 계속 발생한다면, 솔브드 API 서버가 불안정한 것이 원인일 수 있습니다. 이 경우 잠시 후 시도해 보시기 바랍니다.',
+          ],
+        };
+      }
+
+      return {
+        success: false,
+        errorMessage: '문제 추첨 중 에러가 발생했습니다.',
+        errorDescriptions: [
+          '죄송합니다만, 이 에러는 아직 토탐정이 모르는 에러입니다.',
+          '새로고침 후 다시 시도, 쿼리가 올바르게 작성되었는 지 확인, 솔브드 API 서버가 안정적인지 확인하는 등의 방법을 시도해 보시기 바랍니다.',
+          `Status Code는 ${response.status}입니다. 오류 제보 시 개발자에게 이 정보를 제공해 주세요.`,
+        ],
+      };
+    }
+
+    const parsedResponse = await response.json();
+
+    if (!isSolvedAcSearchProblemResponse(parsedResponse)) {
+      return {
+        success: false,
+        errorMessage: '문제 추첨 중 에러가 발생했습니다.',
+        errorDescriptions: [
+          'API에서 불러온 데이터와 토탐정에서 예상한 데이터의 형식이 불일치합니다.',
+          '토탐정의 구현이 잘못되었을 확률이 높으며, 솔브드에서 API 형식을 바꾼 경우에도 이 문제가 발생할 수 있습니다.',
+          '이 문제는 일시적일 문제일 확률이 낮습니다. 개발자에게 이 에러가 발생했음을 제보해주시기를 부탁드리겠습니다.',
+        ],
+      };
+    }
+
+    const { count, items } = parsedResponse;
+
+    if (count === 0) {
+      return {
+        success: false,
+        errorMessage: '',
+        errorDescriptions: [
+          ' ',
+          '토탐정의 구현이 잘못되었을 확률이 높으며, 솔브드에서 API 형식을 바꾼 경우에도 이 문제가 발생할 수 있습니다.',
+          '이 문제는 일시적일 문제일 확률이 낮습니다. 개발자에게 이 에러가 발생했음을 제보해주시기를 부탁드리겠습니다.',
+        ],
+      };
+    }
+
+    return {
+      success: true,
+      problemInfo: items[0],
+    };
+  } catch (error) {
+    return {
+      success: false,
+      errorMessage: '문제 추첨 중 에러가 발생했습니다.',
+      errorDescriptions: [
+        '네트워크 연결이 불안정한 것 같습니다. 네트워크 연결이 원활한지 확인해 주세요.',
+      ],
+    };
+  }
+};

--- a/src/domains/randomDefense/randomDefenseProblemChooser.ts
+++ b/src/domains/randomDefense/randomDefenseProblemChooser.ts
@@ -76,11 +76,10 @@ export const getRandomDefenseResult = async (
     if (count === 0) {
       return {
         success: false,
-        errorMessage: '',
+        errorMessage: '해당 추첨의 쿼리를 만족하는 문제가 없습니다.',
         errorDescriptions: [
-          ' ',
-          '토탐정의 구현이 잘못되었을 확률이 높으며, 솔브드에서 API 형식을 바꾼 경우에도 이 문제가 발생할 수 있습니다.',
-          '이 문제는 일시적일 문제일 확률이 낮습니다. 개발자에게 이 에러가 발생했음을 제보해주시기를 부탁드리겠습니다.',
+          '쿼리에 오타가 있는 지 확인해 보세요.',
+          '다른 주제의 쿼리나, 좀 더 넓은 검색범위의 쿼리를 사용해 보세요.',
         ],
       };
     }

--- a/src/hooks/widget/useRandomDefense.ts
+++ b/src/hooks/widget/useRandomDefense.ts
@@ -194,7 +194,17 @@ const useRandomDefense = (params: UseRandomDefenseParams) => {
     }
 
     const { problemInfo } = randomDefenseResultResponse;
-    const { problemId } = problemInfo;
+    const { problemId, titleKo, level } = problemInfo;
+
+    chrome.runtime.sendMessage({
+      command: COMMANDS.APPEND_RANDOM_DEFENSE_HISTORY_INFO,
+      randomDefenseHistoryInfo: {
+        problemId,
+        title: titleKo,
+        tier: level,
+        createdAt: new Date().toISOString(),
+      },
+    });
 
     location.href = `https://acmicpc.net/problem/${problemId}`;
   };

--- a/src/hooks/widget/useRandomDefense.ts
+++ b/src/hooks/widget/useRandomDefense.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect, useRef } from 'react';
+import { DEFAULT_QUICK_SLOTS_RESPONSE } from '~constants/defaultValues';
+import type { QuickSlotsResponse } from '~types/randomDefense';
+
+const useRandomDefense = () => {
+  const [quickSlotsResponse, setQuickSlotsResponse] =
+    useState<QuickSlotsResponse>(DEFAULT_QUICK_SLOTS_RESPONSE);
+  const pressedKeysRef = useRef<Set<string>>(new Set());
+  const pressedKeyCodesRef = useRef<Set<number>>(new Set());
+
+  /**
+   * keyCode는 deprecated이지만, 일부 사용자에게서 keyCode를 사용하지 않을 경우
+   * 단축키가 인식이 안 되는 문제가 있는 현상이 제보되어, 호환을 위해 유지합니다.
+   */
+  const addPressedKeyInfo = (event: globalThis.KeyboardEvent) => {
+    const key = event.key;
+    const keyCode = event.keyCode;
+
+    pressedKeysRef.current.add(key);
+    pressedKeyCodesRef.current.add(keyCode);
+  };
+
+  const deletePressedKeyInfo = (event: globalThis.KeyboardEvent) => {
+    const key = event.key;
+    const keyCode = event.keyCode;
+
+    pressedKeysRef.current.delete(key);
+    pressedKeyCodesRef.current.delete(keyCode);
+  };
+
+  useEffect(() => {
+    document.addEventListener('keydown', addPressedKeyInfo);
+    document.addEventListener('keyup', deletePressedKeyInfo);
+
+    return () => {
+      document.removeEventListener('keydown', addPressedKeyInfo);
+      document.removeEventListener('keyup', deletePressedKeyInfo);
+    };
+  }, []);
+
+  return {
+    isRandomDefenseAvailable,
+    performRandomDefense,
+  };
+};
+
+export default useRandomDefense;

--- a/src/hooks/widget/useRandomDefense.ts
+++ b/src/hooks/widget/useRandomDefense.ts
@@ -1,46 +1,211 @@
 import { useState, useEffect, useRef } from 'react';
+import { COMMANDS } from '~constants/commands';
 import { DEFAULT_QUICK_SLOTS_RESPONSE } from '~constants/defaultValues';
-import type { QuickSlotsResponse } from '~types/randomDefense';
+import {
+  isQuickSlotsResponse,
+  isSlotNo,
+} from '~domains/dataHandlers/validators/quickSlotsValidator';
+import type { ToastInfo } from '~types/toast';
+import type { QuickSlotsResponse, SlotNo } from '~types/randomDefense';
+import { isRandomDefenseResultResponse } from '~domains/dataHandlers/validators/RandomDefenseResultResponseValidator';
 
-const useRandomDefense = () => {
-  const [quickSlotsResponse, setQuickSlotsResponse] =
-    useState<QuickSlotsResponse>(DEFAULT_QUICK_SLOTS_RESPONSE);
+interface UseRandomDefenseParams {
+  onToast: (toastInfo: ToastInfo, duration: number) => void;
+}
+
+const useRandomDefense = (params: UseRandomDefenseParams) => {
+  const { onToast } = params;
+  const [isRandomDefenseAvailable, setIsRandomDefenseAvailable] =
+    useState(false);
+
+  const isRandomDefenseAvailableRef = useRef(isRandomDefenseAvailable);
   const pressedKeysRef = useRef<Set<string>>(new Set());
-  const pressedKeyCodesRef = useRef<Set<number>>(new Set());
-
-  /**
-   * keyCode는 deprecated이지만, 일부 사용자에게서 keyCode를 사용하지 않을 경우
-   * 단축키가 인식이 안 되는 문제가 있는 현상이 제보되어, 호환을 위해 유지합니다.
-   */
-  const addPressedKeyInfo = (event: globalThis.KeyboardEvent) => {
-    const key = event.key;
-    const keyCode = event.keyCode;
-
-    pressedKeysRef.current.add(key);
-    pressedKeyCodesRef.current.add(keyCode);
-  };
-
-  const deletePressedKeyInfo = (event: globalThis.KeyboardEvent) => {
-    const key = event.key;
-    const keyCode = event.keyCode;
-
-    pressedKeysRef.current.delete(key);
-    pressedKeyCodesRef.current.delete(keyCode);
-  };
+  const pressedCodesRef = useRef<Set<string>>(new Set());
+  const quickSlotsResponseRef = useRef<QuickSlotsResponse>(
+    DEFAULT_QUICK_SLOTS_RESPONSE,
+  );
 
   useEffect(() => {
+    const fetchQuickSlots = async () => {
+      const response = await chrome.runtime.sendMessage({
+        command: COMMANDS.FETCH_QUICK_SLOTS,
+      });
+
+      if (!isQuickSlotsResponse(response)) {
+        return;
+      }
+
+      quickSlotsResponseRef.current = response;
+      isRandomDefenseAvailableRef.current = true;
+      setIsRandomDefenseAvailable(true);
+    };
+
+    fetchQuickSlots();
     document.addEventListener('keydown', addPressedKeyInfo);
     document.addEventListener('keyup', deletePressedKeyInfo);
+    chrome.storage.onChanged.addListener(updateQuickSlotsIfLocalChanged);
 
     return () => {
       document.removeEventListener('keydown', addPressedKeyInfo);
       document.removeEventListener('keyup', deletePressedKeyInfo);
+      chrome.storage.onChanged.removeListener(updateQuickSlotsIfLocalChanged);
     };
   }, []);
 
+  const updateQuickSlotsIfLocalChanged = (
+    changes: { [key: string]: chrome.storage.StorageChange },
+    areaName: chrome.storage.AreaName,
+  ) => {
+    if (areaName !== 'local' || !('quickSlots' in changes)) {
+      return;
+    }
+
+    const { newValue } = changes.quickSlots;
+
+    if (!isQuickSlotsResponse(newValue)) {
+      return;
+    }
+
+    quickSlotsResponseRef.current = newValue;
+  };
+
+  const addPressedKeyInfo = (event: globalThis.KeyboardEvent) => {
+    const key = event.key;
+    const code = event.code;
+
+    pressedKeysRef.current.add(key);
+    pressedCodesRef.current.add(code);
+
+    const altPressed = event.altKey;
+    const f2Pressed = pressedCodesRef.current.has('F2');
+    const isNumberKeyPressedNow =
+      !isNaN(Number(event.key)) || event.code.startsWith('Digit');
+
+    if (!isNumberKeyPressedNow) {
+      return;
+    }
+
+    const { hotkey } = quickSlotsResponseRef.current;
+    const currentNumberKey = !isNaN(Number(event.key))
+      ? Number(event.key)
+      : Number(event.code.at(-1));
+
+    if (!isSlotNo(currentNumberKey)) {
+      return;
+    }
+
+    if (hotkey === 'Alt' && altPressed) {
+      console.log('perform random defense', currentNumberKey);
+      performRandomDefense(currentNumberKey, 'keydown');
+      return;
+    }
+
+    if (hotkey === 'F2' && f2Pressed) {
+      performRandomDefense(currentNumberKey, 'keydown');
+    }
+  };
+
+  const deletePressedKeyInfo = (event: globalThis.KeyboardEvent) => {
+    const key = event.key;
+    const code = event.code;
+
+    pressedKeysRef.current.delete(key);
+    pressedCodesRef.current.delete(code);
+
+    console.log(pressedKeysRef.current, pressedCodesRef.current);
+  };
+
+  const performRandomDefense = async (
+    selectedSlotNo: SlotNo,
+    method: 'keydown' | 'click',
+  ) => {
+    console.log('enter', isRandomDefenseAvailableRef.current);
+    if (!isRandomDefenseAvailableRef.current) {
+      return;
+    }
+
+    isRandomDefenseAvailableRef.current = false;
+    setIsRandomDefenseAvailable(false);
+
+    console.log('start', quickSlotsResponseRef.current);
+
+    const { slots } = quickSlotsResponseRef.current;
+
+    console.log('slots', slots);
+    const selectedSlot = slots[selectedSlotNo];
+
+    console.log('selectedSlot', selectedSlot);
+
+    if (selectedSlot.isEmpty) {
+      if (method === 'click') {
+        onToast(
+          {
+            title: `${selectedSlotNo}번 슬롯은 현재 비어 있습니다.`,
+            mainIconSrc: chrome.runtime.getURL('dice.png'),
+            descriptions: [
+              '추첨을 만들지 않으셨다면, 설정에서 해당 슬롯에 추첨을 먼저 만들어 주세요!',
+              '설정의 퀵슬롯 메뉴에서 선택된 슬롯 번호를 변경하는 것으로 위젯 클릭 시 사용할 추첨의 슬롯을 정하실 수 있습니다.',
+            ],
+          },
+          8000,
+        );
+      }
+      isRandomDefenseAvailableRef.current = true;
+      setIsRandomDefenseAvailable(true);
+
+      return;
+    }
+
+    const randomDefenseResultResponse = await chrome.runtime.sendMessage({
+      command: COMMANDS.GET_RANDOM_DEFENSE_RESULT,
+      query: selectedSlot.query,
+    });
+
+    if (!isRandomDefenseResultResponse(randomDefenseResultResponse)) {
+      onToast(
+        {
+          title: '데이터 불일치가 발견되었습니다.',
+          mainIconSrc: chrome.runtime.getURL('dice.png'),
+          descriptions: '개발자에게 이 문제가 발생했음을 알려 주세요.',
+        },
+        8000,
+      );
+      console.log(randomDefenseResultResponse);
+      isRandomDefenseAvailableRef.current = true;
+      setIsRandomDefenseAvailable(true);
+      return;
+    }
+
+    if (!randomDefenseResultResponse.success) {
+      const { errorMessage, errorDescriptions } = randomDefenseResultResponse;
+
+      onToast(
+        {
+          title: errorMessage,
+          mainIconSrc: chrome.runtime.getURL('dice.png'),
+          descriptions: errorDescriptions,
+        },
+        8000,
+      );
+      isRandomDefenseAvailableRef.current = true;
+      setIsRandomDefenseAvailable(true);
+
+      return;
+    }
+
+    const { problemInfo } = randomDefenseResultResponse;
+    const { problemId } = problemInfo;
+
+    location.href = `https://acmicpc.net/problem/${problemId}`;
+  };
+
+  const performRandomDefenseByClick = () => {
+    performRandomDefense(quickSlotsResponseRef.current.selectedSlotNo, 'click');
+  };
+
   return {
     isRandomDefenseAvailable,
-    performRandomDefense,
+    performRandomDefenseByClick,
   };
 };
 

--- a/src/hooks/widget/useRandomDefense.ts
+++ b/src/hooks/widget/useRandomDefense.ts
@@ -95,7 +95,6 @@ const useRandomDefense = (params: UseRandomDefenseParams) => {
     }
 
     if (hotkey === 'Alt' && altPressed) {
-      console.log('perform random defense', currentNumberKey);
       performRandomDefense(currentNumberKey, 'keydown');
       return;
     }
@@ -111,15 +110,12 @@ const useRandomDefense = (params: UseRandomDefenseParams) => {
 
     pressedKeysRef.current.delete(key);
     pressedCodesRef.current.delete(code);
-
-    console.log(pressedKeysRef.current, pressedCodesRef.current);
   };
 
   const performRandomDefense = async (
     selectedSlotNo: SlotNo,
     method: 'keydown' | 'click',
   ) => {
-    console.log('enter', isRandomDefenseAvailableRef.current);
     if (!isRandomDefenseAvailableRef.current) {
       return;
     }
@@ -127,14 +123,8 @@ const useRandomDefense = (params: UseRandomDefenseParams) => {
     isRandomDefenseAvailableRef.current = false;
     setIsRandomDefenseAvailable(false);
 
-    console.log('start', quickSlotsResponseRef.current);
-
     const { slots } = quickSlotsResponseRef.current;
-
-    console.log('slots', slots);
     const selectedSlot = slots[selectedSlotNo];
-
-    console.log('selectedSlot', selectedSlot);
 
     if (selectedSlot.isEmpty) {
       if (method === 'click') {
@@ -170,7 +160,6 @@ const useRandomDefense = (params: UseRandomDefenseParams) => {
         },
         8000,
       );
-      console.log(randomDefenseResultResponse);
       isRandomDefenseAvailableRef.current = true;
       setIsRandomDefenseAvailable(true);
       return;

--- a/src/hooks/widget/useWidget.ts
+++ b/src/hooks/widget/useWidget.ts
@@ -4,6 +4,7 @@ import { COMMANDS } from '~constants/commands';
 import { isValidCheckedAlgorithmIdsResponse } from '~domains/dataHandlers/validators/checkedAlgorithmIdsValidator';
 import { isHiderOptionsResponse } from '~domains/dataHandlers/validators/hiderOptionsValidator';
 import useInjectedProblemTags from './useInjectedProblemTags';
+import useRandomDefense from './useRandomDefense';
 import { changeNormalToWarnTier } from '~domains/tierHider/normalToWarnTierChanger';
 import type { ToastInfo } from '~types/toast';
 import type { TotamjungTheme } from '~types/totamjungTheme';
@@ -27,7 +28,12 @@ const useWidget = (params: UseWidgetParams) => {
   const [isLoaded, setIsLoaded] = useState(false);
   const { hasUnknownAlgorithms, isSpoilerExist, isSpoilerOpened, toggleTimer } =
     useInjectedProblemTags({ checkedIds, hiderOptions });
+  const { isRandomDefenseAvailable, performRandomDefenseByClick } =
+    useRandomDefense({
+      onToast,
+    });
 
+  const isRandomDefenseButtonDisabled = !isRandomDefenseAvailable;
   const isInspectButtonDisabled =
     !isSpoilerExist || isSpoilerOpened || inspectIconState;
   const isLockButtonDisabled = !isSpoilerExist || isSpoilerOpened;
@@ -143,6 +149,7 @@ const useWidget = (params: UseWidgetParams) => {
     isExpanded,
     isScrollingToTop,
     hasUnknownAlgorithms,
+    isRandomDefenseButtonDisabled,
     isInspectButtonDisabled,
     isLockButtonDisabled,
     shouldShowInspectIcon,
@@ -152,6 +159,7 @@ const useWidget = (params: UseWidgetParams) => {
     toggleWidgetOpen,
     openOptionsPage,
     toggleTotamjungTheme,
+    performRandomDefenseByClick,
     showInspectResultUsingPopup,
     toggleTimer,
   };

--- a/src/types/randomDefense.ts
+++ b/src/types/randomDefense.ts
@@ -150,7 +150,7 @@ interface RandomDefenseFailureResult {
   success: false;
   statusCode?: number;
   errorMessage: string;
-  errorDescriptions: string | string[];
+  errorDescriptions?: string | string[];
 }
 
 interface RandomDefenseSuccessResult {

--- a/src/types/randomDefense.ts
+++ b/src/types/randomDefense.ts
@@ -1,4 +1,5 @@
 import type { solvedAcNumericTierIcons } from '~images/svg/tier';
+import type { SolvedAcSearchProblemInfo } from '~types/solvedAcApi';
 import type { IsoString } from '~types/utils';
 
 export interface RandomDefenseHistoryInfo {
@@ -139,4 +140,20 @@ export interface RepairableQuickSlotsResponse {
   slots: Omit<RepairableLegacyQuickSlotsResponse, 'selectedNo'>;
   hotkey?: unknown;
   selectedSlotNo?: unknown;
+}
+
+export type RandomDefenseResultResponse =
+  | RandomDefenseFailureResult
+  | RandomDefenseSuccessResult;
+
+interface RandomDefenseFailureResult {
+  success: false;
+  statusCode?: number;
+  errorMessage: string;
+  errorDescriptions: string | string[];
+}
+
+interface RandomDefenseSuccessResult {
+  success: true;
+  problemInfo: SolvedAcSearchProblemInfo;
 }


### PR DESCRIPTION
## PR 설명
본 PR에서는 무작위 문제 추첨 기능(랜덤 디펜스)을 구현하였습니다.
- `<Widget>`에서 **무작위 추첨** 버튼을 누르면, 설정에서 선택된 슬롯에 대응되는 쿼리로 추첨을 진행합니다.
- 설정에 따라 `Alt(Option) + 숫자 키` 또는 `F2 + 숫자 키` 를 통해 대응되는 **숫자 키**의 슬롯 번호에 저장된 쿼리로 추첨을 진행합니다.
- 어느 방향으로든 추첨에 성공할 경우, 추첨된 문제에 해당하는 페이지로 이동하며, 추첨 기록에 저장됩니다.
- `fetch`가 실패하는 경우, 문제의 검색 결과가 없는 경우, 슬롯이 빈 경우, `400`, `429`, `5xx`, 그리고 그 외의 에러에 대해 예외처리하며 해결법을 담은 에러 메시지를 출력합니다.

## 서비스 워커 명세
기능을 구현하기 위해 총 두 개의 명세를 추가하였습니다.

### 1️⃣ 무작위 추첨 결과를 불러오기
- 커맨드: `getRandomDefenseResult`
- 요청 메시지 예시
```js
{
  command: 'getRandomDefenseResult'
}
```
- 응답 메시지 예시 (성공). 토탐정에서 사용하지 않는 키 값들은 생략합니다.
```js
{
  success: true,
  problemInfo: {
    problemId: 1000,
    titleKo: 'A+B',
    level: 1,
    ...
  }
}
```
- 응답 메시지 예시 (실패)
```js
{
  success: false,
  errorMessage: '해당 추첨의 쿼리를 만족하는 문제가 없습니다.',
  errorDescriptions: [
    '쿼리에 오타가 있는 지 확인해 보세요.',
    '다른 주제의 쿼리나, 좀 더 넓은 검색범위의 쿼리를 사용해 보세요.',
  ],
}
```
### :two: 문제 정보를 추첨 기록에 추가하기
- 커맨드: `appendRandomDefenseHistoryInfo`
- 요청 메시지 예시
```js
{
  command: 'appendRandomDefenseHistoryInfo',
  randomDefenseHistoryInfo: {
    problemId: 1000,
    title: 'A+B',
    tier: 1,
    createdAt: '2024-08-12T15:33:35.751Z'
  },
}
```
- 응답 메시지 예시

별도의 응답은 없음.

## 참고 자료
### 1️⃣ 무작위 추첨 기능을 사용하는 예시입니다.
직접 위젯을 클릭하여 추첨, 키보드 단축키를 이용하여 추첨, 그리고 추첨 결과가 없는 경우 예외 처리를 하는 모습을 확인할 수 있습니다.

https://github.com/user-attachments/assets/1cb6f0c2-b34d-4b6f-9e7d-677a99b8596a


### 2️⃣   Status Code가 `429`인 경우 토스트로 예외 처리를 하는 예시입니다.
![image](https://github.com/user-attachments/assets/110d06d2-13eb-4369-826c-3d63514ff3f1)
