### PR TITLE
[FEAT] 추첨 기록 메뉴의 alert 창을 모달 창으로 변경

### DIFF
--- a/components/RandomDefenseHistoryMenu/RandomDefenseHistoryMenu.tsx
+++ b/components/RandomDefenseHistoryMenu/RandomDefenseHistoryMenu.tsx
@@ -5,6 +5,8 @@ import Switch from '@/components/common/Switch';
 import NamedFrame from '@/components/common/NamedFrame/NamedFrame';
 import { TrashIcon, PackageIcon } from '@/assets/svg';
 import { MAX_HISTORY_LIMIT } from '@/constants/randomDefense';
+import SimpleModal from '@/components/common/SimpleModal';
+import useModal from '@/hooks/useModal';
 
 const RandomDefenseHistoryMenu = () => {
   const {
@@ -16,6 +18,8 @@ const RandomDefenseHistoryMenu = () => {
     clearHistory,
     updateIsHidden,
   } = useRandomDefenseHistoryMenu();
+  const { activeModalName, openModal, closeModal } =
+    useModal<'confirmClearHistory'>();
 
   return (
     <NamedFrame width="370px" height="537px" padding="10px" title="추첨 기록">
@@ -47,7 +51,9 @@ const RandomDefenseHistoryMenu = () => {
               </S.Indicator>
               <S.Text>추첨 기록 비우기</S.Text>
               <S.DeleteButton
-                onClick={clearHistory}
+                onClick={() => {
+                  openModal('confirmClearHistory');
+                }}
                 disabled={isEmpty}
                 aria-label="추첨 기록 비우기"
               >
@@ -56,6 +62,19 @@ const RandomDefenseHistoryMenu = () => {
             </S.HistoryManagePanel>
           </>
         )}
+        <SimpleModal
+          title="추첨 기록 전체 제거 확인"
+          actionType="yesNo"
+          width="350px"
+          height="auto"
+          open={activeModalName === 'confirmClearHistory'}
+          message="모든 추첨 기록을 제거할까요?"
+          onYesSelect={() => {
+            clearHistory();
+            closeModal();
+          }}
+          onNoSelect={closeModal}
+        />
       </S.Container>
     </NamedFrame>
   );

--- a/hooks/randomDefense/useRandomDefenseHistoryMenu.ts
+++ b/hooks/randomDefense/useRandomDefenseHistoryMenu.ts
@@ -42,9 +42,7 @@ const useRandomDefenseHistoryMenu = () => {
   };
 
   const clearHistory = () => {
-    if (!isEmpty && confirm('모든 추첨 기록을 제거할까요?')) {
-      setItems([]);
-    }
+    setItems([]);
   };
 
   const updateIsHidden: ChangeEventHandler<HTMLInputElement> = (event) => {


### PR DESCRIPTION
## 관련 PR
- #93 

해당 PR에 이은 구현입니다.

## PR 설명
본 PR에서는 #93 에서는 구현하지 못한, 추첨 기록 메뉴의 alert 창을 모달 창으로 변경하였습니다.
## 참고 자료
![image](https://github.com/user-attachments/assets/d408937e-a950-429f-a5e1-0f680e0cbaf4)
