### PR TITLE
[FEAT] 기존의 alert/confirm 창들을 모두 모달 창으로 변경하고, 모달을 개선

### DIFF
--- a/src/components/AlgorithmPool/AlgorithmPool.tsx
+++ b/src/components/AlgorithmPool/AlgorithmPool.tsx
@@ -1,6 +1,8 @@
 import * as S from './AlgorithmPool.styled';
 import AlgorithmList from './AlgorithmList';
+import SimpleModal from '~components/common/SimpleModal';
 import useAlgorithmPool from '~hooks/algorithm/useAlgorithmPool';
+import useModal from '~hooks/useModal';
 import { SearchIcon } from '~images/svg';
 import { allCheckedIcon, allUncheckedIcon } from '~images/png';
 
@@ -15,6 +17,9 @@ const AlgorithmPool = () => {
     checkAllAlgorithms,
     uncheckAllAlgorithms,
   } = useAlgorithmPool();
+  const { activeModalName, openModal, closeModal } = useModal<
+    'checkAll' | 'uncheckAll'
+  >();
 
   return (
     <S.Container>
@@ -41,7 +46,9 @@ const AlgorithmPool = () => {
         <S.CheckButtonPanel>
           <S.CheckButton
             type="button"
-            onClick={checkAllAlgorithms}
+            onClick={() => {
+              openModal('checkAll');
+            }}
             aria-label="알고리즘 분류 전체 선택"
           >
             <S.CheckButtonImage src={allCheckedIcon} />
@@ -49,7 +56,9 @@ const AlgorithmPool = () => {
           </S.CheckButton>
           <S.CheckButton
             type="button"
-            onClick={uncheckAllAlgorithms}
+            onClick={() => {
+              openModal('uncheckAll');
+            }}
             aria-label="알고리즘 분류 전체 해제"
           >
             <S.CheckButtonImage src={allUncheckedIcon} />
@@ -57,6 +66,32 @@ const AlgorithmPool = () => {
           </S.CheckButton>
         </S.CheckButtonPanel>
       </S.ControlPanel>
+      <SimpleModal
+        title="알고리즘 분류 전체 선택 확인"
+        actionType="yesNo"
+        width="350px"
+        height="auto"
+        open={activeModalName === 'checkAll'}
+        message="모든 알고리즘 분류를 선택할까요?"
+        onYesSelect={() => {
+          checkAllAlgorithms();
+          closeModal();
+        }}
+        onNoSelect={closeModal}
+      />
+      <SimpleModal
+        title="알고리즘 분류 전체 해제 확인"
+        actionType="yesNo"
+        width="350px"
+        height="auto"
+        open={activeModalName === 'uncheckAll'}
+        message="모든 알고리즘 분류를 선택 해제할까요?"
+        onYesSelect={() => {
+          uncheckAllAlgorithms();
+          closeModal();
+        }}
+        onNoSelect={closeModal}
+      />
     </S.Container>
   );
 };

--- a/src/components/QuickSlotMenu/QuickSlotMenu.tsx
+++ b/src/components/QuickSlotMenu/QuickSlotMenu.tsx
@@ -7,9 +7,11 @@ import IconButton from '~components/common/IconButton';
 import useQuickSlotMenu from '~hooks/randomDefense/useQuickSlotMenu';
 import SlotEditModal from './SlotEditModal';
 import Loading from '~components/common/Loading';
+import useModal from '~hooks/useModal';
 import { CopyIcon, EditIcon, TrashIcon } from '~images/svg';
 import type { QuickSlotsResponse, SlotNo, Hotkey } from '~types/randomDefense';
 import { theme } from '~styles/theme';
+import SimpleModal from '~components/common/SimpleModal';
 
 interface QuickSlotMenuProps {
   quickSlotsInfo: QuickSlotsResponse;
@@ -22,7 +24,7 @@ interface QuickSlotMenuProps {
 
 const QuickSlotMenu = (props: QuickSlotMenuProps) => {
   const { isLoaded } = props;
-
+  const { activeModalName, openModal, closeModal } = useModal<'copiedQuery'>();
   const {
     slot,
     selectedSlotNo,
@@ -66,7 +68,7 @@ const QuickSlotMenu = (props: QuickSlotMenuProps) => {
               onClick={() => {
                 if (!slot.isEmpty) {
                   navigator.clipboard.writeText(slot.query);
-                  alert('쿼리를 복사했어요!');
+                  openModal('copiedQuery');
                 }
               }}
             />
@@ -101,6 +103,15 @@ const QuickSlotMenu = (props: QuickSlotMenuProps) => {
         open={shouldEditModalShow}
         onClose={closeEditModal}
         onSlotChange={updateSlot}
+      />
+      <SimpleModal
+        actionType="confirm"
+        width="350px"
+        height="auto"
+        open={activeModalName === 'copiedQuery'}
+        onClose={closeModal}
+        title="쿼리 복사 완료"
+        message="쿼리를 클립보드에 복사했어요!"
       />
     </NamedFrame>
   );

--- a/src/components/common/IconButton/IconButton.tsx
+++ b/src/components/common/IconButton/IconButton.tsx
@@ -9,6 +9,7 @@ interface CommonIconButtonProps {
   iconSrc?: string | SVGProps<SVGSVGElement>;
   disabled: boolean;
   ariaLabel: string;
+  autoFocus?: boolean;
 }
 
 interface ButtonTypeProps {

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -1,4 +1,5 @@
 import * as S from './Modal.styled';
+import useEscKey from '~hooks/useEscKey';
 import { CloseIcon } from '~images/svg';
 import { createPortal } from 'react-dom';
 import type { PropsWithChildren } from 'react';
@@ -11,6 +12,7 @@ interface ModalProps {
 
 const Modal = (props: PropsWithChildren<ModalProps>) => {
   const { title, open, onClose, children } = props;
+  useEscKey({ onEscKeyPress: onClose });
 
   return (
     open &&

--- a/src/components/common/SimpleModal/SimpleModal.tsx
+++ b/src/components/common/SimpleModal/SimpleModal.tsx
@@ -78,6 +78,7 @@ const ConfirmButton = (props: Omit<ConfirmModalProps, 'actionType'>) => {
       disabled={false}
       ariaLabel="확인"
       onClick={onClose}
+      autoFocus={true}
     />
   );
 };

--- a/src/hooks/algorithm/useAlgorithmPool.ts
+++ b/src/hooks/algorithm/useAlgorithmPool.ts
@@ -49,17 +49,13 @@ const useAlgorithmPool = () => {
   };
 
   const checkAllAlgorithms = () => {
-    if (confirm('모든 알고리즘 분류를 체크 설정할까요?')) {
-      setCheckedIds(() =>
-        Array.from({ length: ALGORITHMS_COUNT }).map((_, index) => index + 1),
-      );
-    }
+    setCheckedIds(() =>
+      Array.from({ length: ALGORITHMS_COUNT }).map((_, index) => index + 1),
+    );
   };
 
   const uncheckAllAlgorithms = () => {
-    if (confirm('모든 알고리즘 분류를 체크 해제할까요?')) {
-      setCheckedIds(() => []);
-    }
+    setCheckedIds(() => []);
   };
 
   const items = getSearchResults(keyword);

--- a/src/hooks/useEscKey.ts
+++ b/src/hooks/useEscKey.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+interface UseEscKeyParams {
+  onEscKeyPress: () => void;
+}
+
+const useEscKey = (params: UseEscKeyParams) => {
+  const { onEscKeyPress } = params;
+
+  const handleKeyPress = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      onEscKeyPress();
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyPress);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyPress);
+    };
+  }, [onEscKeyPress]);
+};
+
+export default useEscKey;

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+const useModal = <T>() => {
+  const [activeModalName, setActiveModalName] = useState<T | null>(null);
+
+  const openModal = (modalName: T) => {
+    setActiveModalName(modalName);
+  };
+
+  const closeModal = () => {
+    setActiveModalName(null);
+  };
+
+  return { activeModalName, openModal, closeModal };
+};
+
+export default useModal;


### PR DESCRIPTION
## PR 설명
본 PR에서는 아래의 두 가지 작업을 진행했습니다.

### 1️⃣ 기존의 `alert`, `confirm` 창들을 모두 토탐정 내의 모달 컴포넌트를 사용하도록 변경
- 알고리즘 분류 전체 체크 / 전체 체크 해제할 때
- 슬롯의 쿼리를 클립보드에 복사할 때

### 2️⃣ 모달 기능 개선
- `<SimpleModal>`에서 **확인** 버튼만이 있는 모달일 경우 **Enter** 키를 누르는 것으로 모달을 닫을 수 있습니다.
- 모든 종류의 모달의 경우 **Esc** 키를 누르는 것으로 모달을 닫을 수 있습니다.