### PR TITLE
[FIX] 알고리즘 분류 인풋 컴포넌트가 열릴 때 입력창이 포커싱되지 않는 문제를 해결

### DIFF
--- a/hooks/randomDefense/useAlgorithmSearchInput.ts
+++ b/hooks/randomDefense/useAlgorithmSearchInput.ts
@@ -80,14 +80,20 @@ const useAlgorithmSearchInput = (params: UseAlgorithmSearchInputParams) => {
       setIsOpen(containerElement.contains(document.activeElement));
     };
 
+    const focusInputElementOnClick = () => {
+      inputElement.focus();
+    };
+
     document.addEventListener('mousedown', updateOpenStateOnMouseDown);
     document.addEventListener('focusin', updateOpenStateOnFocus);
     document.addEventListener('focusout', updateOpenStateOnFocus);
+    containerElement.addEventListener('click', focusInputElementOnClick);
 
     return () => {
       document.removeEventListener('mousedown', updateOpenStateOnMouseDown);
       document.removeEventListener('focusin', updateOpenStateOnFocus);
       document.removeEventListener('focusout', updateOpenStateOnFocus);
+      containerElement.removeEventListener('click', focusInputElementOnClick);
     };
   }, [containerRef, inputRef]);
 


### PR DESCRIPTION
## PR 설명
본 PR에서는 알고리즘 분류 인풋 컴포넌트가 열릴 때 입력창이 포커싱되지 않는 문제를 해결했습니다.
- 실수로 누락된 포커싱 로직을 추가하였고, 클릭 이벤트를 기준으로 클릭된 컴포넌트가 인풋 컴포넌트 내부의 요소일 경우 인풋에 포커싱을 주도록 변경했습니다.