### PR TITLE
[FIX] 토스트 컴포넌트에서 이전 메시지가 의도치 않게 남아있는 문제를 해결

### DIFF
--- a/hooks/useToastState.ts
+++ b/hooks/useToastState.ts
@@ -65,6 +65,7 @@ const useToastState = () => {
 
     setToastState((prev) => ({
       ...prev,
+      descriptions: '',
       ...toastInfo,
       open: true,
     }));


### PR DESCRIPTION
## PR 설명
본 PR에서는, 토스트 컴포넌트, 즉 `<LeftSlideToast>`에서, 표시해야 하는 메시지가 바뀔 때 이전 메시지의 `description`이 존재하고, 이번에 보여줘야 하는 메시지의 `description`이 없는 경우, 이전 메시지의 `description`이 그대로 현재 메시지에 보여지는 문제를 해결했습니다.

어떤 버그였는지를 설명하기 위해 버그 수정 이전 / 이후의 자료를 코멘트로 별도 첨부합니다.