### PR TITLE
[FIX] 알고리즘 분류 인풋 컴포넌트가 열릴 때 버벅거리는 현상을 해결

### DIFF
--- a/components/RandomDefenseCreateMenu/AlgorithmSearchInput/AlgorithmSearchInput.styled.ts
+++ b/components/RandomDefenseCreateMenu/AlgorithmSearchInput/AlgorithmSearchInput.styled.ts
@@ -36,7 +36,7 @@ export const InputPanel = styled.ul`
 
   position: relative;
 
-  height: 64px;
+  height: 65px;
 
   z-index: 1;
   cursor: text;

--- a/hooks/randomDefense/useAlgorithmSearchInput.ts
+++ b/hooks/randomDefense/useAlgorithmSearchInput.ts
@@ -62,33 +62,34 @@ const useAlgorithmSearchInput = (params: UseAlgorithmSearchInputParams) => {
       return;
     }
 
-    const focusInputAndOpenMenu = () => {
-      inputElement.focus();
-      setIsOpen(() => true);
+    const updateOpenStateOnMouseDown = (event: globalThis.MouseEvent) => {
+      const clickedElement = event.target;
+
+      if (!clickedElement || !(clickedElement instanceof Node)) {
+        return;
+      }
+
+      setIsOpen(containerElement.contains(clickedElement));
     };
 
-    const manageMenuVisibilityOnFocus = () => {
-      setIsOpen(() => {
-        return containerElement.contains(document.activeElement);
-      });
+    const updateOpenStateOnFocus = () => {
+      if (document.activeElement === document.body) {
+        return;
+      }
+
+      setIsOpen(containerElement.contains(document.activeElement));
     };
 
-    containerElement.addEventListener('click', focusInputAndOpenMenu);
-    containerElement.addEventListener('focusin', manageMenuVisibilityOnFocus);
-    containerElement.addEventListener('focusout', manageMenuVisibilityOnFocus);
+    document.addEventListener('mousedown', updateOpenStateOnMouseDown);
+    document.addEventListener('focusin', updateOpenStateOnFocus);
+    document.addEventListener('focusout', updateOpenStateOnFocus);
 
     return () => {
-      containerElement.removeEventListener('click', focusInputAndOpenMenu);
-      containerElement.removeEventListener(
-        'focusin',
-        manageMenuVisibilityOnFocus,
-      );
-      containerElement.removeEventListener(
-        'focusout',
-        manageMenuVisibilityOnFocus,
-      );
+      document.removeEventListener('mousedown', updateOpenStateOnMouseDown);
+      document.removeEventListener('focusin', updateOpenStateOnFocus);
+      document.removeEventListener('focusout', updateOpenStateOnFocus);
     };
-  }, [containerRef, inputRef, isOpen, setIsOpen]);
+  }, [containerRef, inputRef]);
 
   return {
     isOpen,


### PR DESCRIPTION
## PR 설명
본 PR에서는 **알고리즘 분류 인풋**(`<AlgorithmSearchInput>`)가 열릴 때, 버벅거리며 열리는 것처럼 보이는 현상을 해결했습니다.
- 포커싱이 변경될 때 아주 잠깐 동안 `activeElement`가 `document.body`가 되는 것이 원인이었습니다.