### PR TITLE
[FIX] `\u2013`(–)이 들어가는 알고리즘 분류를 인식하지 못하는 문제를 해결

### DIFF
--- a/src/constants/algorithmInfos.ts
+++ b/src/constants/algorithmInfos.ts
@@ -726,7 +726,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
   {
     id: 109,
     name: '벨만-포드',
-    englishName: 'Bellman–ford',
+    englishName: 'Bellman-ford',
     tag: 'bellman_ford',
     alias: [],
   },
@@ -789,7 +789,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
   {
     id: 118,
     name: '벌리캠프-매시',
-    englishName: 'Berlekamp–massey',
+    englishName: 'Berlekamp-massey',
     tag: 'berlekamp_massey',
     alias: ['벌레캠프-매시', '벌래캠프-매시', '벌리컴프-매시'],
   },
@@ -824,7 +824,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
   {
     id: 123,
     name: '라빈-카프',
-    englishName: 'Rabin–karp',
+    englishName: 'Rabin-karp',
     tag: 'rabin_karp',
     alias: [],
   },
@@ -901,7 +901,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
   {
     id: 134,
     name: '밀러-라빈 소수 판별법',
-    englishName: 'Miller–rabin',
+    englishName: 'Miller-rabin',
     tag: 'miller_rabin',
     alias: [],
   },
@@ -1113,7 +1113,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
   {
     id: 166,
     name: '스토어-바그너',
-    englishName: 'Stoer–wagner',
+    englishName: 'Stoer-wagner',
     tag: 'stoer_wagner',
     alias: [],
   },
@@ -1197,7 +1197,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
   {
     id: 178,
     name: '보이어-무어 다수결 투표',
-    englishName: 'Boyer–moore Majority Vote',
+    englishName: 'Boyer-moore Majority Vote',
     tag: 'majority_vote',
     alias: [],
   },

--- a/src/domains/algorithm/getSearchResults.test.ts
+++ b/src/domains/algorithm/getSearchResults.test.ts
@@ -64,6 +64,7 @@ const testcases: [string, Algorithm[]][] = [
       },
     ],
   ],
+  ['플로이드\u2013워셜', [{ id: 60, name: '플로이드-워셜' }]],
 ];
 
 describe('Test #1 - 검색 테스트', () => {

--- a/src/domains/algorithm/getSearchResults.ts
+++ b/src/domains/algorithm/getSearchResults.ts
@@ -3,7 +3,7 @@ import { ALGORITHM_INFOS } from '~constants/algorithmInfos';
 
 const trimWord = (word: string) => {
   const loweredWord = word.toLowerCase();
-  const trimmedWord = loweredWord.replace(/^(tag:|#)|[ ,_/-]/g, '');
+  const trimmedWord = loweredWord.replace(/^(tag:|#)|[ ,_/-]|\u2013/g, '');
 
   return trimmedWord;
 };

--- a/src/hooks/widget/useInjectedProblemTags.ts
+++ b/src/hooks/widget/useInjectedProblemTags.ts
@@ -80,8 +80,8 @@ const UseInjectedProblemTags = (params: UseInjectedProblemTags) => {
     const inspectAndHighlightUnknownAlgorithms = () => {
       const algorithmElements = $$('.spoiler-link');
 
-      const problemAlgorithmNames = algorithmElements.map(
-        (algorithmElement) => algorithmElement.innerText,
+      const problemAlgorithmNames = algorithmElements.map((algorithmElement) =>
+        algorithmElement.innerText.replace(/\u2013/g, '-'),
       );
 
       let hasUnknownAlgorithms = false;


### PR DESCRIPTION
## PR 설명
본 PR에서는 `\u2013`(–)이 들어가는 알고리즘 분류를 인식하지 못하는 문제를 해결했습니다.

BOJ의 알고리즘 분류 이름의 경우 우리가 흔히 사용하는 기호인 하이픈(-)이 쓰이기도 하고, 하이픈과 비슷하게 생겼지만 엄연히 다른 기호인 `\u2013`(–)이 쓰이기도 합니다. 당연히 알고리즘 분류의 이름을 어느 한쪽의 기호를 사용하도록 저장하면 같은 알고리즘으로 인식하지 못하는 문제가 있습니다.

구버전에서는, 알고리즘 분류의 기호가 하이픈인지 아닌지를 직접 확인하고 복사/붙여넣기 및 타이핑을 했지만, 작업 중 **실수하기 쉬우며 생산성도 떨어진다고** 생각했습니다.

고민 결과, 알고리즘 분류를 작업할 때는 항상 하이픈(-)만을 사용하도록 하고, 그 대신 BOJ에서 알고리즘 분류 이름을 가져올 때 **`\u2013`(–)인 경우 하이픈(-)으로 자동 변환**하여 처리하도록 구현하는 것이 좋다고 판단했습니다. 이렇게 하면 알고리즘 분류에 쓰인 기호와 상관없이 제(혹은 기여자)가 작업할 때는 하이픈만 쓰면 되는 것이죠.

BOJ의 알고리즘 분류를 파싱하는 것 외에도, 해당 알고리즘 분류를 복사하여 토탐정 설정의 검색창에 넣으실 분들을 위해, `\u2013`(–)를 사용해도 하이픈(-)으로 인식되게끔 개선하기도 했습니다.