### PR TITLE
[FIX] 출처 페이지에서 문제를 맞춘 경우에도 티어가 가려지는 문제를 해결

### DIFF
--- a/src/styles/tierHider.css
+++ b/src/styles/tierHider.css
@@ -84,7 +84,8 @@ html[hideTier='true']
   .row:has(li[class='active'] > a[href='/category'])
   ~ .row
   .table.table-bordered.table-striped
-  td:nth-child(3):not(:has(.result-ac))
+  tr:not(:has(.problem-label-ac))
+  > td:nth-child(3)
   > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
   content: url('chrome-extension://__MSG_@@extension_id__/solvedac-tier-hidden.svg');
 }


### PR DESCRIPTION
## 관련 이슈
> #63 

## PR 설명
본 PR에서는 출처 페이지(`https://www.acmicpc.net/category` 이하의 페이지)에서, 이미 문제를 맞췄음에도 티어가 가려지는 문제를 해결하였습니다.