### PR TITLE
[FIX] 구버전에서 업데이트 시 토탐정 테마 설정이 반영되지 않는 문제를 해결

### DIFF
--- a/src/domains/dataHandlers/converters/legacyToLatestTotamjungThemeConverter.ts
+++ b/src/domains/dataHandlers/converters/legacyToLatestTotamjungThemeConverter.ts
@@ -1,5 +1,5 @@
 export const convertLegacyToLatestTotamjungTheme = (
   legacyTotamjungTheme: unknown,
 ) => {
-  return legacyTotamjungTheme === 'on' ? 'totamjung' : 'none';
+  return legacyTotamjungTheme === 'yes' ? 'totamjung' : 'none';
 };


### PR DESCRIPTION
## PR 설명
본 PR에서는 구버전(`~v1.1.*`)에서 업데이트를 할 경우, 토탐정 테마 설정이 마이그레이션이 제대로 되지 않아 기존 설정이 반영되지 않는 문제를 해결했습니다.

- 토탐정 테마를 켜진 상태로 간주하는 조건은 `theme`의 값이 `"yes"`여야 하는데, `"on"`으로 잘못 설정된 것이 원인이었습니다.