### PR TITLE
[FIX] 티어 가리개 사용 시 로딩 중 짧은 시간 동안 본래 티어가 보이는 문제를 해결

### DIFF
--- a/assets/css/tierHider.css
+++ b/assets/css/tierHider.css
@@ -7,6 +7,12 @@ html[hideTier='true']
   content: url('/public/solvedac-tier-hidden.svg');
 }
 
+html[hideTier='loading']
+  .page-header:has(#problem_title):not(:has(.problem-label-ac))
+  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  opacity: 0;
+}
+
 /**
 * 문제 페이지에 있는 티어 텍스트에 적힌 티어를 가리기 위한 스타일입니다.
 */
@@ -26,6 +32,13 @@ html[hideTier='true']
   content: '어려운 문제 경고';
 }
 
+html[hideTier='loading']
+  .row:has(#problem_title):not(:has(.problem-label-ac))
+  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg'])
+  + span::after {
+  content: '';
+}
+
 /**
 * 문제 목록 페이지에서 문제 티어를 가리기 위한 스타일입니다.
 */
@@ -36,6 +49,13 @@ html[hideTier='true']
   content: url('/public/solvedac-tier-hidden.svg');
 }
 
+html[hideTier='loading']
+  #problemset
+  tr:not(:has(.problem-label-ac))
+  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  opacity: 0;
+}
+
 /**
 * 채점 현황 페이지에서 문제 티어를 가리기 위한 스타일입니다.
 */
@@ -44,6 +64,13 @@ html[hideTier='true']
   td:nth-child(3):not(:has(.result-ac))
   .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
   content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='loading']
+  #status-table
+  td:nth-child(3):not(:has(.result-ac))
+  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  opacity: 0;
 }
 
 /**
@@ -58,6 +85,15 @@ html[hideTier='true']
   content: url('/public/solvedac-tier-hidden.svg');
 }
 
+html[hideTier='loading']
+  .col-md-12:has(a[href='/board/list/solvedac'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  td:nth-child(2):not(:has(.result-ac))
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  opacity: 0;
+}
+
 /**
 * 게시글에서의 문제 티어를 가리기 위한 스타일입니다.
 */
@@ -69,12 +105,25 @@ html[hideTier='true']
   content: url('/public/solvedac-tier-hidden.svg');
 }
 
+html[hideTier='loading']
+  .col-md-12:has(a[href='/board/list/solvedac'])
+  ~ .col-md-12
+  blockquote
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  opacity: 0;
+}
+
 /**
 * 네비게이션 메뉴 내부의 티어를 가리기 위한 스타일입니다.
 */
 html[hideTier='true'] .nav.nav-pills.no-print.problem-menu:not(:has(a[href^="https://solved.ac/contribute/"]))
  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
   content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='loading'] .nav.nav-pills.no-print.problem-menu:not(:has(a[href^="https://solved.ac/contribute/"]))
+ .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  opacity: 0;
 }
 
 /**
@@ -90,6 +139,16 @@ html[hideTier='true']
   content: url('/public/solvedac-tier-hidden.svg');
 }
 
+html[hideTier='loading']
+  .row:has(li[class='active'] > a[href='/category'])
+  ~ .row
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  > td:nth-child(3)
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  opacity: 0;
+}
+
 /**
 * 문제집 페이지에서 문제 티어를 가리기 위한 스타일입니다.
 */
@@ -103,6 +162,16 @@ html[hideTier='true']
   content: url('/public/solvedac-tier-hidden.svg');
 }
 
+html[hideTier='loading']
+  .col-md-12:has(a[href='/workbook/top'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  td:nth-child(2)
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  opacity: 0;
+}
+
 /**
 * BOJ Extended의 유저 프로필 페이지에서 맞추지 않은 문제의 티어를 가리기 위한 스타일입니다.
 */
@@ -114,4 +183,9 @@ html[hideTier='true']
 html[hideTier='true']
   .problem-link-style-box.warn:not(.result-ac):not([data-tier='0'])::before {
   content: url('/public/solvedac-tier-warn.svg') !important;
+}
+
+html[hideTier='loading']
+  .problem-link-style-box:not(.result-ac):not([data-tier='0'])::before {
+  opacity: 0;
 }

--- a/entrypoints/injectionScript.content.ts
+++ b/entrypoints/injectionScript.content.ts
@@ -20,6 +20,7 @@ const executeInjectionScript = () => {
 
   const injectFontsAndThemes = () => {
     const htmlElement = document.documentElement;
+    htmlElement.setAttribute('hideTier', 'loading');
 
     browser.runtime
       .sendMessage({ command: COMMANDS.FETCH_TOTAMJUNG_THEME })


### PR DESCRIPTION
## PR 설명
본 PR에서는 티어 가리개 기능에서 로딩 중 아주 짧은 시간동안 본래의 티어가 보이는 문제를 해결했습니다.
- 티어 가리개의 경우 확장 프로그램이 컨텐트 스크립트와 CSS 파일을 로드/실행하는 과정에서 티어를 가릴 수 있도록 덮어씌우는 형태이기 때문에, 로딩이 느릴 경우 티어가 아주 짧은 시간동안 공개되는 문제가 있습니다.
- Firefox 브라우저에서 이 문제가 두드러졌습니다.
- 본래 HTML의 attribute에서 `hideTier`의 값을 `"true"` 또는 `"false"`로 두는 것으로 티어 가리개의 활성화 여부를 판단했는데, `"loading"`을 추가하고 컨텐트 스크립트에서 **스토리지에서 티어 가리개 활성화 여부를 요청하기 전** 빠르게 `hideTier="loading"`으로 초기 설정을 해 줌으로써 이 문제를 많이 해소시켰습니다.
    - `hideTier="loading"` 인 경우 티어를 아예 숨기면서, 공간은 차지합니다. 즉 `opacity: 0`입니다.