### PR TITLE
[FIX] Spoqa Han Sans Neo 웹폰트로 인해 토탐정의 로딩 시간이 과도하게 길어지는 문제를 해결

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -13,11 +13,31 @@
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/gh/neodgm/neodgm-webfont@latest/neodgm/style.css"
 />
-<link
-  href="https://spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css"
-  rel="stylesheet"
-  type="text/css"
-/>
+<style>
+  @font-face {
+    font-family: 'Spoqa Han Sans Neo';
+    src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Regular.woff')
+      format('woff');
+    font-weight: 400;
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: 'Spoqa Han Sans Neo';
+    src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Medium.woff')
+      format('woff');
+    font-weight: 500;
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: 'Spoqa Han Sans Neo';
+    src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Bold.woff')
+      format('woff');
+    font-weight: 700;
+    font-style: normal;
+  }
+</style>
 <script>
   var chrome = {
     runtime: {

--- a/src/injectionScript.ts
+++ b/src/injectionScript.ts
@@ -90,14 +90,32 @@ const injectFontsAndThemes = () => {
         href: 'https://cdn.jsdelivr.net/gh/neodgm/neodgm-webfont@latest/neodgm/style.css',
       },
     );
-    const spoqaHanSansNeoLinkElement = Object.assign(
-      document.createElement('link'),
-      {
-        rel: 'stylesheet',
-        href: 'https://spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css',
-        type: 'text/css',
-      },
-    );
+    const spoqaHanSansNeoStyleElement = document.createElement('style');
+    spoqaHanSansNeoStyleElement.innerHTML = `
+      @font-face {
+        font-family: 'Spoqa Han Sans Neo';
+        src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Regular.woff')
+          format('woff');
+        font-weight: 400;
+        font-style: normal;
+      }
+
+      @font-face {
+        font-family: 'Spoqa Han Sans Neo';
+        src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Medium.woff')
+          format('woff');
+        font-weight: 500;
+        font-style: normal;
+      }
+
+      @font-face {
+        font-family: 'Spoqa Han Sans Neo';
+        src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Bold.woff')
+          format('woff');
+        font-weight: 700;
+        font-style: normal;
+      }
+    `;
 
     [
       pretendardLinkElement,
@@ -105,7 +123,7 @@ const injectFontsAndThemes = () => {
       googleStaticLinkElement,
       fontsLinkElement,
       dunggeunmoNeoLinkElement,
-      spoqaHanSansNeoLinkElement,
+      spoqaHanSansNeoStyleElement,
     ].forEach((element) => {
       headElement.appendChild(element);
     });

--- a/src/options.html
+++ b/src/options.html
@@ -17,11 +17,35 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/neodgm/neodgm-webfont@latest/neodgm/style.css"
     />
-    <link
-      href="https://spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css"
-      rel="stylesheet"
-      type="text/css"
-    />
+    <style>
+      @font-face {
+        font-family: 'Spoqa Han Sans Neo';
+        src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Regular.woff')
+          format('woff');
+        font-weight: 400;
+        font-style: normal;
+      }
+
+      @font-face {
+        font-family: 'Spoqa Han Sans Neo';
+        src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Medium.woff')
+          format('woff');
+        font-weight: 500;
+        font-style: normal;
+      }
+
+      @font-face {
+        font-family: 'Spoqa Han Sans Neo';
+        src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Bold.woff')
+          format('woff');
+        font-weight: 700;
+        font-style: normal;
+      }
+
+      body {
+        background: url(./background.webp) repeat;
+      }
+    </style>
     <title>토탐정</title>
   </head>
   <body>


### PR DESCRIPTION
## PR 설명
본 PR에서는 Spoqa Han Sans Neo 폰트 로딩 시 매우 오랜 시간이 걸려 아래의 두 문제가 발생했습니다.
- 토탐정 자체 로직이 비효율적인 경우가 아님에도 설정 페이지가 로딩되는 데 매우 오랜 시간이 걸림
- 가끔 Spoqa Han Sans Neo가 적용되지 않음

눈누 서비스에 있는 웹폰트 주소로 변경함으로써 이 문제를 해결했습니다.

## 참고 자료
- https://noonnu.cc/font_page/744