### PR TITLE
[REFACTOR] 프로젝트에서 `ReactDOM.render` 대신 `createRoot`를 사용하도록 변경

### DIFF
--- a/entrypoints/content/main.tsx
+++ b/entrypoints/content/main.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { StyleSheetManager, ThemeProvider } from 'styled-components';
 import GlobalStyle from '@/styles/GlobalStyle';
 import { theme } from '@/styles/theme';
@@ -13,10 +13,10 @@ const executeContentScript = () => {
   const hostStyle = document.createElement('style');
 
   hostStyle.textContent = `
-  :host {
-    display: block;
-  }
-`;
+    :host {
+      display: block;
+    }
+  `;
 
   shadowRoot.appendChild(styleContainer);
   shadowRoot.appendChild(appContainer);
@@ -24,7 +24,9 @@ const executeContentScript = () => {
 
   document.body.appendChild(wrapper);
 
-  render(
+  const root = createRoot(appContainer);
+
+  root.render(
     <StrictMode>
       <StyleSheetManager target={styleContainer}>
         <ThemeProvider theme={theme}>
@@ -33,7 +35,6 @@ const executeContentScript = () => {
         </ThemeProvider>
       </StyleSheetManager>
     </StrictMode>,
-    appContainer,
   );
 };
 

--- a/entrypoints/options/main.tsx
+++ b/entrypoints/options/main.tsx
@@ -1,16 +1,18 @@
-import { render } from 'react-dom';
 import { StrictMode } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '@/styles/theme';
 import GlobalStyle from '@/styles/GlobalStyle';
 import Options from '@/components/core/Options';
+import { createRoot } from 'react-dom/client';
 
-render(
+const rootElement = document.getElementById('root');
+const root = rootElement && createRoot(rootElement);
+
+root?.render(
   <StrictMode>
     <ThemeProvider theme={theme}>
       <GlobalStyle />
       <Options />
     </ThemeProvider>
   </StrictMode>,
-  document.getElementById('root'),
 );


### PR DESCRIPTION
## PR 설명
본 PR에서는 프로젝트에서 `ReactDOM.render` 대신 `createRoot`를 사용하도록 변경했습니다.
- 토탐정은 React 18 버전을 사용하며, React 18에서는 이제 `ReactDOM.render`가 deprecated된 상태입니다.