### PR TITLE
[CHORE] storybook 배포 자동화

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy Storybook
+
+on:
+  push:
+    branches: ['totamjung-react']
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Dependencies
+        run: |
+          npm ci
+
+      - name: Build Storybook
+        run: |
+          npm run build-storybook
+
+      - name: Deploy Storybook
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./storybook-static
+          publish_branch: storybook-deploy


### PR DESCRIPTION
## PR 설명

본 PR에서는 storybook 페이지를 정적으로 자동 배포하도록 Github Actions의 workflow를 추가했습니다.
- 빌드한 결과물은 [`storybook-deploy` ](https://github.com/wzrabbit/boj-totamjung/tree/storybook-deploy)브랜치에 자동 push됩니다.
- https://wzrabbit.github.io/boj-totamjung 에서 배포된 페이지를 확인할 수 있습니다.