### PR TITLE
[FIX] 난이도 경고가 꺼져있음에도 불구하고 게시글의 `<blockquote>`에서 문제 경고를 하는 문제를 해결

### DIFF
--- a/src/domains/tierHider/normalToWarnTierChanger.ts
+++ b/src/domains/tierHider/normalToWarnTierChanger.ts
@@ -38,7 +38,7 @@ export const changeNormalToWarnTier = (
   warnTier: RatedTier,
   shouldWarnHighTier: boolean,
 ) => {
-  changeBoardBlockquoteBadgeTier(warnTier);
+  changeBoardBlockquoteBadgeTier(warnTier, shouldWarnHighTier);
 
   if (shouldWarnHighTier) {
     changeRegularBadgeTier(warnTier);
@@ -47,7 +47,10 @@ export const changeNormalToWarnTier = (
   }
 };
 
-const changeBoardBlockquoteBadgeTier = async (warnTier: RatedTier) => {
+const changeBoardBlockquoteBadgeTier = async (
+  warnTier: RatedTier,
+  shouldWarnHighTier: boolean,
+) => {
   const boardBlockquoteTierBadgeElement = $(
     BOARD_BLOCKQUOTE_TIER_BADGE_CSS_SELECTOR,
   );
@@ -98,7 +101,7 @@ const changeBoardBlockquoteBadgeTier = async (warnTier: RatedTier) => {
     return;
   }
 
-  if (tier >= warnTier) {
+  if (tier >= warnTier && shouldWarnHighTier) {
     boardBlockquoteTierBadgeElement.style.content = `url(${solvedAcRankIcons.warn})`;
   }
 };


### PR DESCRIPTION
## PR 설명
본 PR에서는 티어 가리개는 활성화되어 있으나 난이도 경고 기능이 꺼져 있는 상태에서, 백준 게시판의 단일 게시글 페이지에 접속했을 때, `<blockquote>`에 있는 문제의 티어가 경고 아이콘으로 바뀌는 문제를 해결했습니다.
- 게시글 페이지의 경우 CSS만으로는 사용자가 문제를 풀었는 지를 알 수 없어, solved.ac의 API를 이용해 이 여부를 판단하기에 다른 로직과 다릅니다. 이 로직에서 문제가 풀려있지 않고, 난이도가 경고 난이도 이상일 경우 항상 경고 아이콘을 표시하는 것이 문제였습니다. 유저가 난이도 경고를 켠 경우에만 경고 아이콘을 표시하도록 수정했습니다.