### PR TITLE
[TEST] 스토리북 내 모킹 데이터를 올바르게 수정, 컴포넌트 설명을 `argTypes`에 추가

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,7 +10,7 @@ const config: StorybookConfig = {
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
-    '@storybook/addon-interactions'
+    '@storybook/addon-interactions',
   ],
   framework: {
     name: '@storybook/react-vite',
@@ -18,6 +18,9 @@ const config: StorybookConfig = {
   },
   docs: {
     autodocs: true,
+  },
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
   },
   viteFinal: async (config) => {
     if (config.resolve) {

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -39,146 +39,229 @@
   }
 </style>
 <script>
+  const STORAGE_KEY = {
+    DATA_VERSION: 'dataVersion',
+    CHECKED_ALGORITHM_IDS: 'checkedAlgorithmIds',
+    QUICK_SLOTS: 'quickSlots',
+    TOTAMJUNG_THEME: 'totamjungTheme',
+    HIDER_OPTIONS: 'hiderOptions',
+    RANDOM_DEFENSE_HISTORY: 'randomDefenseHistory',
+    IS_TIER_HIDDEN: 'isTierHidden',
+    FONT_NO: 'fontNo',
+    TIMERS: 'timers',
+  };
+
+  const COMMANDS = {
+    FETCH_CHECKED_ALGORITHM_IDS: 'fetchCheckedAlgorithmIds',
+    FETCH_QUICK_SLOTS: 'fetchQuickSlots',
+    FETCH_TOTAMJUNG_THEME: 'fetchTotamjungTheme',
+    FETCH_HIDER_OPTIONS: 'fetchHiderOptions',
+    FETCH_OPTIONS_DATA: 'fetchOptionsData',
+    SAVE_AND_GET_REMAINING_LOCK_TIME: 'saveAndGetRemainingLockTime',
+    GET_RANDOM_DEFENSE_RESULT: 'getRandomDefenseResult',
+    OPEN_OPTIONS_PAGE: 'openOptionsPage',
+  };
+
+  const checkedAlgorithmIds = [1, 2, 4, 8];
+
+  const randomDefenseHistory = [
+    {
+      problemId: 27959,
+      title: '초코바',
+      tier: 1,
+      createdAt: '2024-03-04T01:00:00.000Z',
+    },
+    {
+      problemId: 27964,
+      title: '콰트로치즈피자',
+      tier: 6,
+      createdAt: '2024-03-02T06:04:10.000Z',
+    },
+    {
+      problemId: 27943,
+      title: '가지 사진 찾기',
+      tier: 11,
+      createdAt: '2024-02-29T22:12:33.040Z',
+    },
+    {
+      problemId: 27470,
+      title: '멋진 부분집합',
+      tier: 16,
+      createdAt: '2024-02-29T22:10:33.127Z',
+    },
+    {
+      problemId: 30243,
+      title: '🧩 N-Queen (Hard)',
+      tier: 21,
+      createdAt: '2023-01-11T10:20:44.790Z',
+    },
+    {
+      problemId: 31442,
+      title: '좋은 수열',
+      tier: 26,
+      createdAt: '2023-01-11T10:20:44.789Z',
+    },
+    {
+      problemId: 1223,
+      title: '마법의 돌',
+      tier: 0,
+      createdAt: '2022-03-17T18:00:40.000Z',
+    },
+    {
+      problemId: 27903,
+      title: '인생',
+      tier: 31,
+      createdAt: '2022-03-15T00:00:00.000Z',
+    },
+  ];
+
+  const isTierHidden = false;
+
+  const quickSlotsResponse = {
+    selectedSlotNo: 1,
+    hotkey: 'Alt',
+    slots: {
+      1: { isEmpty: true },
+      2: {
+        isEmpty: false,
+        title: '골드 랜덤 디펜스',
+        query: '*11..15 s#3000.. solvable:true',
+      },
+      3: { isEmpty: true },
+      4: {
+        isEmpty: false,
+        title: '외국어 문제 풀어보기',
+        query: '*5..20 !lang:ko solvable:true',
+      },
+      5: { isEmpty: true },
+      6: { isEmpty: true },
+      7: { isEmpty: true },
+      8: {
+        isEmpty: false,
+        title: '이추첨의이름은정확히삼십글자이며이렇게하는이유는테스트를위함',
+        query:
+          '*1..30 (-#rope-#bayes-#knuth-#dancing_links-#differential_cryptanalysis-#discrete_sqrt-#lgv-#green-#stoer_wagner-#multipoint_evaluation-#lte-#geometric_boolean_operations-#a_star-#discrete_kth_root)',
+      },
+      9: { isEmpty: true },
+      0: { isEmpty: true },
+    },
+  };
+
+  const hiderOptionsResponse = {
+    problemTagLockDuration: {
+      hours: 1,
+      minutes: 30,
+    },
+    shouldHideTier: true,
+    shouldWarnHighTier: true,
+    warnTier: 16,
+    algorithmHiderUsage: 'always',
+    problemTagLockUsage: 'click',
+  };
+
+  const totamjungTheme = 'totamjung';
+
+  const fontNo = 22;
+
   var process = {
     env: {
       BUILD_DATE: new Date().toLocaleDateString('ko-KR'),
     },
   };
+
   var browser = {
     runtime: {
-      getURL: (path) => path,
       getManifest: () => ({ version: 'Test', manifest_version: 3 }),
+      getURL: (path) => path,
       sendMessage: async ({ command, message }, callback) => {
-        if (command === 'openOptionsPage') {
-          alert(
-            '이 alert가 뜬다면, 실제 실행 환경에서는 설정 페이지가 뜰 것입니다.',
-          );
+        switch (command) {
+          case COMMANDS.FETCH_CHECKED_ALGORITHM_IDS:
+            return { checkedIds: checkedAlgorithmIds };
+          case COMMANDS.FETCH_HIDER_OPTIONS:
+            return hiderOptionsResponse;
+          case COMMANDS.SAVE_AND_GET_REMAINING_LOCK_TIME:
+            return 0;
+          case COMMANDS.FETCH_QUICK_SLOTS:
+            return quickSlotsResponse;
+          case COMMANDS.GET_RANDOM_DEFENSE_RESULT:
+            return {
+              success: false,
+              errorMessage: '테스트!',
+              errorDescriptions: [
+                '이 테스트 메시지가 디버그 도구에 표시된다면, 랜덤 디펜스가 진행되었음을 의미하는 것입니다.',
+              ],
+            };
+          case COMMANDS.OPEN_OPTIONS_PAGE:
+            if (command === 'openOptionsPage') {
+              alert(
+                '이 alert가 뜬다면, 실제 실행 환경에서는 설정 페이지가 뜰 것입니다.',
+              );
+            }
+            return;
+          default:
+            console.error(
+              `알 수 없는 메시지가 전달되었습니다: 메시지명이 올바른지, 테스트 데이터를 채우는 것을 까먹지 않았는지 다시 점검해 보세요.`,
+              { command, message },
+            );
         }
+      },
+    },
 
-        if (command === 'fetchCheckedAlgorithmIds') {
-          return {
-            checkedIds: [1, 2, 3],
-          };
-        }
+    storage: {
+      onChanged: {
+        addListener: () => {},
+        removeListener: () => {},
+      },
 
-        if (command === 'fetchRandomDefenseHistory') {
-          const randomDefenseHistory = [
-            {
-              problemId: 27959,
-              title: '초코바',
-              tier: 1,
-              createdAt: '2024-03-04T01:00:00.000Z',
-            },
-            {
-              problemId: 27964,
-              title: '콰트로치즈피자',
-              tier: 6,
-              createdAt: '2024-03-02T06:04:10.000Z',
-            },
-            {
-              problemId: 27943,
-              title: '가지 사진 찾기',
-              tier: 11,
-              createdAt: '2024-02-29T22:12:33.040Z',
-            },
-            {
-              problemId: 27470,
-              title: '멋진 부분집합',
-              tier: 16,
-              createdAt: '2024-02-29T22:10:33.127Z',
-            },
-            {
-              problemId: 30243,
-              title: '🧩 N-Queen (Hard)',
-              tier: 21,
-              createdAt: '2023-01-11T10:20:44.790Z',
-            },
-            {
-              problemId: 31442,
-              title: '좋은 수열',
-              tier: 26,
-              createdAt: '2023-01-11T10:20:44.789Z',
-            },
-            {
-              problemId: 1223,
-              title: '마법의 돌',
-              tier: 0,
-              createdAt: '2022-03-17T18:00:40.000Z',
-            },
-            {
-              problemId: 27903,
-              title: '인생',
-              tier: 31,
-              createdAt: '2022-03-15T00:00:00.000Z',
-            },
-          ];
+      local: {
+        get: (command) => {
+          const commandList = typeof command === 'string' ? [command] : command;
+          const response = {};
 
-          return {
-            randomDefenseHistory,
-            isHidden: false,
-          };
-        }
+          commandList.forEach((currentCommand) => {
+            switch (currentCommand) {
+              case STORAGE_KEY.CHECKED_ALGORITHM_IDS:
+                Object.assign(response, { checkedAlgorithmIds });
+                break;
 
-        if (command === 'fetchQuickSlots') {
-          return {
-            selectedSlotNo: 1,
-            hotkey: 'Alt',
-            slots: {
-              1: { isEmpty: true },
-              2: {
-                isEmpty: false,
-                title: '골드 랜덤 디펜스',
-                query: '*11..15 s#3000.. solvable:true',
-              },
-              3: { isEmpty: true },
-              4: {
-                isEmpty: false,
-                title: '외국어 문제 풀어보기',
-                query: '*5..20 !lang:ko solvable:true',
-              },
-              5: { isEmpty: true },
-              6: { isEmpty: true },
-              7: { isEmpty: true },
-              8: {
-                isEmpty: false,
-                title:
-                  '이추첨의이름은정확히삼십글자이며이렇게하는이유는테스트를위함',
-                query:
-                  '*1..30 (-#rope-#bayes-#knuth-#dancing_links-#differential_cryptanalysis-#discrete_sqrt-#lgv-#green-#stoer_wagner-#multipoint_evaluation-#lte-#geometric_boolean_operations-#a_star-#discrete_kth_root)',
-              },
-              9: { isEmpty: true },
-              0: { isEmpty: true },
-            },
-          };
-        }
+              case STORAGE_KEY.RANDOM_DEFENSE_HISTORY:
+                Object.assign(response, { randomDefenseHistory });
+                break;
 
-        if (command === 'fetchTotamjungTheme') {
-          return {
-            totamjungTheme: 'none',
-          };
-        }
+              case STORAGE_KEY.IS_TIER_HIDDEN:
+                Object.assign(response, { isTierHidden });
+                break;
 
-        if (command === 'fetchHiderOptions') {
-          return {
-            problemTagLockDuration: {
-              hours: 1,
-              minutes: 30,
-            },
-            shouldHideTier: true,
-            shouldWarnHighTier: true,
-            warnTier: 16,
-            algorithmHiderUsage: 'always',
-            problemTagLockUsage: 'click',
-          };
-        }
+              case STORAGE_KEY.HIDER_OPTIONS:
+                Object.assign(response, { hiderOptionsResponse });
+                break;
 
-        if (command === 'fetchFontNo') {
-          return {
-            fontNo: 10,
-          };
-        }
+              case STORAGE_KEY.QUICK_SLOTS:
+                Object.assign(response, quickSlotsResponse);
+                break;
 
-        return {};
+              case STORAGE_KEY.TOTAMJUNG_THEME:
+                Object.assign(response, { totamjungTheme });
+                break;
+
+              case STORAGE_KEY.FONT_NO:
+                Object.assign(response, { fontNo });
+                break;
+
+              default:
+                console.error(
+                  `알 수 없는 커맨드가 전달되었습니다: ${currentCommand}\n커맨드명이 올바른지, 테스트 데이터를 채우는 것을 까먹지 않았는지 다시 점검해 보세요.`,
+                );
+            }
+          });
+
+          return response;
+        },
+
+        set: (object) => {
+          console.log('browser.storage.local.set 호출!');
+          console.log(object);
+        },
       },
     },
   };

--- a/components/AlgorithmPool/AlgorithmList/AlgorithmList.stories.tsx
+++ b/components/AlgorithmPool/AlgorithmList/AlgorithmList.stories.tsx
@@ -9,7 +9,18 @@ import type { Algorithm } from '@/types/algorithm';
 const meta = {
   title: 'components/AlgorithmPool/AlgorithmList',
   component: AlgorithmList,
-  argTypes: {},
+  argTypes: {
+    items: {
+      description: '알고리즘 분류에 대한 정보로 이루어진 항목들입니다.',
+    },
+    checkedIds: {
+      description: '사용자가 체크해 둔 알고리즘 분류의 ID 목록입니다.',
+    },
+    onChange: {
+      description:
+        '사용자가 체크해 둔 알고리즘 분류의 정보가 변경되었을 경우 호출할 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof AlgorithmList>;
 
 export default meta;

--- a/components/AlgorithmPool/AlgorithmList/AlgorithmList.stories.tsx
+++ b/components/AlgorithmPool/AlgorithmList/AlgorithmList.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import AlgorithmList from './AlgorithmList';
+import { fn } from '@storybook/test';
 import type { Algorithm } from '@/types/algorithm';
 
 /**
@@ -64,8 +65,6 @@ export const Default: Story = {
   args: {
     items,
     checkedIds,
-    onChange: (id) => {
-      alert(`onChange(${id});`);
-    },
+    onChange: fn(),
   },
 };

--- a/components/AlgorithmPool/AlgorithmList/AlgorithmListItem/AlgorithmListItem.stories.tsx
+++ b/components/AlgorithmPool/AlgorithmList/AlgorithmListItem/AlgorithmListItem.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import AlgorithmListItem from './AlgorithmListItem';
+import { fn } from '@storybook/test';
 
 /**
  * `AlgorithmListItem`는 하나의 알고리즘 분류에 대한 체크 여부를 설정할 수 있는 컴포넌트입니다.
@@ -20,9 +21,7 @@ export const CheckedLightBrownColor: Story = {
     name: '그리디 알고리즘',
     isChecked: true,
     backgroundColor: 'light-brown',
-    onChange: (id: number) => {
-      alert(`onChange(${id})`);
-    },
+    onChange: fn(),
   },
 };
 
@@ -32,9 +31,7 @@ export const NotCheckedLightBrownColor: Story = {
     name: '그리디 알고리즘',
     isChecked: false,
     backgroundColor: 'light-brown',
-    onChange: (id: number) => {
-      alert(`onChange(${id})`);
-    },
+    onChange: fn(),
   },
 };
 
@@ -44,9 +41,7 @@ export const CheckedBrownColor: Story = {
     name: '그리디 알고리즘',
     isChecked: true,
     backgroundColor: 'brown',
-    onChange: (id: number) => {
-      alert(`onChange(${id})`);
-    },
+    onChange: fn(),
   },
 };
 
@@ -56,8 +51,6 @@ export const NotCheckedBrownColor: Story = {
     name: '그리디 알고리즘',
     isChecked: false,
     backgroundColor: 'brown',
-    onChange: (id: number) => {
-      alert(`onChange(${id})`);
-    },
+    onChange: fn(),
   },
 };

--- a/components/AlgorithmPool/AlgorithmList/AlgorithmListItem/AlgorithmListItem.stories.tsx
+++ b/components/AlgorithmPool/AlgorithmList/AlgorithmListItem/AlgorithmListItem.stories.tsx
@@ -8,7 +8,23 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/AlgorithmPool/AlgorithmListItem',
   component: AlgorithmListItem,
-  argTypes: {},
+  argTypes: {
+    id: {
+      description: '알고리즘 분류의 ID입니다.',
+    },
+    name: {
+      description: '알고리즘 분류의 이름입니다.',
+    },
+    isChecked: {
+      description: '알고리즘 분류가 체크되어 있는지의 여부입니다.',
+    },
+    backgroundColor: {
+      description: '메뉴의 색상입니다.',
+    },
+    onChange: {
+      description: '체크 여부가 변경되었을 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof AlgorithmListItem>;
 
 export default meta;

--- a/components/InspectResultIcon/InspectResultIcon.stories.tsx
+++ b/components/InspectResultIcon/InspectResultIcon.stories.tsx
@@ -7,6 +7,17 @@ import InspectResultIcon from './InspectResultIcon';
 const meta = {
   title: 'components/InspectResultIcon',
   component: InspectResultIcon,
+  argTypes: {
+    theme: {
+      description: '본 컴포넌트에 적용할 테마를 의미합니다.',
+      control: 'radio',
+      options: ['none', 'totamjung'],
+    },
+    icon: {
+      description: '아이콘의 종류를 의미합니다.',
+      control: 'radio',
+    },
+  },
 } satisfies Meta<typeof InspectResultIcon>;
 
 export default meta;

--- a/components/LeftSlideToast/LeftSlideToast.stories.tsx
+++ b/components/LeftSlideToast/LeftSlideToast.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import LeftSlideToast from './LeftSlideToast';
 import { CopyIcon } from '@/assets/svg';
+import { fn } from '@storybook/test';
 
 /**
  * `LeftSlideToast`는 사용자에게 특정 내용을 알리기 위한, 좌측에서 등장하는 토스트입니다.
@@ -39,9 +40,7 @@ export const Default: Story = {
     descriptions:
       '그리고 여기에는 지금 무슨 일이 일어났는지에 대한 설명이 있을 거에요.',
     open: true,
-    onClose: () => {
-      alert('onClose()');
-    },
+    onClose: fn(),
   },
 };
 
@@ -61,9 +60,7 @@ export const SvgIcon: Story = {
     descriptions:
       '그리고 여기에는 지금 무슨 일이 일어났는지에 대한 설명이 있을 거에요.',
     open: true,
-    onClose: () => {
-      alert('onClose()');
-    },
+    onClose: fn(),
   },
 };
 
@@ -83,9 +80,7 @@ export const TotamjungTheme: Story = {
     descriptions:
       '그리고 여기에는 지금 무슨 일이 일어났는지에 대한 설명이 있을 거에요.',
     open: true,
-    onClose: () => {
-      alert('onClose()');
-    },
+    onClose: fn(),
   },
 };
 
@@ -105,9 +100,7 @@ export const TotamjungThemeWithSvgIcon: Story = {
     descriptions:
       '그리고 여기에는 지금 무슨 일이 일어났는지에 대한 설명이 있을 거에요.',
     open: true,
-    onClose: () => {
-      alert('onClose()');
-    },
+    onClose: fn(),
   },
 };
 
@@ -129,9 +122,7 @@ export const MultipleDescriptions: Story = {
       '이건 두 번째 설명입니다. 설명을 여러 개 사용할 경우에는 배열을 사용해 주세요.',
     ],
     open: true,
-    onClose: () => {
-      alert('onClose()');
-    },
+    onClose: fn(),
   },
 };
 
@@ -149,9 +140,7 @@ export const NoDescription: Story = {
     progress: 65,
     title: '설명이 필요 없다고요? 그럼 메시지만 간결하게 전달해도 문제 없죠.',
     open: true,
-    onClose: () => {
-      alert('onClose()');
-    },
+    onClose: fn(),
   },
 };
 
@@ -174,8 +163,6 @@ export const VeryLongDescription: Story = {
     descriptions:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum vestibulum. Cras venenatis euismod malesuada. Nulla facilisi. Curabitur facilisis, libero a pretium auctor, sapien erat tincidunt nulla, vitae vestibulum elit leo at odio. Donec vehicula mauris ut nisi hendrerit, ac dictum libero consequat. Integer euismod neque eu magna facilisis, in suscipit sem sagittis.',
     open: true,
-    onClose: () => {
-      alert('onClose()');
-    },
+    onClose: fn(),
   },
 };

--- a/components/LeftSlideToast/LeftSlideToast.stories.tsx
+++ b/components/LeftSlideToast/LeftSlideToast.stories.tsx
@@ -10,12 +10,35 @@ const meta = {
   title: 'components/LeftSlideToast',
   component: LeftSlideToast,
   argTypes: {
+    mainIconSrc: {
+      description: '토스트의 좌측에 표시할 큰 아이콘의 파일 경로입니다.',
+    },
+    theme: {
+      description: '본 컴포넌트에 적용할 테마를 의미합니다.',
+      control: 'radio',
+      options: ['none', 'totamjung'],
+    },
     progress: {
+      description:
+        '토스트의 프로그레스 바가 얼마나 차 있는지를 의미합니다. 이 값은 **0 이상 100 이하의 수**여야 합니다.',
       control: {
         type: 'range',
         min: 0,
         max: 100,
       },
+    },
+    title: {
+      description: '토스트의 제목입니다.',
+    },
+    descriptions: {
+      description: '토스트의 제목을 뒷받침할 설명입니다.',
+    },
+    open: {
+      description:
+        '토스트가 열려 있는지(=사용자에게 보이는 상태인지)를 의미합니다.',
+    },
+    onClose: {
+      description: '토스트를 닫아야 할 때 실행시킬 콜백 함수입니다.',
     },
   },
 } satisfies Meta<typeof LeftSlideToast>;

--- a/components/MenuTitle/MenuTitle.stories.tsx
+++ b/components/MenuTitle/MenuTitle.stories.tsx
@@ -8,7 +8,15 @@ import MenuTitle from './MenuTitle';
 const meta = {
   title: 'components/MenuTitle',
   component: MenuTitle,
-  argTypes: {},
+  argTypes: {
+    iconSrc: {
+      description: '제목 컴포넌트에서 표시할 좌측의 아이콘을 의미합니다.',
+      control: false,
+    },
+    title: {
+      description: '제목 컴포넌트에 표시할 제목을 의미합니다.',
+    },
+  },
 } satisfies Meta<typeof MenuTitle>;
 
 export default meta;

--- a/components/OptionsDataManageMenu/DataFileUploadButton/DataFileUploadButton.stories.tsx
+++ b/components/OptionsDataManageMenu/DataFileUploadButton/DataFileUploadButton.stories.tsx
@@ -8,7 +8,11 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/OptionsDataManageMenu/DataFileUploadButton',
   component: DataFileUploadButton,
-  argTypes: {},
+  argTypes: {
+    onChange: {
+      description: '사용자가 파일을 업로드한 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof DataFileUploadButton>;
 
 export default meta;

--- a/components/OptionsDataManageMenu/DataFileUploadButton/DataFileUploadButton.stories.tsx
+++ b/components/OptionsDataManageMenu/DataFileUploadButton/DataFileUploadButton.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import DataFileUploadButton from './DataFileUploadButton';
+import { fn } from '@storybook/test';
 
 /**
  * `DataFileUploadButton`은 토탐정의 세이브파일을 업로드할 수 있도록 해 주는 버튼 컴포넌트입니다.
@@ -15,5 +16,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {},
+  args: {
+    onChange: fn(),
+  },
 };

--- a/components/OptionsDataManageMenu/OptionsDataResetModal/OptionsDataResetModal.stories.tsx
+++ b/components/OptionsDataManageMenu/OptionsDataResetModal/OptionsDataResetModal.stories.tsx
@@ -9,7 +9,19 @@ import { useState } from 'react';
 const meta = {
   title: 'components/OptionsDataManageMenu/OptionsDataResetModal',
   component: OptionsDataResetModal,
-  argTypes: {},
+  argTypes: {
+    open: {
+      description: '이 모달이 열려 있는지의 여부입니다.',
+    },
+    onClose: {
+      description:
+        '이 모달이 닫혀야 할 때 실행시킬 콜백 함수입니다. 사용자가 초기화 작업을 취소했음을 의미합니다.',
+    },
+    onReset: {
+      description:
+        '토탐정 설정 데이터를 초기화해야 할 때 실행시킬 콜백 함수입니다. 사용자가 최종적으로 초기화 작업을 승인했음을 의미합니다.',
+    },
+  },
 } satisfies Meta<typeof OptionsDataResetModal>;
 
 export default meta;

--- a/components/OptionsDataManageMenu/OptionsDataUploadModal/OptionsDataUploadModal.stories.tsx
+++ b/components/OptionsDataManageMenu/OptionsDataUploadModal/OptionsDataUploadModal.stories.tsx
@@ -9,7 +9,19 @@ import { useState } from 'react';
 const meta = {
   title: 'components/OptionsDataManageMenu/OptionsDataUploadModal',
   component: OptionsDataUploadModal,
-  argTypes: {},
+  argTypes: {
+    open: {
+      description: '이 모달이 열려 있는지의 여부입니다.',
+    },
+    onClose: {
+      description:
+        '이 모달이 닫혀야 할 때 실행시킬 콜백 함수입니다. 사용자가 초기화 작업을 취소했음을 의미합니다.',
+    },
+    onUpload: {
+      description:
+        '토탐정 설정 데이터를 초기화해야 할 때 실행시킬 콜백 함수입니다. 사용자가 최종적으로 초기화 작업을 승인했음을 의미합니다.',
+    },
+  },
 } satisfies Meta<typeof OptionsDataUploadModal>;
 
 export default meta;

--- a/components/OptionsHeader/OptionsHeader.stories.tsx
+++ b/components/OptionsHeader/OptionsHeader.stories.tsx
@@ -8,6 +8,14 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/OptionsHeader',
   component: OptionsHeader,
+  argTypes: {
+    selectedCategory: {
+      description: '현재 선택되어 있는 메뉴 카테고리입니다.',
+    },
+    onCategoryChange: {
+      description: '카테고리를 변경할 때 호출할 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof OptionsHeader>;
 
 export default meta;

--- a/components/OptionsHeader/OptionsHeader.stories.tsx
+++ b/components/OptionsHeader/OptionsHeader.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import OptionsHeader from './OptionsHeader';
+import { fn } from '@storybook/test';
 
 /**
  * `OptionsHeader`는 설정 페이지의 헤더 컴포넌트입니다.
@@ -16,5 +17,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     selectedCategory: 'algorithmHider',
+    onCategoryChange: fn(),
   },
 };

--- a/components/OptionsHeader/OptionsNav/OptionsNav.stories.tsx
+++ b/components/OptionsHeader/OptionsNav/OptionsNav.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import OptionsNav from './OptionsNav';
+import { fn } from '@storybook/test';
 
 /**
  * `OptionsNav`는 설정 페이지에서 원하는 메뉴 카테고리를 고를 수 있게 해 주는 네비게이션 컴포넌트입니다.
@@ -16,5 +17,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     selectedCategory: 'algorithmHider',
+    onChange: fn(),
   },
 };

--- a/components/OptionsHeader/OptionsNav/OptionsNav.stories.tsx
+++ b/components/OptionsHeader/OptionsNav/OptionsNav.stories.tsx
@@ -8,6 +8,14 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/OptionsHeader/OptionsNav',
   component: OptionsNav,
+  argTypes: {
+    selectedCategory: {
+      description: '현재 선택되어 있는 메뉴 카테고리입니다.',
+    },
+    onChange: {
+      description: '카테고리를 변경될 경우 호출할 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof OptionsNav>;
 
 export default meta;

--- a/components/OptionsHeader/TotamjungInfoModal/TotamjungInfoModal.stories.tsx
+++ b/components/OptionsHeader/TotamjungInfoModal/TotamjungInfoModal.stories.tsx
@@ -9,7 +9,14 @@ import { useState } from 'react';
 const meta = {
   title: 'components/OptionsHeader/TotamjungInfoModal',
   component: TotamjungInfoModal,
-  argTypes: {},
+  argTypes: {
+    open: {
+      description: '모달이 열려있는 지의 여부입니다.',
+    },
+    onClose: {
+      description: '모달을 닫아야 할 경우 실행할 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof TotamjungInfoModal>;
 
 export default meta;

--- a/components/ProblemTagLockTimer/ProblemTagLockTimer.stories.tsx
+++ b/components/ProblemTagLockTimer/ProblemTagLockTimer.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import ProblemTagLockTimer from './ProblemTagLockTimer';
+import { fn } from '@storybook/test';
 
 /**
  * `ProblemTagLockTimer`는 알고리즘 분류를 잠글 시, 잠금 시간을 설정할 수 있는 타이머 컴포넌트입니다.
@@ -19,6 +20,7 @@ export const Default: Story = {
     hours: 0,
     minutes: 20,
     disabled: false,
+    onChange: fn(),
   },
 };
 
@@ -27,5 +29,6 @@ export const Disabled: Story = {
     hours: 0,
     minutes: 20,
     disabled: true,
+    onChange: fn(),
   },
 };

--- a/components/ProblemTagLockTimer/ProblemTagLockTimer.stories.tsx
+++ b/components/ProblemTagLockTimer/ProblemTagLockTimer.stories.tsx
@@ -8,7 +8,22 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/ProblemTagLockTimer',
   component: ProblemTagLockTimer,
-  argTypes: {},
+  argTypes: {
+    hours: {
+      description: '타이머에 설정된 **시간**을 의미합니다.',
+    },
+    minutes: {
+      description: '타이머에 설정된 **분**을 의미합니다.',
+    },
+    disabled: {
+      description:
+        '본 컴포넌트가 비활성화되어 있는지의 여부입니다. 비활성화되어 있는 경우 본 컴포넌트를 조작할 수 없습니다.',
+    },
+    onChange: {
+      description:
+        '타이머에 설정된 시간이 변경될 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof ProblemTagLockTimer>;
 
 export default meta;
@@ -24,6 +39,9 @@ export const Default: Story = {
   },
 };
 
+/**
+ * 스토리지로부터 데이터를 아직 받아오지 못한 상황, 즉 로딩 중인 상황일 경우에는 컴포넌트가 비활성화됩니다.
+ */
 export const Disabled: Story = {
   args: {
     hours: 0,

--- a/components/QuickSlotMenu/HotkeySwitcher/HotkeySwitcher.stories.tsx
+++ b/components/QuickSlotMenu/HotkeySwitcher/HotkeySwitcher.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import HotkeySwitcher from './HotkeySwitcher';
+import { fn } from '@storybook/test';
 
 /**
  * `HotkeySwitcher`는 무작위 추첨을 시작하기 위한 단축키를 스위칭하는 기능을 제공하기 위한 컴포넌트입니다. `Alt/Option`과 `F2`를 번갈아 스위칭하는 것이 가능합니다. `Alt/Option`의 경우 사용자의 운영체제에 따라 `Alt` 또는 `Option` 중 하나가 표시됩니다.
@@ -18,8 +19,6 @@ export const Default: Story = {
   args: {
     selectedSlotNo: 3,
     hotkey: 'Alt',
-    onClick: () => {
-      alert('onClick()');
-    },
+    onClick: fn(),
   },
 };

--- a/components/QuickSlotMenu/QuickSlotMenu.stories.tsx
+++ b/components/QuickSlotMenu/QuickSlotMenu.stories.tsx
@@ -9,7 +9,22 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/QuickSlotMenu',
   component: QuickSlotMenu,
-  argTypes: {},
+  argTypes: {
+    quickSlotsInfo: {
+      description:
+        '퀵 슬롯 정보들의 목록을 의미합니다. 이 정보에는 10개의 슬롯에 대한 쿼리 정보, 설정되어 있는 단축키, 선택된 슬롯 번호가 포함됩니다.',
+    },
+    isLoaded: {
+      description: '이 컴포넌트가 로드되었는지를 의미합니다.',
+    },
+    onHotkeyChange: {
+      description: '단축키가 변경되어야 할 때 실행시킬 콜백 함수입니다.',
+    },
+    onSlotChange: {
+      description:
+        '퀵 슬롯의 정보가 변경되어야 할 때 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof QuickSlotMenu>;
 
 export default meta;

--- a/components/QuickSlotMenu/QuickSlotMenu.stories.tsx
+++ b/components/QuickSlotMenu/QuickSlotMenu.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import QuickSlotMenu from './QuickSlotMenu';
 import type { QuickSlotsResponse } from '@/types/randomDefense';
+import { fn } from '@storybook/test';
 
 /**
  * `QuickSlotMenu`는 추첨 생성 폼을 통해 생성된 연습 쿼리들을 관리할 수 있는 메뉴 형태의 컴포넌트입니다.
@@ -49,17 +50,9 @@ export const Default: Story = {
   args: {
     quickSlotsInfo: quickSlotsResponse,
     isLoaded: true,
-    onHotkeyChange: (hotkey) => {
-      alert(`onHotkeyChange('${hotkey}')`);
-    },
-    onSlotChange: (title: string, query: string) => {
-      alert(`onSlotChange('${title}', '${query}')`);
-    },
-    onSlotDelete: () => {
-      alert(`onSlotDelete()`);
-    },
-    onSlotNoChange: (slotNo) => {
-      alert(`onSlotNoChange(${slotNo})`);
-    },
+    onHotkeyChange: fn(),
+    onSlotChange: fn(),
+    onSlotDelete: fn(),
+    onSlotNoChange: fn(),
   },
 };

--- a/components/QuickSlotMenu/SlotEditModal/SlotEditModal.stories.tsx
+++ b/components/QuickSlotMenu/SlotEditModal/SlotEditModal.stories.tsx
@@ -9,7 +9,24 @@ import { useState } from 'react';
 const meta = {
   title: 'components/QuickSlotMenu/SlotEditModal',
   component: SlotEditModal,
-  argTypes: {},
+  argTypes: {
+    title: {
+      description: '모달에 표시할 슬롯의 제목입니다.',
+    },
+    query: {
+      description: '모달에 표시할 슬롯의 쿼리입니다.',
+    },
+    open: {
+      description: '모달이 열려있는지의 여부입니다.',
+    },
+    onClose: {
+      description: '모달을 닫아야 할 경우 실행시킬 콜백 함수입니다.',
+    },
+    onSlotChange: {
+      description:
+        '사용자가 슬롯 정보의 수정을 완료하여 슬롯의 정보가 변경되어야 할 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof SlotEditModal>;
 
 export default meta;

--- a/components/QuickSlotMenu/SlotInfo/SlotInfo.stories.tsx
+++ b/components/QuickSlotMenu/SlotInfo/SlotInfo.stories.tsx
@@ -7,7 +7,17 @@ import SlotInfo from './SlotInfo';
 const meta = {
   title: 'components/QuickSlotMenu/SlotInfo',
   component: SlotInfo,
-  argTypes: {},
+  argTypes: {
+    isEmpty: {
+      description: '해당하는 슬롯이 비어 있는지의 여부입니다.',
+    },
+    title: {
+      description: '슬롯에 저장된 추첨의 제목(=이름)입니다.',
+    },
+    query: {
+      description: '슬롯에 저장된 추첨의 쿼리 정보입니다.',
+    },
+  },
 } satisfies Meta<typeof SlotInfo>;
 
 export default meta;

--- a/components/QuickSlotMenu/SlotPagination/SlotPagination.stories.tsx
+++ b/components/QuickSlotMenu/SlotPagination/SlotPagination.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import SlotPagination from './SlotPagination';
+import { fn } from '@storybook/test';
 
 /**
  * `SlotPagination`는 선택된 슬롯의 번호를 변경할 때 사용하는 컴포넌트입니다. 각 슬롯이 생성되어 있는지도 시각적으로 표시하는 역할을 겸합니다.
@@ -18,8 +19,6 @@ export const Default: Story = {
   args: {
     selectedSlotNo: 1,
     occupiedSlotNos: [2, 8, 4],
-    onChange: (slotNo: number) => {
-      alert(`onChange(${slotNo})`);
-    },
+    onChange: fn(),
   },
 };

--- a/components/QuickSlotMenu/SlotPagination/SlotPagination.stories.tsx
+++ b/components/QuickSlotMenu/SlotPagination/SlotPagination.stories.tsx
@@ -8,7 +8,18 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/QuickSlotMenu/SlotPagination',
   component: SlotPagination,
-  argTypes: {},
+  argTypes: {
+    selectedSlotNo: {
+      description: '선택되어 있는 슬롯의 번호입니다.',
+    },
+    occupiedSlotNos: {
+      description:
+        '추첨 정보가 있어 비어 있지 않은 슬롯의 번호들의 목록입니다.',
+    },
+    onChange: {
+      description: '슬롯의 정보가 변경되어야 할 때 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof SlotPagination>;
 
 export default meta;

--- a/components/RandomDefenseCreateMenu/AlgorithmSearchInput/AlgorithmSearchInput.stories.tsx
+++ b/components/RandomDefenseCreateMenu/AlgorithmSearchInput/AlgorithmSearchInput.stories.tsx
@@ -8,6 +8,15 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/RandomDefenseCreateMenu/AlgorithmSearchInput',
   component: AlgorithmSearchInput,
+  argTypes: {
+    selectedAlgorithmIds: {
+      description: '인풋 컴포넌트에 선택된 알고리즘의 ID 목록입니다.',
+    },
+    onChange: {
+      description:
+        '선택되어 있는 알고리즘의 ID가 변경되어야 할 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof AlgorithmSearchInput>;
 
 export default meta;

--- a/components/RandomDefenseCreateMenu/AlgorithmSearchInput/AlgorithmSearchInput.stories.tsx
+++ b/components/RandomDefenseCreateMenu/AlgorithmSearchInput/AlgorithmSearchInput.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import AlgorithmSearchInput from './AlgorithmSearchInput';
+import { fn } from '@storybook/test';
 
 /**
  * `AlgorithmSearchInput`는 검색에 활용할 알고리즘들을 관리할 수 있는 인풋 컴포넌트입니다. 정확한 알고리즘을 등록할 수 있도록 검색에 기반하여 알고리즘 분류들을 추가할 수 있으며, 이미 추가한 알고리즘들도 단순 클릭을 통해 쉽게 지울 수 있습니다.
@@ -30,9 +31,7 @@ export const Default: Story = {
   ],
   args: {
     selectedAlgorithmIds: [8, 35, 82],
-    onChange: (algorithmIds) => {
-      alert(`onChange([${algorithmIds.join(', ')}])`);
-    },
+    onChange: fn(),
   },
 };
 
@@ -56,8 +55,6 @@ export const ReachedLimit: Story = {
   ],
   args: {
     selectedAlgorithmIds: [8, 35, 82, 127, 40],
-    onChange: (algorithmIds) => {
-      alert(`onChange([${algorithmIds.join(', ')}])`);
-    },
+    onChange: fn(),
   },
 };

--- a/components/RandomDefenseCreateMenu/AlgorithmSearchInput/MiniAlgorithmButton/MIniAlgorithmButton.stories.tsx
+++ b/components/RandomDefenseCreateMenu/AlgorithmSearchInput/MiniAlgorithmButton/MIniAlgorithmButton.stories.tsx
@@ -9,6 +9,21 @@ const meta = {
   title:
     'components/RandomDefenseCreateMenu/AlgorithmSearchInput/MiniAlgorithmButton',
   component: MiniAlgorithmButton,
+  argTypes: {
+    id: {
+      description: '알고리즘 분류의 ID입니다.',
+    },
+    name: {
+      description: '알고리즘 분류의 이름입니다.',
+    },
+    mode: {
+      description:
+        '이 컴포넌트의 **용도**를 의미합니다. 클릭할 경우 해당 알고리즘 분류를 목록에서 추가하는 `add` 모드와, 클릭할 경우 해당 알고리즘 분류를 목록에서 제거하는 `delete` 모드 중 용도에 맞게 하나를 선택하여 사용할 수 있습니다.',
+    },
+    onClick: {
+      description: '클릭되었을 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof MiniAlgorithmButton>;
 
 export default meta;

--- a/components/RandomDefenseCreateMenu/AlgorithmSearchInput/MiniAlgorithmButton/MIniAlgorithmButton.stories.tsx
+++ b/components/RandomDefenseCreateMenu/AlgorithmSearchInput/MiniAlgorithmButton/MIniAlgorithmButton.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import MiniAlgorithmButton from './MiniAlgorithmButton';
+import { fn } from '@storybook/test';
 
 /**
  * `MiniAlgorithmButton`는 검색에 사용할 알고리즘을 정하는 `AlgorithmSearchInput` 컴포넌트의 하위 컴포넌트입니다. 클릭 시 용도에 따라 새로운 알고리즘을 추가하거나, 이미 지정된 알고리즘을 목록에서 제거하는 기능을 수행합니다.
@@ -22,9 +23,7 @@ export const DeleteMode: Story = {
     id: 2,
     name: '그리디 알고리즘',
     mode: 'delete',
-    onClick: (algorithm) => {
-      alert(`onClick(${JSON.stringify(algorithm)})`);
-    },
+    onClick: fn(),
   },
 };
 
@@ -36,8 +35,6 @@ export const AddMode: Story = {
     id: 1,
     name: '그리디 알고리즘',
     mode: 'add',
-    onClick: (algorithm) => {
-      alert(`onClick(${JSON.stringify(algorithm)})`);
-    },
+    onClick: fn(),
   },
 };

--- a/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/DifficultyAdjustMenu.stories.tsx
+++ b/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/DifficultyAdjustMenu.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import DifficultyAdjustMenu from './DifficultyAdjustMenu';
+import { fn } from '@storybook/test';
 
 /**
  * `DifficultyAdjustMenu`는 무작위 추첨에서 난이도의 범위를 설정할 수 있는 메뉴형 컴포넌트입니다.
@@ -18,8 +19,6 @@ export const Default: Story = {
   args: {
     startTier: 1,
     endTier: 30,
-    onChange: (start, end) => {
-      alert(`onChange(${start}, ${end})`);
-    },
+    onChange: fn(),
   },
 };

--- a/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/DifficultyAdjustMenu.stories.tsx
+++ b/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/DifficultyAdjustMenu.stories.tsx
@@ -8,7 +8,17 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/RandomDefenseCreateMenu/DifficultyAdjustMenu',
   component: DifficultyAdjustMenu,
-  argTypes: {},
+  argTypes: {
+    startTier: {
+      description: '난이도 범위에서의 **시작 티어**입니다.',
+    },
+    endTier: {
+      description: '난이도 범위에서의 **끝 티어**입니다.',
+    },
+    onChange: {
+      description: '난이도 범위가 변경되어야 할 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof DifficultyAdjustMenu>;
 
 export default meta;

--- a/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierPresetButtonList/TierPresetButton/TierPresetButton.stories.tsx
+++ b/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierPresetButtonList/TierPresetButton/TierPresetButton.stories.tsx
@@ -9,7 +9,14 @@ const meta = {
   title:
     'components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierPresetButton',
   component: TierPresetButton,
-  argTypes: {},
+  argTypes: {
+    rank: {
+      description: '버튼에서 사용할 **랭크**를 의미합니다.',
+    },
+    onClick: {
+      description: '버튼이 클릭될 경우 실행시킬 콜백 함수를 의미합니다.',
+    },
+  },
 } satisfies Meta<typeof TierPresetButton>;
 
 export default meta;

--- a/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierPresetButtonList/TierPresetButton/TierPresetButton.stories.tsx
+++ b/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierPresetButtonList/TierPresetButton/TierPresetButton.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import TierPresetButton from './TierPresetButton';
+import { fn } from '@storybook/test';
 
 /**
  * `TierPresetButton`은 무작위 추첨에서 티어를 설정할 때, 티어를 특정 범위로 빠르게 지정할 수 있는 버튼입니다.
@@ -18,62 +19,48 @@ type Story = StoryObj<typeof meta>;
 export const Unrated: Story = {
   args: {
     rank: 'unrated',
-    onClick: (start, end) => {
-      alert(`onClick(${start}, ${end})`);
-    },
+    onClick: fn(),
   },
 };
 
 export const Bronze: Story = {
   args: {
     rank: 'bronze',
-    onClick: (start, end) => {
-      alert(`onClick(${start}, ${end})`);
-    },
+    onClick: fn(),
   },
 };
 
 export const Silver: Story = {
   args: {
     rank: 'silver',
-    onClick: (start, end) => {
-      alert(`onClick(${start}, ${end})`);
-    },
+    onClick: fn(),
   },
 };
 
 export const Gold: Story = {
   args: {
     rank: 'gold',
-    onClick: (start, end) => {
-      alert(`onClick(${start}, ${end})`);
-    },
+    onClick: fn(),
   },
 };
 
 export const Platinum: Story = {
   args: {
     rank: 'platinum',
-    onClick: (start, end) => {
-      alert(`onClick(${start}, ${end})`);
-    },
+    onClick: fn(),
   },
 };
 
 export const Diamond: Story = {
   args: {
     rank: 'diamond',
-    onClick: (start, end) => {
-      alert(`onClick(${start}, ${end})`);
-    },
+    onClick: fn(),
   },
 };
 
 export const Ruby: Story = {
   args: {
     rank: 'ruby',
-    onClick: (start, end) => {
-      alert(`onClick(${start}, ${end})`);
-    },
+    onClick: fn(),
   },
 };

--- a/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierPresetButtonList/TierPresetButtonList.stories.tsx
+++ b/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierPresetButtonList/TierPresetButtonList.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import TierPresetButtonList from './TierPresetButtonList';
+import { fn } from '@storybook/test';
 
 /**
  * `TierPresetButtonList`은 무작위 추첨에서 티어를 설정할 때, 티어를 특정 범위로 빠르게 지정할 수 있는 버튼들을 모아둔 메뉴입니다.
@@ -17,8 +18,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    onClick: (start, end) => {
-      alert(`onClick(${start}, ${end});`);
-    },
+    onClick: fn(),
   },
 };

--- a/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierPresetButtonList/TierPresetButtonList.stories.tsx
+++ b/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierPresetButtonList/TierPresetButtonList.stories.tsx
@@ -9,7 +9,12 @@ const meta = {
   title:
     'components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierPresetButtonList',
   component: TierPresetButtonList,
-  argTypes: {},
+  argTypes: {
+    onClick: {
+      description:
+        '이 리스트의 버튼이 클릭되었을 경우 실행시킬 콜백 함수입니다. 이 때 변경해야 하는 티어 범위와 함께 실행됩니다.',
+    },
+  },
 } satisfies Meta<typeof TierPresetButtonList>;
 
 export default meta;

--- a/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierSlider/TierSlider.stories.tsx
+++ b/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierSlider/TierSlider.stories.tsx
@@ -9,7 +9,17 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierSlider',
   component: TierSlider,
-  argTypes: {},
+  argTypes: {
+    startTier: {
+      description: '난이도 범위에서의 **시작 티어**입니다.',
+    },
+    endTier: {
+      description: '난이도 범위에서의 **끝 티어**입니다.',
+    },
+    onChange: {
+      description: '난이도 범위가 변경되어야 할 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof TierSlider>;
 
 export default meta;

--- a/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierSlider/TierSlider.stories.tsx
+++ b/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierSlider/TierSlider.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import TierSlider from './TierSlider';
 import type { TierWithoutNotRatable } from '@/types/randomDefense';
+import { fn } from '@storybook/test';
 
 /**
  * `TierSlider`는 무작위 추첨에서 티어의 범위를 조절할 수 있는 슬라이더 형태의 컴포넌트입니다.
@@ -19,8 +20,6 @@ export const Default: Story = {
   args: {
     startTier: 1,
     endTier: 30,
-    onChange: (start: TierWithoutNotRatable, end: TierWithoutNotRatable) => {
-      alert(`onChange(${start}, ${end})`);
-    },
+    onChange: fn(),
   },
 };

--- a/components/RandomDefenseCreateMenu/RandomDefenseCapsuleButton/RandomDefenseCapsuleButton.stories.tsx
+++ b/components/RandomDefenseCreateMenu/RandomDefenseCapsuleButton/RandomDefenseCapsuleButton.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import RandomDefenseCapsuleButton from './RandomDefenseCapsuleButton';
+import { fn } from '@storybook/test';
 
 /**
  * `RandomDefenseCapsuleButton`는 추첨 생성 메뉴에서 모드를 스위칭할 수 있는 캡슐 모양의 버튼입니다.
@@ -17,17 +18,13 @@ type Story = StoryObj<typeof meta>;
 export const EasyMode: Story = {
   args: {
     mode: 'easy',
-    onClick: (mode) => {
-      alert(`onClick('${mode}')`);
-    },
+    onClick: fn(),
   },
 };
 
 export const ManualMode: Story = {
   args: {
     mode: 'manual',
-    onClick: (mode) => {
-      alert(`onClick('${mode}')`);
-    },
+    onClick: fn(),
   },
 };

--- a/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.stories.tsx
+++ b/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import RandomDefenseCreateButton from './RandomDefenseCreateButton';
+import { fn } from '@storybook/test';
 
 /**
  * `RandomDefenseCreateButton`는 추첨 생성 메뉴에서 추첨 생성 확정 시 사용될 버튼입니다. 추첨이 생성될 슬롯의 번호를 알려주는 역할도 겸합니다.
@@ -18,9 +19,7 @@ export const Default: Story = {
   args: {
     selectedSlotNo: 1,
     isLoaded: true,
-    onClick: () => {
-      alert('onClick()');
-    },
+    onClick: fn(),
   },
 };
 
@@ -31,8 +30,6 @@ export const Loading: Story = {
   args: {
     selectedSlotNo: 1,
     isLoaded: false,
-    onClick: () => {
-      alert('onClick()');
-    },
+    onClick: fn(),
   },
 };

--- a/components/RandomDefenseCreateMenu/RandomDefenseCreateMenu.stories.tsx
+++ b/components/RandomDefenseCreateMenu/RandomDefenseCreateMenu.stories.tsx
@@ -7,7 +7,18 @@ import RandomDefenseCreateMenu from './RandomDefenseCreateMenu';
 const meta = {
   title: 'components/RandomDefenseCreateMenu',
   component: RandomDefenseCreateMenu,
-  argTypes: {},
+  argTypes: {
+    selectedSlotNo: {
+      description: '현재 선택되어 있는 슬롯의 번호입니다.',
+    },
+    isLoaded: {
+      description: '본 컴포넌트가 로드되었는지를 의미합니다.',
+    },
+    onSubmit: {
+      description:
+        '사용자가 추첨 생성 버튼을 눌러 새로운 추첨 결과를 생성하기 위해 정보를 보낼 때 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof RandomDefenseCreateMenu>;
 
 export default meta;

--- a/components/RandomDefenseCreateMenu/SearchOperatorSelect/SearchOperatorSelect.stories.tsx
+++ b/components/RandomDefenseCreateMenu/SearchOperatorSelect/SearchOperatorSelect.stories.tsx
@@ -8,7 +8,15 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/RandomDefenseCreateMenu/SearchOperatorSelect',
   component: SearchOperatorSelect,
-  argTypes: {},
+  argTypes: {
+    searchOperator: {
+      description:
+        '선택되어 있는 **연산자**를 의미합니다. **연산자**의 값이 어떤가에 따라 추첨 생성 시 생성되는 쿼리의 방식이 달라집니다. `AND`가 선택된 경우에는 해당되는 알고리즘을 포함하는 경우, `OR`는 해당되는 알고리즘 중 적어도 하나를 포함하는 경우, `NOR`는 해당되는 알고리즘을 모두 포함하지 않는 경우를 의미합니다.',
+    },
+    onClick: {
+      description: '연산자가 변경되어야 할 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof SearchOperatorSelect>;
 
 export default meta;

--- a/components/RandomDefenseCreateMenu/SearchOperatorSelect/SearchOperatorSelect.stories.tsx
+++ b/components/RandomDefenseCreateMenu/SearchOperatorSelect/SearchOperatorSelect.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import SearchOperatorSelect from './SearchOperatorSelect';
+import { fn } from '@storybook/test';
 
 /**
  * `SearchOperatorSelect`는 추첨 생성 폼에서, 검색에 포함할 알고리즘들의 검색 방법을 정할 수 있는 컴포넌트입니다. 보다 구체적으로는, 여러 개의 알고리즘을 쿼리에 포함시킬 때, 사용할 연산자(`|`, `&`, `-`)를 정할 수 있습니다.
@@ -17,8 +18,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     searchOperator: 'AND',
-    onClick: (searchOperator) => {
-      alert(`onClick('${searchOperator}')`);
-    },
+    onClick: fn(),
   },
 };

--- a/components/RandomDefenseHistoryMenu/RandomDefenseHistoryList/RandomDefenseHistoryItem/RandomDefenseHistoryItem.stories.tsx
+++ b/components/RandomDefenseHistoryMenu/RandomDefenseHistoryList/RandomDefenseHistoryItem/RandomDefenseHistoryItem.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import RandomDefenseHistoryItem from './RandomDefenseHistoryItem';
+import { fn } from '@storybook/test';
 
 /**
  * `RandomDefenseHistoryItem`는 추첨 기록에서 추첨된 문제 하나의 정보를 보여주는 컴포넌트입니다.
@@ -21,9 +22,7 @@ export const Bronze: Story = {
     tier: 1,
     createdAt: '2025-01-01T23:35:00.123Z',
     isHidden: false,
-    onDelete: () => {
-      alert(`onDelete()`);
-    },
+    onDelete: fn(),
   },
 };
 
@@ -34,9 +33,7 @@ export const Silver: Story = {
     tier: 6,
     createdAt: '2025-01-01T23:35:00.123Z',
     isHidden: false,
-    onDelete: () => {
-      alert(`onDelete()`);
-    },
+    onDelete: fn(),
   },
 };
 
@@ -47,9 +44,7 @@ export const Gold: Story = {
     tier: 11,
     createdAt: '2025-01-01T23:35:00.123Z',
     isHidden: false,
-    onDelete: () => {
-      alert(`onDelete()`);
-    },
+    onDelete: fn(),
   },
 };
 
@@ -60,9 +55,7 @@ export const Platinum: Story = {
     tier: 16,
     createdAt: '2025-01-01T23:35:00.123Z',
     isHidden: false,
-    onDelete: () => {
-      alert(`onDelete()`);
-    },
+    onDelete: fn(),
   },
 };
 
@@ -73,9 +66,7 @@ export const Diamond: Story = {
     tier: 21,
     createdAt: '2025-01-01T23:35:00.123Z',
     isHidden: false,
-    onDelete: () => {
-      alert(`onDelete()`);
-    },
+    onDelete: fn(),
   },
 };
 
@@ -86,9 +77,7 @@ export const Ruby: Story = {
     tier: 26,
     createdAt: '2025-01-01T23:35:00.123Z',
     isHidden: false,
-    onDelete: () => {
-      alert(`onDelete()`);
-    },
+    onDelete: fn(),
   },
 };
 
@@ -99,9 +88,7 @@ export const Unrated: Story = {
     tier: 0,
     createdAt: '2025-01-01T23:35:00.123Z',
     isHidden: false,
-    onDelete: () => {
-      alert(`onDelete()`);
-    },
+    onDelete: fn(),
   },
 };
 
@@ -112,9 +99,7 @@ export const NotRatable: Story = {
     tier: 31,
     createdAt: '2025-01-01T23:35:00.123Z',
     isHidden: false,
-    onDelete: () => {
-      alert(`onDelete()`);
-    },
+    onDelete: fn(),
   },
 };
 
@@ -125,9 +110,7 @@ export const Hidden: Story = {
     tier: 1,
     createdAt: '2025-01-01T23:35:00.123Z',
     isHidden: true,
-    onDelete: () => {
-      alert(`onDelete()`);
-    },
+    onDelete: fn(),
   },
 };
 
@@ -138,8 +121,6 @@ export const LongTitle: Story = {
     tier: 15,
     createdAt: '2025-01-01T23:35:00.123Z',
     isHidden: false,
-    onDelete: () => {
-      alert('onDelete()');
-    },
+    onDelete: fn(),
   },
 };

--- a/components/RandomDefenseHistoryMenu/RandomDefenseHistoryList/RandomDefenseHistoryItem/RandomDefenseHistoryItem.stories.tsx
+++ b/components/RandomDefenseHistoryMenu/RandomDefenseHistoryList/RandomDefenseHistoryItem/RandomDefenseHistoryItem.stories.tsx
@@ -8,7 +8,26 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/RandomDefenseHistoryMenu/RandomDefenseHistoryItem',
   component: RandomDefenseHistoryItem,
-  argTypes: {},
+  argTypes: {
+    problemId: {
+      description: '이 추첨 기록의 문제 번호입니다.',
+    },
+    title: {
+      description: '이 추첨 기록의 문제의 제목입니다.',
+    },
+    tier: {
+      description: '이 추첨 기록의 문제에 책정되어 있는 난이도(티어)입니다.',
+    },
+    createdAt: {
+      description: '해당 문제에 대응되는 추첨 결과가 실행된 시각입니다.',
+    },
+    isHidden: {
+      description: '이 추첨 기록의 문제 티어가 가려져 있는지의 여부입니다.',
+    },
+    onDelete: {
+      description: '이 추첨 기록을 지워야 할 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof RandomDefenseHistoryItem>;
 
 export default meta;

--- a/components/RandomDefenseHistoryMenu/RandomDefenseHistoryList/RandomDefenseHistoryList.stories.tsx
+++ b/components/RandomDefenseHistoryMenu/RandomDefenseHistoryList/RandomDefenseHistoryList.stories.tsx
@@ -9,7 +9,19 @@ import type { RandomDefenseHistoryInfo } from '@/types/randomDefense';
 const meta = {
   title: 'components/RandomDefenseHistoryMenu/RandomDefenseHistoryList',
   component: RandomDefenseHistoryList,
-  argTypes: {},
+  argTypes: {
+    items: {
+      description: '추첨 기록들의 목록입니다.',
+    },
+    isHidden: {
+      description:
+        '추첨 기록들의 티어가 가려져야 하는지의 여부입니다. `true`일 경우 기록에 있는 모든 추첨 기록의 티어를 감춥니다.',
+    },
+    onDelete: {
+      description:
+        '추첨 기록 중 하나가 삭제되어야 할 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof RandomDefenseHistoryList>;
 
 export default meta;

--- a/components/RandomDefenseHistoryMenu/RandomDefenseHistoryList/RandomDefenseHistoryList.stories.tsx
+++ b/components/RandomDefenseHistoryMenu/RandomDefenseHistoryList/RandomDefenseHistoryList.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import RandomDefenseHistoryList from './RandomDefenseHistoryList';
+import { fn } from '@storybook/test';
 import type { RandomDefenseHistoryInfo } from '@/types/randomDefense';
 
 /**
@@ -70,8 +71,6 @@ export const Default: Story = {
   args: {
     items,
     isHidden: false,
-    onDelete: (id) => {
-      alert(`onDelete("${id}")`);
-    },
+    onDelete: fn(),
   },
 };

--- a/components/TierDropdown/TierDropdown.stories.tsx
+++ b/components/TierDropdown/TierDropdown.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import TierDropdown from './TierDropdown';
+import { fn } from '@storybook/test';
 
 /**
  * `TierDropdown`은 사용자에게 solved.ac 티어 하나를 선택할 수 있는 기능을 제공하는 드롭다운 형태의 컴포넌트입니다.
@@ -23,5 +24,6 @@ export const Default: Story = {
   ],
   args: {
     selectedTier: 1,
+    onChange: fn(),
   },
 };

--- a/components/TierDropdown/TierDropdown.stories.tsx
+++ b/components/TierDropdown/TierDropdown.stories.tsx
@@ -8,6 +8,14 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/TierDropdown',
   component: TierDropdown,
+  argTypes: {
+    selectedTier: {
+      description: '현재 선택되어 있는 티어입니다.',
+    },
+    onChange: {
+      description: '티어가 변경되어야 할 때 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof TierDropdown>;
 
 export default meta;

--- a/components/Widget/Widget.stories.tsx
+++ b/components/Widget/Widget.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Widget from './Widget';
+import { fn } from '@storybook/test';
 
 /**
  * `Widget`는 BOJ 웹사이트에서 토탐정의 기능을 쉽게 이용하기 위해, 우측 하단에 표시되는 위젯입니다. 평소에는 TOP 버튼으로써 이용되며, 우클릭 시 위젯의 메뉴를 펼치거나 접을 수 있습니다.
@@ -24,8 +25,7 @@ export const Default: Story = {
   ],
   args: {
     theme: 'none',
-    onChangeTheme: () => {
-      alert('onChangeTheme()');
-    },
+    onChangeTheme: fn(),
+    onToast: fn(),
   },
 };

--- a/components/Widget/Widget.stories.tsx
+++ b/components/Widget/Widget.stories.tsx
@@ -8,7 +8,17 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/Widget',
   component: Widget,
-  argTypes: {},
+  argTypes: {
+    theme: {
+      description: '위젯에 적용될 테마입니다.',
+    },
+    onChangeTheme: {
+      description: '테마를 변경해야 할 경우 실행시킬 콜백 함수입니다.',
+    },
+    onToast: {
+      description: '토스트를 띄워야 할 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof Widget>;
 
 export default meta;

--- a/components/common/Checkbox/Checkbox.stories.tsx
+++ b/components/common/Checkbox/Checkbox.stories.tsx
@@ -12,6 +12,9 @@ const meta = {
     isChecked: {
       description: '체크박스의 체크 여부를 의미합니다.',
     },
+    ariaLabel: {
+      description: '`aria-label` 속성입니다.',
+    },
     onChange: {
       description:
         '체크박스의 체크 여부가 달라지는 경우 실행하게 될 함수를 의미합니다.',

--- a/components/common/Checkbox/Checkbox.stories.tsx
+++ b/components/common/Checkbox/Checkbox.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Checkbox from './Checkbox';
+import { fn } from '@storybook/test';
 
 /**
  * `Checkbox`는 공용 체크박스 컴포넌트입니다. 크기가 작기 때문에 단독으로 쓰이기보다는 다른 요소들과 같이 쓰입니다.
@@ -26,9 +27,7 @@ export const Checked: Story = {
   args: {
     isChecked: true,
     ariaLabel: '다이나믹 프로그래밍',
-    onChange: () => {
-      alert('onChange()');
-    },
+    onChange: fn(),
   },
 };
 
@@ -36,8 +35,6 @@ export const NotChecked: Story = {
   args: {
     isChecked: false,
     ariaLabel: '다이나믹 프로그래밍',
-    onChange: () => {
-      alert('onChange()');
-    },
+    onChange: fn(),
   },
 };

--- a/components/common/CircleProgressBar/CircleProgressBar.stories.tsx
+++ b/components/common/CircleProgressBar/CircleProgressBar.stories.tsx
@@ -8,12 +8,23 @@ const meta = {
   title: 'components/CircleProgressBar',
   component: CircleProgressBar,
   argTypes: {
+    size: {
+      description: '프로그레스 바의 크기입니다.',
+    },
     progress: {
+      description:
+        '프로그레스 바가 얼마나 채워져 있는가를 의미합니다. **이 값은 0 이상 100 이하의 수여야 합니다.**',
       control: {
         type: 'range',
         min: 0,
         max: 100,
       },
+    },
+    color: {
+      description: '프로그레스 바의, **채워져 있는 부분**의 색상입니다.',
+    },
+    trackColor: {
+      description: '프로그레스 바의, **채워져 있지 않은 부분**의 색상입니다.',
     },
   },
 } satisfies Meta<typeof CircleProgressBar>;

--- a/components/common/ErrorText/ErrorText.stories.tsx
+++ b/components/common/ErrorText/ErrorText.stories.tsx
@@ -9,6 +9,18 @@ import ErrorText from './ErrorText';
 const meta = {
   title: 'components/common/ErrorText',
   component: ErrorText,
+  argTypes: {
+    fontSize: {
+      description: '에러 메시지의 폰트 크기입니다.',
+    },
+    errorMessage: {
+      description: '에러 메시지에 보여질 텍스트입니다.',
+    },
+    height: {
+      description:
+        '에러 메시지의 높이입니다. 이 값은 필수로 명시하지 않아도 되며, 에러 메시지가 길어져 컴포넌트의 범위를 벗어날 가능성이 있을 경우 미리 컴포넌트의 높이를 설정해둘 때 사용할 수 있습니다.',
+    },
+  },
 } satisfies Meta<typeof ErrorText>;
 
 export default meta;

--- a/components/common/Fieldset/Fieldset.stories.tsx
+++ b/components/common/Fieldset/Fieldset.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Fieldset from './Fieldset';
 import Input from '../Input';
+import { fn } from '@storybook/test';
 
 /**
  * `Fieldset`는 어느 하나의 주제에 대해 사용자가 원하는 옵션을 선택할 수 있도록 해주는 컴포넌트입니다. 각 옵션에는 평범하게 `string`을 사용하거나, `ReactNode`와 같은 컴포넌트를 사용할 수 있습니다.
@@ -71,9 +72,7 @@ export const Default: Story = {
     name: 'favoriteFruit',
     options,
     checkedValue: 'apple',
-    onChange: (value: string) => {
-      alert(`onChange('${value}')`);
-    },
+    onChange: fn(),
   },
 };
 
@@ -84,9 +83,7 @@ export const Vertical: Story = {
     options,
     checkedValue: 'apple',
     isVertical: true,
-    onChange: (value: string) => {
-      alert(`onChange('${value}')`);
-    },
+    onChange: fn(),
   },
 };
 
@@ -99,9 +96,7 @@ export const TooManyOptions: Story = {
     name: 'tooManyOptions',
     options: randomOptions,
     checkedValue: randomOptions[0].value,
-    onChange: (value: string) => {
-      alert(`onChange('${value}')`);
-    },
+    onChange: fn(),
   },
 };
 
@@ -115,9 +110,7 @@ export const ComponentOptions: Story = {
     options: optionsWithImages,
     checkedValue: 'apple',
     isVertical: true,
-    onChange: (value: string) => {
-      alert(`onChange('${value}')`);
-    },
+    onChange: fn(),
   },
 };
 
@@ -132,8 +125,6 @@ export const Disabled: Story = {
     options,
     checkedValue: 'apple',
     disabled: true,
-    onChange: (value: string) => {
-      alert(`onChange('${value}')`);
-    },
+    onChange: fn(),
   },
 };

--- a/components/common/Fieldset/Fieldset.stories.tsx
+++ b/components/common/Fieldset/Fieldset.stories.tsx
@@ -9,6 +9,39 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/common/Fieldset',
   component: Fieldset,
+  argTypes: {
+    legend: {
+      description: '필드셋의 제목입니다.',
+    },
+    name: {
+      description:
+        '**폼 제출 시** 사용될 `name`값입니다. 실제로 **필드셋에 보이는 제목이 아님**에 유의하세요.',
+    },
+    options: {
+      description:
+        '필드셋의 여러 옵션으로 구성된 목록입니다. 각 옵션의 이름을 여기에 명시하면 됩니다.',
+    },
+    checkedValue: {
+      description: '현재 선택되어 있는 옵션입니다.',
+    },
+    onChange: {
+      description:
+        '필드셋에 체크되어 있는 항목이 변경되어야 할 경우 실행시킬 콜백 함수입니다.',
+    },
+    disabled: {
+      description: '필드셋이 비활성화되어 있는지의 여부입니다.',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
+    isVertical: {
+      description:
+        '필드셋의 옵션들을 한 줄에 하나씩, 세로로 정렬해서 표시할 것인지의 여부입니다.',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
+  },
 } satisfies Meta<typeof Fieldset>;
 
 export default meta;

--- a/components/common/IconButton/IconButton.stories.tsx
+++ b/components/common/IconButton/IconButton.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import IconButton from './IconButton';
 import { PackageIcon } from '@/assets/svg';
+import { fn } from '@storybook/test';
 
 /**
  * `IconButton`은 범용적으로 사용할 수 있는 버튼 컴포넌트입니다. 일반 이미지 형태의 아이콘과 svg 형태의 아이콘 중 원하는 것을 골라 사용할 수 있으며, 사용하지 않고 텍스트만 표시되는 버튼으로도 사용할 수 있습니다.
@@ -27,9 +28,7 @@ export const MediumWithSvgIcon: Story = {
     iconSrc: <PackageIcon />,
     disabled: false,
     ariaLabel: '테스트용 버튼',
-    onClick: () => {
-      alert('onClick()');
-    },
+    onClick: () => fn(),
   },
 };
 
@@ -42,9 +41,7 @@ export const MediumWithSvgIconDisabled: Story = {
     iconSrc: <PackageIcon />,
     disabled: true,
     ariaLabel: '테스트용 버튼',
-    onClick: () => {
-      alert('onClick()');
-    },
+    onClick: () => fn(),
   },
 };
 
@@ -57,9 +54,7 @@ export const LargeWithSvgIcon: Story = {
     iconSrc: <PackageIcon />,
     disabled: false,
     ariaLabel: '테스트용 버튼',
-    onClick: () => {
-      alert('onClick()');
-    },
+    onClick: () => fn(),
   },
 };
 
@@ -72,9 +67,7 @@ export const MediumWithImageIcon: Story = {
     iconSrc: YOUTUBE_IMAGE_ICON_SRC,
     disabled: false,
     ariaLabel: '테스트용 버튼',
-    onClick: () => {
-      alert('onClick()');
-    },
+    onClick: () => fn(),
   },
 };
 
@@ -87,9 +80,7 @@ export const LargeWithImageIcon: Story = {
     iconSrc: YOUTUBE_IMAGE_ICON_SRC,
     disabled: false,
     ariaLabel: '테스트용 버튼',
-    onClick: () => {
-      alert('onClick()');
-    },
+    onClick: () => fn(),
   },
 };
 
@@ -101,9 +92,7 @@ export const MediumWithNoIcon: Story = {
     color: '#d9d9d9',
     disabled: false,
     ariaLabel: '테스트용 버튼',
-    onClick: () => {
-      alert('onClick()');
-    },
+    onClick: () => fn(),
   },
 };
 
@@ -115,8 +104,6 @@ export const LargeWithNoIcon: Story = {
     color: '#d9d9d9',
     disabled: false,
     ariaLabel: '테스트용 버튼',
-    onClick: () => {
-      alert('onClick()');
-    },
+    onClick: () => fn(),
   },
 };

--- a/components/common/IconButton/IconButton.stories.tsx
+++ b/components/common/IconButton/IconButton.stories.tsx
@@ -9,7 +9,46 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/common/IconButton',
   component: IconButton,
-  argTypes: {},
+  argTypes: {
+    type: {
+      description: '버튼의 `type`입니다.',
+    },
+    name: {
+      description: '버튼에 표시할 텍스트입니다.',
+    },
+    size: {
+      description: '버튼의 크기입니다.',
+    },
+    color: {
+      description: '버튼의 색상입니다.',
+    },
+    iconSrc: {
+      description: '버튼의 좌측에 표시할 아이콘의 경로입니다.',
+      control: false,
+    },
+    disabled: {
+      description: '버튼이 비활성화되어 있는지의 여부입니다.',
+    },
+    ariaLabel: {
+      description: '버튼의 `aria-label`입니다.',
+    },
+    onClick: {
+      description: '버튼이 클릭될 경우 실행시킬 콜백 함수입니다.',
+    },
+    width: {
+      description: '버튼의 가로 길이입니다.',
+      table: {
+        defaultValue: { summary: 'auto' },
+      },
+    },
+    autoFocus: {
+      description:
+        '이 버튼이 생성될 때, 자동으로 포커스를 줄 것인지의 여부입니다.',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
+  },
 } satisfies Meta<typeof IconButton>;
 
 export default meta;

--- a/components/common/Input/Input.stories.tsx
+++ b/components/common/Input/Input.stories.tsx
@@ -8,6 +8,43 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/common/Input',
   component: Input,
+  argTypes: {
+    type: {
+      description: '인풋 컴포넌트의 `type`입니다.',
+    },
+    width: {
+      description: '인풋 컴포넌트의 가로 길이입니다.',
+    },
+    value: {
+      description: '인풋 컴포넌트에 적혀있는 값입니다.',
+    },
+    textAlign: {
+      description: '인풋 컴포넌트에 적힌 텍스트의 정렬 방법입니다.',
+    },
+    placeholder: {
+      description:
+        '인풋 컴포넌트의 `placeholder`입니다. 입력을 시작하기 전 보여지는 힌트 문구를 의미합니다.',
+    },
+    hasError: {
+      description:
+        '에러 발생 여부입니다. 에러가 발생한 경우에는 인풋 컴포넌트의 윤곽선이 붉은색이 됩니다.',
+    },
+    ariaLabel: {
+      description: '인풋 컴포넌트의 `aria-label`입니다.',
+    },
+    onChange: {
+      description: '인풋 컴포넌트의 값이 변경될 경우 실행시킬 콜백 함수입니다.',
+    },
+    name: {
+      description: '인풋 컴포넌트의 `name`입니다.',
+    },
+    minLength: {
+      description: '인풋 컴포넌트에 적을 수 있는 최소 문자 수입니다.',
+    },
+    maxLength: {
+      description: '인풋 컴포넌트에 적을 수 있는 최대 문자 수입니다.',
+    },
+  },
 } satisfies Meta<typeof Input>;
 
 export default meta;

--- a/components/common/Input/Input.stories.tsx
+++ b/components/common/Input/Input.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Input from './Input';
+import { fn } from '@storybook/test';
 
 /**
  * `Input`는 공통 인풋 컴포넌트입니다.
@@ -22,6 +23,7 @@ export const Default: Story = {
     placeholder: '마음가는 대로 입력해 보세요',
     hasError: false,
     ariaLabel: '아무 값이든 입력해 보세요',
+    onChange: fn(),
   },
 };
 
@@ -34,5 +36,6 @@ export const Error: Story = {
     placeholder: '사람은 누구나 실수를 하죠',
     hasError: true,
     ariaLabel: '아무 값이든 입력해 보세요',
+    onChange: fn(),
   },
 };

--- a/components/common/Modal/Modal.stories.tsx
+++ b/components/common/Modal/Modal.stories.tsx
@@ -11,7 +11,17 @@ import { CheckCircleIcon, CloseCircleIcon } from '@/assets/svg';
 const meta = {
   title: 'components/common/Modal',
   component: Modal,
-  argTypes: {},
+  argTypes: {
+    open: {
+      description: '모달이 열려있는지의 여부입니다.',
+    },
+    title: {
+      description: '모달의 제목입니다.',
+    },
+    onClose: {
+      description: '모달을 닫아야 할 경우 실행시킬 콜백 함수입니다.',
+    },
+  },
 } satisfies Meta<typeof Modal>;
 
 export default meta;

--- a/components/common/NamedFrame/NamedFrame.stories.tsx
+++ b/components/common/NamedFrame/NamedFrame.stories.tsx
@@ -7,7 +7,25 @@ import NamedFrame from './NamedFrame';
 const meta = {
   title: 'components/common/NamedFrame',
   component: NamedFrame,
-  argTypes: {},
+  argTypes: {
+    width: {
+      description: '레이아웃의 가로 길이입니다.',
+    },
+    height: {
+      description: '레이아웃의 세로 길이입니다.',
+    },
+    padding: {
+      description: '레이아웃의 `padding`입니다.',
+    },
+    title: {
+      description: '레이아웃의 제목입니다. 제목의 경우 우측 상단에 표기됩니다.',
+    },
+    children: {
+      description:
+        '`children` prop입니다. 레이아웃의 내부에 담을 컴포넌트를 여기에 명시해주시면 됩니다.',
+      controls: false,
+    },
+  },
 } satisfies Meta<typeof NamedFrame>;
 
 export default meta;

--- a/components/common/Radio/Radio.stories.tsx
+++ b/components/common/Radio/Radio.stories.tsx
@@ -9,12 +9,24 @@ const meta = {
   title: 'components/common/Radio',
   component: Radio,
   argTypes: {
+    name: {
+      description: '라디오의 `name`입니다.',
+    },
+    value: {
+      description: '라디오의 `value`입니다.',
+    },
     checked: {
       description: '라디오의 체크 여부를 의미합니다.',
     },
     onChange: {
       description:
         '라디오의 체크 여부가 달라지는 경우 실행하게 될 함수를 의미합니다.',
+    },
+    disabled: {
+      description: '라디오가 비활성화되어 있는지의 여부입니다.',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
     },
   },
 } satisfies Meta<typeof Radio>;

--- a/components/common/Radio/Radio.stories.tsx
+++ b/components/common/Radio/Radio.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Radio from './Radio';
+import { fn } from '@storybook/test';
 
 /**
  * `Radio`는 공용 라디오 컴포넌트입니다. 크기가 작기 때문에 단독으로 쓰이기보다는 다른 요소들과 같이 쓰입니다.
@@ -30,9 +31,7 @@ export const Checked: Story = {
     name: 'optionName',
     value: 'optionValue',
     checked: true,
-    onChange: (value) => {
-      alert(`onChange('${value}')`);
-    },
+    onChange: fn(),
   },
 };
 
@@ -41,9 +40,7 @@ export const NotChecked: Story = {
     name: 'optionName',
     value: 'optionValue',
     checked: false,
-    onChange: (value) => {
-      alert(`onChange('${value}')`);
-    },
+    onChange: fn(),
   },
 };
 
@@ -53,8 +50,6 @@ export const Disabled: Story = {
     value: 'optionValue',
     checked: false,
     disabled: true,
-    onChange: (value) => {
-      alert(`onChange('${value}')`);
-    },
+    onChange: fn(),
   },
 };

--- a/components/common/SimpleModal/SimpleModal.stories.tsx
+++ b/components/common/SimpleModal/SimpleModal.stories.tsx
@@ -9,6 +9,43 @@ import type { Meta, StoryObj } from '@storybook/react';
 const meta = {
   title: 'components/common/SimpleModal',
   component: SimpleModal,
+  argTypes: {
+    actionType: {
+      description:
+        '모달의 **종류**입니다. 어느 옵션을 선택하느냐에 따라 모달의 하단에 표시되는 버튼의 종류가 달라집니다.',
+    },
+    width: {
+      description: '모달의 가로 길이입니다.',
+    },
+    height: {
+      description: '모달의 세로 길이입니다.',
+    },
+    title: {
+      description: '모달에 표시될 제목입니다.',
+    },
+    message: {
+      description: '모달에 표시할 내용입니다.',
+    },
+    open: {
+      description: '모달이 열려있는 지의 여부입니다.',
+    },
+    onClose: {
+      description:
+        '모달이 닫혀야 할 경우 실행시킬 콜백 함수입니다. **`actionType`가 `confirm`인 경우 확인 버튼을 눌렀을 때 이 함수가 호출됩니다.**',
+    },
+    onConfirm: {
+      description:
+        '모달에서 **확인** 버튼을 누를 경우 실행시킬 콜백 함수입니다. **`actionType`가 `cancelConfirm`인 경우에만 적용됩니다.**',
+    },
+    onYesSelect: {
+      description:
+        '모달에서 **예** 버튼을 누를 경우 실행시킬 콜백 함수입니다. **`actionType`가 `yesNo`인 경우에만 적용됩니다.**',
+    },
+    onNoSelect: {
+      description:
+        '모달에서 **아니요** 버튼을 누를 경우 실행시킬 콜백 함수입니다. **`actionType`가 `yesNo`인 경우에만 적용됩니다.**',
+    },
+  },
 } satisfies Meta<typeof SimpleModal>;
 
 export default meta;

--- a/components/common/Switch/Switch.stories.tsx
+++ b/components/common/Switch/Switch.stories.tsx
@@ -9,12 +9,18 @@ const meta = {
   title: 'components/common/Switch',
   component: Switch,
   argTypes: {
+    size: {
+      description: '스위치의 크기입니다.',
+    },
     isChecked: {
-      description: '스위치의 체크 여부를 의미합니다.',
+      description: '스위치의 체크 여부입니다.',
+    },
+    ariaLabel: {
+      description: '스위치의 `aria-label`입니다.',
     },
     onChange: {
       description:
-        '스위치의 체크 여부가 달라지는 경우 실행하게 될 함수를 의미합니다.',
+        '스위치의 체크 여부가 달라지는 경우 실행하게 될 콜백 함수입니다.',
     },
   },
 } satisfies Meta<typeof Switch>;

--- a/components/common/Switch/Switch.stories.tsx
+++ b/components/common/Switch/Switch.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Switch from './Switch';
+import { fn } from '@storybook/test';
 
 /**
  * `Switch`는 공용 스위치 컴포넌트입니다.
@@ -27,9 +28,7 @@ export const LargeChecked: Story = {
     size: 'large',
     isChecked: true,
     ariaLabel: '테스트',
-    onChange: () => {
-      alert('onChange()');
-    },
+    onChange: fn(),
   },
 };
 
@@ -38,9 +37,7 @@ export const LargeNotChecked: Story = {
     size: 'large',
     isChecked: false,
     ariaLabel: '테스트',
-    onChange: () => {
-      alert('onChange()');
-    },
+    onChange: fn(),
   },
 };
 
@@ -49,9 +46,7 @@ export const MediumChecked: Story = {
     size: 'medium',
     isChecked: true,
     ariaLabel: '테스트',
-    onChange: () => {
-      alert('onChange()');
-    },
+    onChange: fn(),
   },
 };
 
@@ -60,8 +55,6 @@ export const MediumNotChecked: Story = {
     size: 'medium',
     isChecked: false,
     ariaLabel: '테스트',
-    onChange: () => {
-      alert('onChange()');
-    },
+    onChange: fn(),
   },
 };

--- a/components/common/Text/Text.stories.tsx
+++ b/components/common/Text/Text.stories.tsx
@@ -7,6 +7,24 @@ import Text from './Text';
 const meta = {
   title: 'components/common/Text',
   component: Text,
+  argTypes: {
+    type: {
+      description: '텍스트의 디자인 종류입니다.',
+    },
+    fontSize: {
+      description: '텍스트의 폰트 크기입니다.',
+    },
+    children: {
+      description:
+        '`children` prop입니다. 여기에 내용을 명시할 수 있으며, 일부 또는 전부에 스타일을 적용하기 위해 HTML 태그를 사용할 수도 있습니다.',
+    },
+    textAlign: {
+      description: '텍스트를 어느 방향으로 정렬해야 할 지를 의미합니다.',
+      table: {
+        defaultValue: { summary: 'left' },
+      },
+    },
+  },
 } satisfies Meta<typeof Text>;
 
 export default meta;
@@ -19,6 +37,7 @@ export const Primary16px: Story = {
     fontSize: '16px',
     children:
       '아르페지오는 음악 용어로, 연주되는 음을 서로 다른 높낮이로 연속적으로 연주하는 기법을 가리킵니다. 주로 현악기나 기타와 같은 현악 악기에서 사용되며, 반주를 장식하거나 멜로디를 부각시키는 데에 쓰입니다. 이 용어는 이탈리아어 "arpeggiare"에서 비롯되었으며, "하나씩 피다"라는 뜻입니다. 아르페지오는 화음의 구성음들을 순차적으로 연주하여 하나의 화음을 나타내는 방식으로 사용되며, 주로 빠르고 부드러운 연주로 특징지어지며, 서정적이고 우아한 분위기를 만들어냅니다.',
+    textAlign: 'left',
   },
 };
 

--- a/components/common/TextLink/TextLink.stories.tsx
+++ b/components/common/TextLink/TextLink.stories.tsx
@@ -8,6 +8,17 @@ import TextLink from './TextLink';
 const meta = {
   title: 'components/common/TextLink',
   component: TextLink,
+  argTypes: {
+    children: {
+      description: '`children` prop입니다. 여기에 내용을 명시할 수 있습니다.',
+    },
+    fontSize: {
+      description: '텍스트의 폰트 크기입니다.',
+    },
+    href: {
+      description: '클릭 시 이동할 URL입니다.',
+    },
+  },
 } satisfies Meta<typeof TextLink>;
 
 export default meta;

--- a/components/common/Textarea/Textarea.stories.tsx
+++ b/components/common/Textarea/Textarea.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Textarea from './Textarea';
+import { fn } from '@storybook/test';
 
 /**
  * `Textarea`는 사용자가 여러 줄의 내용을 작성할 수 있는 텍스트 입력 영역 컴포넌트입니다.
@@ -21,6 +22,7 @@ export const Default: Story = {
     placeholder: '마음가는 대로 입력해 보세요',
     hasError: false,
     ariaLabel: '아무 값이든 입력해 보세요',
+    onChange: fn(),
   },
 };
 
@@ -32,5 +34,6 @@ export const Error: Story = {
     placeholder: '사람은 누구나 실수를 하죠',
     hasError: true,
     ariaLabel: '아무 값이든 입력해 보세요',
+    onChange: fn(),
   },
 };

--- a/components/common/Textarea/Textarea.stories.tsx
+++ b/components/common/Textarea/Textarea.stories.tsx
@@ -8,6 +8,40 @@ import { fn } from '@storybook/test';
 const meta = {
   title: 'components/common/Textarea',
   component: Textarea,
+  argTypes: {
+    width: {
+      description: '컴포넌트의 가로 길이입니다.',
+    },
+    height: {
+      description: '컴포넌트의 세로 길이입니다.',
+    },
+    value: {
+      description: '현재 입력되어 있는 값입니다.',
+    },
+    placeholder: {
+      description:
+        '컴포넌트의 `placeholder`입니다. 입력을 시작하기 전 보여지는 힌트 문구를 의미합니다.',
+    },
+    hasError: {
+      description:
+        '에러 발생 여부입니다. 에러가 발생한 경우에는 컴포넌트의 윤곽선이 붉은색이 됩니다.',
+    },
+    ariaLabel: {
+      description: '컴포넌트의 `aria-label`입니다.',
+    },
+    onChange: {
+      description: '컴포넌트의 값이 변경될 경우 실행시킬 콜백 함수입니다.',
+    },
+    name: {
+      description: '컴포넌트의 `name`입니다.',
+    },
+    minLength: {
+      description: '컴포넌트에 적을 수 있는 최소 문자 수입니다.',
+    },
+    maxLength: {
+      description: '컴포넌트에 적을 수 있는 최대 문자 수입니다.',
+    },
+  },
 } satisfies Meta<typeof Textarea>;
 
 export default meta;

--- a/components/sections/AppearanceAndDataManageSection/AppearanceAndDataManageSection.stories.tsx
+++ b/components/sections/AppearanceAndDataManageSection/AppearanceAndDataManageSection.stories.tsx
@@ -7,6 +7,11 @@ import AppearanceAndDataManageSection from './AppearanceAndDataManageSection';
 const meta = {
   title: 'components/sections/AppearanceAndDataManageSection',
   component: AppearanceAndDataManageSection,
+  argTypes: {
+    show: {
+      description: '본 섹션을 표시할 것인지의 여부입니다.',
+    },
+  },
 } satisfies Meta<typeof AppearanceAndDataManageSection>;
 
 export default meta;

--- a/components/sections/HiderSection/HiderSection.stories.tsx
+++ b/components/sections/HiderSection/HiderSection.stories.tsx
@@ -7,6 +7,11 @@ import HiderSection from './HiderSection';
 const meta = {
   title: 'components/sections/HiderSection',
   component: HiderSection,
+  argTypes: {
+    show: {
+      description: '본 섹션을 표시할 것인지의 여부입니다.',
+    },
+  },
 } satisfies Meta<typeof HiderSection>;
 
 export default meta;

--- a/components/sections/RandomDefenseSection/RandomDefenseSection.stories.tsx
+++ b/components/sections/RandomDefenseSection/RandomDefenseSection.stories.tsx
@@ -7,6 +7,11 @@ import RandomDefenseSection from './RandomDefenseSection';
 const meta = {
   title: 'components/sections/RandomDefenseSection',
   component: RandomDefenseSection,
+  argTypes: {
+    show: {
+      description: '본 섹션을 표시할 것인지의 여부입니다.',
+    },
+  },
 } satisfies Meta<typeof RandomDefenseSection>;
 
 export default meta;


### PR DESCRIPTION
## PR 설명
본 PR에서는 아래의 변경사항을 반영했습니다.

- `.storybook/preview-head.html`에 모킹용 객체를 재작성. **이 방법은 임시이며 추후 더 추천되는 방법으로 바꿀 예정입니다.**
- storybook 8에서 제공하는 `@storybook/test`의 `fn()`을 사용하여 컴포넌트에서의 함수 실행을 모니터링하도록 변경
- 모든 컴포넌트에 각 prop에 대한 설명을 작성 및 문서화
- storybook의 `reactDocgen`을 `react-docgen-typescript`로 변경

`react-docgen-typescript`로의 변경 이유는, storybook 8로의 마이그레이션 이후, 유니온 타입이지만 구체적으로 표시되어야 하는 타입들이 `union`으로만 포괄적으로만 표시되는 문제가 있었습니다. 이는 storybook에서 새롭게 변경된 parser의 동작 방식의 문제였으며, 성능이 다소 떨어지더라도 문서에 정확한 정보가 표시되는 것이 더 중요하므로 구버전의 parser에서의 동작 방식으로 변경했습니다.
- https://github.com/storybookjs/storybook/issues/26407
