### PR TITLE
[FEAT] 추첨 만들기 / 퀵 슬롯 메뉴의 기능을 개선

### DIFF
--- a/components/QuickSlotMenu/QuickSlotMenu.tsx
+++ b/components/QuickSlotMenu/QuickSlotMenu.tsx
@@ -24,7 +24,9 @@ interface QuickSlotMenuProps {
 
 const QuickSlotMenu = (props: QuickSlotMenuProps) => {
   const { isLoaded } = props;
-  const { activeModalName, openModal, closeModal } = useModal<'copiedQuery'>();
+  const { activeModalName, openModal, closeModal } = useModal<
+    'copiedQuery' | 'confirmDeleteSlot'
+  >();
   const {
     slot,
     selectedSlotNo,
@@ -90,7 +92,9 @@ const QuickSlotMenu = (props: QuickSlotMenuProps) => {
               iconSrc={<TrashIcon />}
               disabled={slot.isEmpty}
               ariaLabel="슬롯 삭제하기"
-              onClick={deleteSlot}
+              onClick={() => {
+                openModal('confirmDeleteSlot');
+              }}
             />
           </S.SlotControlPanel>
         </S.Container>
@@ -112,6 +116,19 @@ const QuickSlotMenu = (props: QuickSlotMenuProps) => {
         onClose={closeModal}
         title="쿼리 복사 완료"
         message="쿼리를 클립보드에 복사했어요!"
+      />
+      <SimpleModal
+        actionType="yesNo"
+        width="350px"
+        height="auto"
+        open={activeModalName === 'confirmDeleteSlot'}
+        onYesSelect={() => {
+          deleteSlot();
+          closeModal();
+        }}
+        onNoSelect={closeModal}
+        title="추첨 삭제 확인"
+        message={`${selectedSlotNo}번 슬롯에 저장되어 있는 추첨을 삭제할까요?`}
       />
     </NamedFrame>
   );

--- a/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.styled.ts
+++ b/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.styled.ts
@@ -51,18 +51,14 @@ export const LowerSide = styled.div`
   bottom: 0;
 `;
 
-export const DiceIconWrapper = styled.div`
+export const DiceIcon = styled.img`
   flex-shrink: 0;
 
-  width: 36px;
-  height: 36px;
+  width: 26px;
+  height: 27px;
+  margin: 4px;
 
-  & svg {
-    width: 36px;
-    height: 36px;
-
-    color: ${({ theme }) => theme.color.DARK_ORANGE};
-  }
+  filter: ${({ theme }) => theme.filter.DARK_ORANGE_FILTER};
 `;
 
 export const TextContainer = styled.div`

--- a/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.tsx
+++ b/components/RandomDefenseCreateMenu/RandomDefenseCreateButton/RandomDefenseCreateButton.tsx
@@ -1,5 +1,4 @@
 import { SlotNo } from '@/types/randomDefense';
-import { DiceIcon } from '@/assets/svg';
 import type { MouseEvent } from 'react';
 import * as S from './RandomDefenseCreateButton.styled';
 
@@ -20,9 +19,7 @@ const RandomDefenseCreateButton = (props: RandomDefenseCreateButtonProps) => {
       disabled={!isLoaded}
     >
       <S.UpperSide>
-        <S.DiceIconWrapper>
-          <DiceIcon />
-        </S.DiceIconWrapper>
+        <S.DiceIcon src={browser.runtime.getURL('/dice.png')} alt="" />
         <S.TextContainer>
           <S.TitleText>추첨 생성</S.TitleText>
           <S.SlotNoText>

--- a/constants/defaultValues.ts
+++ b/constants/defaultValues.ts
@@ -53,7 +53,10 @@ export const DEFAULT_FONT_NO = 0;
 
 export const DEFAULT_TIMERS = [];
 
-export const DEFAULT_INITIAL_DATA = {
+/**
+ * 데이터를 초기화했을 때 덮어씌우게 될 빈 데이터입니다. 최초 설치 데이터와는 약간 다릅니다.
+ */
+export const DEFAULT_EMPTY_DATA = {
   [STORAGE_KEY.DATA_VERSION]: 'v1.2',
   [STORAGE_KEY.CHECKED_ALGORITHM_IDS]: DEFAULT_CHECKED_ALGORITHM_IDS,
   [STORAGE_KEY.QUICK_SLOTS]: DEFAULT_QUICK_SLOTS_RESPONSE,

--- a/domains/dataHandlers/dataInitializer.ts
+++ b/domains/dataHandlers/dataInitializer.ts
@@ -1,0 +1,41 @@
+import type { QuickSlots, QuickSlotsResponse } from '@/types/randomDefense';
+import { DEFAULT_EMPTY_DATA } from '@/constants/defaultValues';
+import { STORAGE_KEY } from '@/constants/commands';
+
+/**
+ * 최초 설치 시 덮어씌우게 될 데이터입니다. 데이터 초기화 시에 덮어씌우는 데이터와는 다소 다르며, 세 개의 범용성 높은 쿼리가 생성되어 있는채로 시작하게 됩니다.
+ */
+const INITIAL_QUICK_SLOTS: QuickSlots = {
+  1: {
+    isEmpty: false,
+    title: '골드 랜덤 디펜스',
+    query: 'o? -w? *g',
+  },
+  2: {
+    isEmpty: false,
+    title: '실버 랜덤 디펜스',
+    query: 'o? -w? *s',
+  },
+  3: { isEmpty: false, title: '올 랜덤', query: '(*0&!s?|!*0) o? -w?' },
+  4: { isEmpty: true },
+  5: { isEmpty: true },
+  6: { isEmpty: true },
+  7: { isEmpty: true },
+  8: { isEmpty: true },
+  9: { isEmpty: true },
+  0: { isEmpty: true },
+} as const;
+
+export const INITIAL_QUICK_SLOTS_RESPONSE: QuickSlotsResponse = {
+  hotkey: 'Alt',
+  selectedSlotNo: 1,
+  slots: INITIAL_QUICK_SLOTS,
+};
+
+export const initializeDataOnFirstInstall = () => {
+  browser.storage.local.set({
+    ...DEFAULT_EMPTY_DATA,
+    [STORAGE_KEY.QUICK_SLOTS]: INITIAL_QUICK_SLOTS_RESPONSE,
+    [STORAGE_KEY.SHOULD_SHOW_WELCOME_MESSAGE]: true,
+  });
+};

--- a/domains/dataHandlers/optionsDataHandler.ts
+++ b/domains/dataHandlers/optionsDataHandler.ts
@@ -7,7 +7,7 @@ import { fetchRandomDefenseHistory } from './randomDefenseHistoryDataHandler';
 import { fetchFontNo } from './fontNoDataHandler';
 import { fetchTimers } from './timersDataHandler';
 import type { OptionsDataResponse } from '@/types/options';
-import { DEFAULT_INITIAL_DATA } from '@/constants/defaultValues';
+import { DEFAULT_EMPTY_DATA } from '@/constants/defaultValues';
 import { isOptionsDataResponse } from './validators/optionsDataValidator';
 
 export const fetchOptionsData = async (): Promise<OptionsDataResponse> => {
@@ -54,7 +54,7 @@ export const saveOptionsData = async (data: unknown) => {
 };
 
 export const deleteOptionsData = async () => {
-  await browser.storage.local.set(DEFAULT_INITIAL_DATA);
+  await browser.storage.local.set(DEFAULT_EMPTY_DATA);
 
   return true;
 };

--- a/domains/randomDefense/randomDefenseQueryGenerator.test.ts
+++ b/domains/randomDefense/randomDefenseQueryGenerator.test.ts
@@ -16,7 +16,7 @@ describe('#Test 1 - 쿼리 생성 테스트', () => {
         algorithmIds: [],
         customQuery: '',
       },
-      '(*0&s?false|!*0) o?true w?false ~@test_user s#100..500 *10..16',
+      '(*0&!s?|!*0) o? -w? ~@test_user s#100..500 *10..16',
     ],
     [
       {
@@ -31,7 +31,7 @@ describe('#Test 1 - 쿼리 생성 테스트', () => {
         algorithmIds: [],
         customQuery: '',
       },
-      '(*0&s?false|!*0) o?true w?false *11..15',
+      '(*0&!s?|!*0) o? -w? *11..15',
     ],
     [
       {
@@ -46,7 +46,7 @@ describe('#Test 1 - 쿼리 생성 테스트', () => {
         algorithmIds: [7],
         customQuery: '',
       },
-      '(*0&s?false|!*0) o?true w?false ~@silverlove1234 s#200.. *6..10 (#greedy)',
+      '(*0&!s?|!*0) o? -w? ~@silverlove1234 s#200.. *6..10 (#greedy)',
     ],
     [
       {
@@ -61,7 +61,7 @@ describe('#Test 1 - 쿼리 생성 테스트', () => {
         algorithmIds: [],
         customQuery: 'foobar 1234',
       },
-      '(*0&s?false|!*0) o?true w?false ~@ChoGosu *0',
+      '(*0&!s?|!*0) o? -w? ~@ChoGosu *0',
     ],
     [
       {
@@ -76,7 +76,7 @@ describe('#Test 1 - 쿼리 생성 테스트', () => {
         algorithmIds: [4, 9, 16],
         customQuery: '',
       },
-      '(*0&s?false|!*0) o?true w?false s#..10000 *1..30 (#graphs&#graph_traversal&#bfs)',
+      '(*0&!s?|!*0) o? -w? s#..10000 *1..30 (#graphs&#graph_traversal&#bfs)',
     ],
     [
       {
@@ -91,7 +91,7 @@ describe('#Test 1 - 쿼리 생성 테스트', () => {
         algorithmIds: [1, 14],
         customQuery: '',
       },
-      '(*0&s?false|!*0) o?true w?false s#0.. *1..30 (-#math-#geometry)',
+      '(*0&!s?|!*0) o? -w? s#0.. *1..30 (-#math-#geometry)',
     ],
   ];
 

--- a/domains/randomDefense/randomDefenseQueryGenerator.ts
+++ b/domains/randomDefense/randomDefenseQueryGenerator.ts
@@ -43,7 +43,7 @@ export const generateRandomDefenseQuery = (
       )})`
     : '';
 
-  return `(*0&s?false|!*0) o?true w?false ${handleBanQuery}${solvedRangeQuery}${difficultyRangeQuery}${algorithmNamesQuery}`.trim();
+  return `(*0&!s?|!*0) o? -w? ${handleBanQuery}${solvedRangeQuery}${difficultyRangeQuery}${algorithmNamesQuery}`.trim();
 };
 
 const generateAlgorithmTags = (algorithmIds: number[]) => {

--- a/hooks/randomDefense/useQuickSlotMenu.ts
+++ b/hooks/randomDefense/useQuickSlotMenu.ts
@@ -68,11 +68,7 @@ const useQuickSlotMenu = (params: UseQuickSlotMenuParams) => {
       return;
     }
 
-    if (
-      confirm(`${selectedSlotNo}번 슬롯에 저장되어 있는 쿼리를 삭제할까요?`)
-    ) {
-      onSlotDelete();
-    }
+    onSlotDelete();
   };
 
   const setSelectedSlotNo = (slotNo: SlotNo) => {

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -131,6 +131,8 @@ export const theme = {
       'brightness(0) saturate(100%) invert(49%) sepia(26%) saturate(568%) hue-rotate(330deg) brightness(93%) contrast(86%)',
     ORANGE_FILTER:
       'brightness(0) saturate(100%) invert(49%) sepia(34%) saturate(983%) hue-rotate(339deg) brightness(115%) contrast(101%)',
+    DARK_ORANGE_FILTER:
+      'brightness(0) saturate(100%) invert(26%) sepia(97%) saturate(1465%) hue-rotate(11deg) brightness(97%) contrast(101%)',
     GOLD_FILTER:
       'brightness(0) saturate(100%) invert(77%) sepia(25%) saturate(571%) hue-rotate(1deg) brightness(89%) contrast(91%);',
     WHITE_FILTER:


### PR DESCRIPTION
## PR 설명
본 PR에서는 **추첨 만들기 / 퀵 슬롯** 메뉴와 관련된, 아래의 개선사항을 냈습니다.

### 1️⃣ 최초 설치 시 퀵 슬롯에 3개의 샘플 추첨을 생성하도록 개선

아래의 세 추첨을 1, 2, 3번 슬롯에 각각 자동 생성합니다.
1. 골드 랜덤 디펜스 / `o? -w? *g`
2. 실버 랜덤 디펜스 / `o? -w? *s`
3. 올 랜덤 / `(*0&!s?|!*0) o? -w?`

이 샘플 추첨은 데이터를 유저가 직접 초기화한 경우에는 다시 추첨이 자동 생성되지는 않습니다.

여담으로, `v1.1.*`에서도 예시를 보여주기 위한 목적으로, 1번 슬롯에 `All Random`이라는 이름의 추첨을 자동 생성해 둔 적이 있었습니다.

### 2️⃣ 간편 모드로 추첨을 생성할 때, 생성되는 쿼리를 간단화

쿼리의 `o?true`, `w?false` 부분을 각각 `o?`, `-w?` 로 변경하였습니다.

### 3️⃣ 추첨 생성 버튼의 주사위 아이콘을 `svg` 아이콘에서 이전에 사용하던 `png` 이미지를 다시 사용하였습니다.

### 4️⃣ 퀵 슬롯 메뉴에서, 추첨을 삭제할 때 `confirm` 창이 뜨는 대신, 모달 창이 뜨도록 개선했습니다.