### PR TITLE
[FEAT] 스크롤바의 색상을 설정 페이지에 적용, 스크롤바의 모양을 기본 스크롤바로 변경

### DIFF
--- a/assets/css/totamjungTheme.css
+++ b/assets/css/totamjungTheme.css
@@ -1616,30 +1616,9 @@ html[totamjungTheme='totamjung'] .media-object {
   filter: brightness(45%) sepia(80%) hue-rotate(-24deg);
 }
 
-html[totamjungTheme='totamjung'] ::-webkit-scrollbar,
-html[totamjungTheme='totamjung'] pre::-webkit-scrollbar,
-html[totamjungTheme='totamjung'] ::-webkit-scrollbar-track,
-html[totamjungTheme='totamjung'] pre::-webkit-scrollbar-track,
-html[totamjungTheme='totamjung']::-webkit-scrollbar-thumb,
-html[totamjungTheme='totamjung'] pre::-webkit-scrollbar-thumb,
-html[totamjungTheme='totamjung'] .table-responsive::-webkit-scrollbar {
-  width: 15px;
-  height: 15px;
-}
-
-html[totamjungTheme='totamjung'] ::-webkit-scrollbar,
-html[totamjungTheme='totamjung'] pre::-webkit-scrollbar,
-html[totamjungTheme='totamjung'] ::-webkit-scrollbar-track,
-html[totamjungTheme='totamjung'] pre::-webkit-scrollbar-track,
-html[totamjungTheme='totamjung'] .table-responsive::-webkit-scrollbar-track {
-  background-color: var(--secondary-menu-color);
-}
-
-html[totamjungTheme='totamjung'] ::-webkit-scrollbar-thumb,
-html[totamjungTheme='totamjung'] pre::-webkit-scrollbar-thumb,
-html[totamjungTheme='totamjung'] .table-responsive::-webkit-scrollbar-thumb {
-  background-color: var(--bright-menu-line-color);
-  border-radius: 10px;
+html[totamjungTheme='totamjung'] {
+  scrollbar-width: 15px;
+  scrollbar-color: var(--bright-menu-line-color) var(--secondary-menu-color);
 }
 
 html[totamjungTheme='totamjung'] ::selection,

--- a/styles/GlobalStyle.ts
+++ b/styles/GlobalStyle.ts
@@ -1,4 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
+import { theme } from './theme';
 
 const GlobalStyle = createGlobalStyle`
   *,
@@ -56,6 +57,11 @@ const GlobalStyle = createGlobalStyle`
 
   body:has([role="dialog"]) {
     overflow: hidden;
+  }
+
+  * {
+    scrollbar-width: 15px;
+    scrollbar-color: ${theme.color.LIGHTEST_BROWN} ${theme.color.SLIGHT_DARK_BROWN};
   }
 `;
 

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -8,6 +8,7 @@ export const theme = {
     LIGHTER_BROWN: '#694132',
     LIGHT_BROWN: '#412a23',
     BROWN: '#301e18',
+    SLIGHT_DARK_BROWN: '#271610',
     DARK_BROWN: '#1a0e0a',
     WHITE: '#eeeeee',
     PURE_WHITE: '#ffffff',


### PR DESCRIPTION
## PR 설명
본 PR에서는 아래의 두 작업을 수행했습니다.
- 설정 페이지에 토탐정의 설정 페이지와 어울리는 색상으로 스크롤바에 색상을 입혔습니다.
- 스크롤바의 디자인을 기본 스크롤바 디자인으로 되돌렸습니다. 이는 Firefox와 스타일을 통일하기 위함입니다.

## 참고 자료
- 스크롤 바의 모습입니다.
![image](https://github.com/user-attachments/assets/f2a37087-c89f-4763-af2a-1b4705ca7afa)

![image](https://github.com/user-attachments/assets/40b8c7fc-b448-4d50-a205-b00a6a314784)

![image](https://github.com/user-attachments/assets/8f45ec16-7fb1-4690-a75d-212267660d9d)
