### PR TITLE
[REFACTOR] 설정 페이지의 내의 컴포넌트에서 데이터를 불러올 때 메시지 패싱 대신 직접 데이터 관리 함수를 사용하도록 리팩터링

### DIFF
--- a/src/hooks/algorithm/useAlgorithmPool.ts
+++ b/src/hooks/algorithm/useAlgorithmPool.ts
@@ -30,28 +30,28 @@ const useAlgorithmPool = () => {
   }, [checkedIds]);
 
   const handleChangeKeyword: ChangeEventHandler<HTMLInputElement> = (event) => {
-    setKeyword(() => event.target.value);
+    setKeyword(event.target.value);
   };
 
   const toggleAlgorithm = (id: number) => {
     if (checkedIds.includes(id)) {
       const newCheckedIds = checkedIds.filter((checkedId) => checkedId !== id);
-      setCheckedIds(() => newCheckedIds);
+      setCheckedIds(newCheckedIds);
       return;
     }
 
     const newCheckedIds = [...checkedIds, id];
-    setCheckedIds(() => newCheckedIds);
+    setCheckedIds(newCheckedIds);
   };
 
   const checkAllAlgorithms = () => {
-    setCheckedIds(() =>
+    setCheckedIds(
       Array.from({ length: ALGORITHMS_COUNT }).map((_, index) => index + 1),
     );
   };
 
   const uncheckAllAlgorithms = () => {
-    setCheckedIds(() => []);
+    setCheckedIds([]);
   };
 
   const items = getSearchResults(keyword);

--- a/src/hooks/algorithm/useAlgorithmPool.ts
+++ b/src/hooks/algorithm/useAlgorithmPool.ts
@@ -1,8 +1,11 @@
 import { getSearchResults } from '~domains/algorithm/getSearchResults';
 import { ALGORITHMS_COUNT } from '~constants/algorithmInfos';
 import { useState, useEffect } from 'react';
-import { COMMANDS } from '~constants/commands';
 import type { ChangeEventHandler } from 'react';
+import {
+  fetchCheckedAlgorithmIds,
+  saveCheckedAlgorithmIds,
+} from '~domains/dataHandlers/checkedAlgorithmsHandler';
 
 const useAlgorithmPool = () => {
   const [keyword, setKeyword] = useState('');
@@ -10,16 +13,12 @@ const useAlgorithmPool = () => {
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
-    const fetchAlgorithmPool = async () => {
-      const response = await chrome.runtime.sendMessage({
-        command: COMMANDS.FETCH_CHECKED_ALGORITHM_IDS,
-      });
+    (async () => {
+      const response = await fetchCheckedAlgorithmIds();
 
-      setCheckedIds(() => response.checkedIds);
-      setIsLoaded(() => true);
-    };
-
-    fetchAlgorithmPool();
+      setCheckedIds(response.checkedIds);
+      setIsLoaded(true);
+    })();
   }, []);
 
   useEffect(() => {
@@ -27,10 +26,7 @@ const useAlgorithmPool = () => {
       return;
     }
 
-    chrome.runtime.sendMessage({
-      command: COMMANDS.SAVE_CHECKED_ALGORITHM_IDS,
-      checkedIds,
-    });
+    saveCheckedAlgorithmIds(checkedIds);
   }, [checkedIds]);
 
   const handleChangeKeyword: ChangeEventHandler<HTMLInputElement> = (event) => {

--- a/src/hooks/algorithm/useHiderFieldsetMenu.ts
+++ b/src/hooks/algorithm/useHiderFieldsetMenu.ts
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
-import { isHiderOptionsResponse } from '~domains/dataHandlers/validators/hiderOptionsValidator';
 import type { HiderOptionsResponse } from '~types/algorithm';
-import { COMMANDS } from '~constants/commands';
 import { RatedTier } from '~types/tierHider';
+import {
+  fetchHiderOptions,
+  saveHiderOptions,
+} from '~domains/dataHandlers/hiderOptionsDataHandler';
 
 const fallbackHiderOptions = {
   problemTagLockDuration: {
@@ -37,22 +39,14 @@ const useHiderFieldsetMenu = () => {
   );
 
   useEffect(() => {
-    const fetchHiderOptions = async () => {
-      const response = await chrome.runtime.sendMessage({
-        command: COMMANDS.FETCH_HIDER_OPTIONS,
-      });
-
-      if (!isHiderOptionsResponse(response)) {
-        return;
-      }
+    (async () => {
+      const response = await fetchHiderOptions();
 
       setHiderOptionsState({
         ...response,
         isLoaded: true,
       });
-    };
-
-    fetchHiderOptions();
+    })();
   }, []);
 
   useEffect(() => {
@@ -62,10 +56,7 @@ const useHiderFieldsetMenu = () => {
       return;
     }
 
-    chrome.runtime.sendMessage({
-      command: COMMANDS.SAVE_HIDER_OPTIONS,
-      hiderOptions: hiderOptionsWithoutLoadingParam,
-    });
+    saveHiderOptions(hiderOptionsWithoutLoadingParam);
   }, [hiderOptionsState]);
 
   const updateProblemTagLockDuration = (hours: number, minutes: number) => {

--- a/src/hooks/appearance/useAppearanceFieldsetMenu.ts
+++ b/src/hooks/appearance/useAppearanceFieldsetMenu.ts
@@ -1,11 +1,14 @@
 import { useState, useEffect } from 'react';
-import { COMMANDS } from '~constants/commands';
-import {
-  isTotamjungTheme,
-  isTotamjungThemeResponse,
-} from '~domains/dataHandlers/validators/totamjungThemeValidator';
-import { isFontNoResponse } from '~domains/dataHandlers/validators/fontNoValidator';
+import { isTotamjungTheme } from '~domains/dataHandlers/validators/totamjungThemeValidator';
 import { TotamjungTheme } from '~types/totamjungTheme';
+import {
+  fetchTotamjungTheme,
+  saveTotamjungTheme,
+} from '~domains/dataHandlers/totamjungThemeDataHandler';
+import {
+  fetchFontNo,
+  saveFontNo,
+} from '~domains/dataHandlers/fontNoDataHandler';
 
 const UseAppearanceFieldsetMenu = () => {
   const [totamjungTheme, setTotamjungTheme] = useState<
@@ -17,20 +20,9 @@ const UseAppearanceFieldsetMenu = () => {
   useEffect(() => {
     const loadAppearanceFieldsetMenuData = async () => {
       const [totamjungThemeResponse, fontNoResponse] = await Promise.all([
-        chrome.runtime.sendMessage({
-          command: COMMANDS.FETCH_TOTAMJUNG_THEME,
-        }),
-        chrome.runtime.sendMessage({
-          command: COMMANDS.FETCH_FONT_NO,
-        }),
+        fetchTotamjungTheme(),
+        fetchFontNo(),
       ]);
-      if (!isTotamjungThemeResponse(totamjungThemeResponse)) {
-        return;
-      }
-
-      if (!isFontNoResponse(fontNoResponse)) {
-        return;
-      }
 
       const { totamjungTheme: currentTheme } = totamjungThemeResponse;
       const { fontNo: currentFontNo } = fontNoResponse;
@@ -48,10 +40,7 @@ const UseAppearanceFieldsetMenu = () => {
       return;
     }
 
-    chrome.runtime.sendMessage({
-      command: COMMANDS.SAVE_TOTAMJUNG_THEME,
-      totamjungTheme,
-    });
+    saveTotamjungTheme(totamjungTheme);
   }, [totamjungTheme]);
 
   useEffect(() => {
@@ -59,10 +48,7 @@ const UseAppearanceFieldsetMenu = () => {
       return;
     }
 
-    chrome.runtime.sendMessage({
-      command: COMMANDS.SAVE_FONT_NO,
-      fontNo,
-    });
+    saveFontNo(fontNo);
   }, [fontNo]);
 
   const updateTotamjungTheme = (totamjungTheme: string) => {

--- a/src/hooks/randomDefense/useRandomDefenseHistoryMenu.ts
+++ b/src/hooks/randomDefense/useRandomDefenseHistoryMenu.ts
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
 import type { ChangeEventHandler } from 'react';
 import type { RandomDefenseHistoryInfo } from '~types/randomDefense';
-import { isRandomDefenseHistoryResponse } from '~domains/dataHandlers/validators/randomDefenseHistoryValidator';
-import { COMMANDS } from '~constants/commands';
+import {
+  fetchRandomDefenseHistory,
+  saveRandomDefenseHistory,
+} from '~domains/dataHandlers/randomDefenseHistoryDataHandler';
 
 const useRandomDefenseHistoryMenu = () => {
   const [items, setItems] = useState<RandomDefenseHistoryInfo[]>([]);
@@ -12,21 +14,13 @@ const useRandomDefenseHistoryMenu = () => {
   const isEmpty = items.length === 0;
 
   useEffect(() => {
-    const fetchRandomDefenseHistoryInfo = async () => {
-      const response = await chrome.runtime.sendMessage({
-        command: COMMANDS.FETCH_RANDOM_DEFENSE_HISTORY,
-      });
+    (async () => {
+      const response = await fetchRandomDefenseHistory();
 
-      if (!isRandomDefenseHistoryResponse(response)) {
-        return;
-      }
-
-      setIsHidden(() => response.isHidden);
-      setItems(() => response.randomDefenseHistory);
-      setIsLoaded(() => true);
-    };
-
-    fetchRandomDefenseHistoryInfo();
+      setIsHidden(response.isHidden);
+      setItems(response.randomDefenseHistory);
+      setIsLoaded(true);
+    })();
   }, []);
 
   useEffect(() => {
@@ -34,11 +28,7 @@ const useRandomDefenseHistoryMenu = () => {
       return;
     }
 
-    chrome.runtime.sendMessage({
-      command: COMMANDS.SAVE_RANDOM_DEFENSE_HISTORY,
-      randomDefenseHistory: items,
-      isHidden,
-    });
+    saveRandomDefenseHistory(items, isHidden);
   }, [items, isHidden]);
 
   const deleteHistoryById = (id: string) => {

--- a/src/hooks/randomDefense/useRandomDefenseHistoryMenu.ts
+++ b/src/hooks/randomDefense/useRandomDefenseHistoryMenu.ts
@@ -38,17 +38,17 @@ const useRandomDefenseHistoryMenu = () => {
       return currentItemId !== id;
     });
 
-    setItems(() => newItems);
+    setItems(newItems);
   };
 
   const clearHistory = () => {
     if (!isEmpty && confirm('모든 추첨 기록을 제거할까요?')) {
-      setItems(() => []);
+      setItems([]);
     }
   };
 
   const updateIsHidden: ChangeEventHandler<HTMLInputElement> = (event) => {
-    setIsHidden(() => event.target.checked);
+    setIsHidden(event.target.checked);
   };
 
   return {


### PR DESCRIPTION
## PR 설명
본 PR에서는 **설정 페이지의 내의 컴포넌트에서 데이터를 불러올 때 메시지 패싱 대신 직접 데이터 관리 함수를 사용하도록 리팩터링**하였습니다.
- 설정 페이지 내의 컴포넌트들은 서비스 워커 및 `chrome.runtime.local` API 직접 사용이 가능한 위치에 있기 때문에, 메시지를 통해 소통할 필요가 없습니다.

부가적으로, 상태를 업데이트할 때 불필요한 **함수형 업데이트**가 진행되고 있는 부분을 함수형 업데이트를 사용하지 않도록 변경하였습니다.
- 모두 상태를 업데이트할 때 최신화된 이전 값이 요구되지 않는 로직들입니다.