### PR TITLE
[FIX] `injectionScript.ts`에서 `<head>` 요소가 `null`인지를 확인하지 않아 에러가 발생하는 점을 해결

### DIFF
--- a/entrypoints/injectionScript.content.ts
+++ b/entrypoints/injectionScript.content.ts
@@ -2,10 +2,10 @@ import { COMMANDS } from '@/constants/commands';
 import { isFontNoResponse } from '@/domains/dataHandlers/validators/fontNoValidator';
 import { isHiderOptionsResponse } from '@/domains/dataHandlers/validators/hiderOptionsValidator';
 import { isTotamjungThemeResponse } from '@/domains/dataHandlers/validators/totamjungThemeValidator';
-import '~/assets/css/palette.css';
-import '~/assets/css/totamjungTheme.css';
-import '~/assets/css/tierHider.css';
-import '~/assets/css/problemTheme.css';
+import '@/assets/css/palette.css';
+import '@/assets/css/totamjungTheme.css';
+import '@/assets/css/tierHider.css';
+import '@/assets/css/problemTheme.css';
 
 export default defineContentScript({
   matches: ['https://www.acmicpc.net/*'],
@@ -69,6 +69,10 @@ const executeInjectionScript = () => {
 
     const headInjectionObserver = new MutationObserver(() => {
       const headElement = document.head;
+
+      if (!headElement) {
+        return;
+      }
 
       const pretendardLinkElement = Object.assign(
         document.createElement('link'),


### PR DESCRIPTION
## PR 설명
본 PR에서는, `injectionScript.ts`에서 스타일 및 폰트를 백준 웹사이트의 `<head>`에 삽입하기 위한 로직에서, `<head>` 요소가 `null`인지를 확인하지 않아 1회 에러가 발생한 후 정상적으로 삽입되는 문제를 해결했습니다.

`html.headElement`는 TypeScript에서 항상 `null`이 아닌 것으로 추론되지만, 현재 상황은 확장 프로그램을 개발하는 상황이고, 이에 따라 HTML이 로드되지 않은 상황에서도 이 스크립트는 실행될 수 있으므로 여전히 에러가 발생할 가능성이 있습니다.

따라서, 타입이 추론되더라도 별도의 예외 처리 로직을 작성합니다.