### PR TITLE
[FIX] Firefox에서 티어 슬라이더의 스타일이 제대로 적용되지 않고 사용자가 드래그하여 조작할 수 없는 점을 해결

### DIFF
--- a/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierSlider/TierSlider.styled.ts
+++ b/components/RandomDefenseCreateMenu/DifficultyAdjustMenu/TierSlider/TierSlider.styled.ts
@@ -37,6 +37,7 @@ export const Track = styled.div`
 export const Thumb = styled.input<{ value: TierWithoutNotRatable }>`
   position: absolute;
   -webkit-appearance: none;
+  -moz-appearance: none;
   appearance: none;
 
   width: 100%;
@@ -46,6 +47,13 @@ export const Thumb = styled.input<{ value: TierWithoutNotRatable }>`
 
   &::-webkit-slider-runnable-track {
     -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+  }
+
+  &::-moz-range-track {
+    -webkit-appearance: none;
+    -moz-appearance: none;
     appearance: none;
   }
 
@@ -59,6 +67,23 @@ export const Thumb = styled.input<{ value: TierWithoutNotRatable }>`
       inset;
 
     -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+
+    pointer-events: auto;
+  }
+
+  &::-moz-range-thumb {
+    height: 15px;
+    width: 15px;
+
+    border-radius: 7.5px;
+    background-color: ${({ theme, value }) => theme.solvedAcTier[value]};
+    box-shadow: 0 0 0 2px ${({ theme }) => theme.color.TRANSPARENT_FAINT_WHITE}
+      inset;
+
+    -webkit-appearance: none;
+    -moz-appearance: none;
     appearance: none;
 
     pointer-events: auto;


### PR DESCRIPTION
## PR 설명
본 PR에서는 **티어 슬라이더**(`<TierSlider>`)를 Firefox에서 구동했을 때, 슬라이더의 손잡이(thumb) 부분에 스타일이 적용되지 않고, 드래그를 해 조작할 수 없는 문제를 해결했습니다.