### PR TITLE
[FEAT] 진행중인 잠금 타이머를 마이그레이션하는 기능을 추가하고, 테마를 마이그레이션하는 기능이 잘못된 점을 수정

### DIFF
--- a/constants/commands.ts
+++ b/constants/commands.ts
@@ -51,7 +51,6 @@ export const STORAGE_KEY = {
 export const LEGACY_SYNC_STORAGE_KEY = {
   CHECKED_ALGORITHM_IDS: 'algorithm',
   QUICK_SLOTS: 'query',
-  TOTAMJUNG_THEME: 'theme',
   TIMER: 'timer',
   SETTINGS: 'settings',
 } as const;

--- a/domains/dataHandlers/converters/legacyToLatestFontNo.ts
+++ b/domains/dataHandlers/converters/legacyToLatestFontNo.ts
@@ -1,14 +1,17 @@
 import { isObject } from '@/types/typeGuards';
 import { isLegacyFontNo } from '../validators/fontNoValidator';
 
+/**
+ * 이 컨버터 함수에는 유효하지 않은 구버전 설정 값이 주어져도 괜찮습니다.
+ */
 export const convertLegacyToLatestFontNoBySettings = (
-  settings: unknown,
+  legacySettings: unknown,
 ): number => {
-  if (!isObject(settings) || !('font' in settings)) {
+  if (!isObject(legacySettings) || !('font' in legacySettings)) {
     return 0;
   }
 
-  const legacyFontNo = settings.font;
+  const legacyFontNo = legacySettings.font;
 
   if (!isLegacyFontNo(legacyFontNo)) {
     return 0;

--- a/domains/dataHandlers/converters/legacyToLatestHiderOptionsConverter.ts
+++ b/domains/dataHandlers/converters/legacyToLatestHiderOptionsConverter.ts
@@ -1,6 +1,6 @@
 import {
   isLegacyTimer,
-  isLegacyHiderOptions,
+  isLegacySettings,
 } from '../validators/hiderOptionsValidator';
 import { DEFAULT_HIDER_OPTIONS } from '@/constants/defaultValues';
 import type { HiderOptionsResponse } from '@/types/algorithm';
@@ -10,20 +10,21 @@ interface HiderOptionsUsage {
   problemTagLockUsage: 'click' | 'auto';
 }
 
+/**
+ * 이 컨버터 함수에는 유효하지 않은 구버전 타이머 값, 또는 구버전 설정 값이 주어져도 괜찮습니다.
+ */
 export const convertLegacyToLatestHiderOptions = (
   legacyTimer: unknown,
-  legacyHiderOptions: unknown,
+  legacySettings: unknown,
 ): HiderOptionsResponse => {
   const duration = isLegacyTimer(legacyTimer)
     ? { hours: Number(legacyTimer.hour), minutes: Number(legacyTimer.minute) }
     : { hours: 0, minutes: 20 };
-  const hiderOptions: HiderOptionsUsage = isLegacyHiderOptions(
-    legacyHiderOptions,
-  )
+  const hiderOptions: HiderOptionsUsage = isLegacySettings(legacySettings)
     ? {
-        algorithmHiderUsage: legacyHiderOptions.predict,
+        algorithmHiderUsage: legacySettings.predict,
         problemTagLockUsage:
-          legacyHiderOptions.lock === 'always' ? 'auto' : 'click',
+          legacySettings.lock === 'always' ? 'auto' : 'click',
       }
     : {
         algorithmHiderUsage: 'click',

--- a/domains/dataHandlers/converters/legacyToLatestTimers.ts
+++ b/domains/dataHandlers/converters/legacyToLatestTimers.ts
@@ -1,0 +1,33 @@
+import type { Timer } from '@/types/algorithm';
+import { isTimer } from '../validators/isTimersValidator';
+import { isLegacyTimer } from '../validators/hiderOptionsValidator';
+
+/**
+ * 이 컨버터 함수에는 유효하지 않은 구버전 타이머 값이 주어져도 괜찮습니다.
+ */
+export const convertLegacyToLatestTimers = (legacyTimer: unknown): Timer[] => {
+  if (!isLegacyTimer(legacyTimer)) {
+    return [];
+  }
+
+  const { expire, problem } = legacyTimer;
+
+  const legacyTimerDate = new Date(expire);
+
+  if (isNaN(legacyTimerDate.getTime())) {
+    return [];
+  }
+
+  if (problem === -1) {
+    return [];
+  }
+
+  const expiresAt = new Date(expire).toISOString();
+
+  const timer = {
+    problemId: problem,
+    expiresAt,
+  };
+
+  return isTimer(timer) ? [timer] : [];
+};

--- a/domains/dataHandlers/converters/legacyToLatestTotamjungThemeConverter.ts
+++ b/domains/dataHandlers/converters/legacyToLatestTotamjungThemeConverter.ts
@@ -1,5 +1,17 @@
-export const convertLegacyToLatestTotamjungTheme = (
-  legacyTotamjungTheme: unknown,
-) => {
-  return legacyTotamjungTheme === 'yes' ? 'totamjung' : 'none';
+import type { TotamjungTheme } from '@/types/totamjungTheme';
+import { isObject } from '@/types/typeGuards';
+
+/**
+ * 이 컨버터 함수에는 유효하지 않은 구버전 설정 값이 주어져도 괜찮습니다.
+ */
+export const convertLegacyToLatestTotamjungThemeBySettings = (
+  legacySettings: unknown,
+): TotamjungTheme => {
+  if (!isObject(legacySettings) || !('theme' in legacySettings)) {
+    return 'none';
+  }
+
+  const { theme } = legacySettings;
+
+  return theme === 'yes' ? 'totamjung' : 'none';
 };

--- a/domains/dataHandlers/legacyDataUpdater.test.ts
+++ b/domains/dataHandlers/legacyDataUpdater.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_IS_TIER_HIDDEN,
   DEFAULT_QUICK_SLOTS_RESPONSE,
   DEFAULT_RANDOM_DEFENSE_HISTORY,
+  DEFAULT_TIMERS,
   DEFAULT_TOTAMJUNG_THEME,
 } from '@/constants/defaultValues';
 
@@ -50,7 +51,7 @@ describe('Test #1 - 구버전 데이터를 최신 버전 데이터로 변환하�
         predict: 'always',
         theme: 'yes',
       },
-      timer: { expire: -1, hour: '1', minute: '30', problem: -1 },
+      timer: { expire: 1728488132677, hour: '1', minute: '30', problem: 1234 },
     };
 
     const legacyLocalData = {
@@ -211,7 +212,13 @@ describe('Test #1 - 구버전 데이터를 최신 버전 데이터로 변환하�
           title: '36진수',
         },
       ],
-      totamjungTheme: 'none',
+      timers: [
+        {
+          problemId: 1234,
+          expiresAt: '2024-10-09T15:35:32.677Z',
+        },
+      ],
+      totamjungTheme: 'totamjung',
       fontNo: 19,
     };
 
@@ -402,6 +409,7 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
           title: 'Locked Doors',
         },
       ],
+      timers: [],
       totamjungTheme: 'none',
       fontNo: 3,
     };
@@ -472,7 +480,8 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
       isTierHidden: DEFAULT_IS_TIER_HIDDEN,
       quickSlots: DEFAULT_QUICK_SLOTS_RESPONSE,
       randomDefenseHistory: DEFAULT_RANDOM_DEFENSE_HISTORY,
-      totamjungTheme: DEFAULT_TOTAMJUNG_THEME,
+      timers: DEFAULT_TIMERS,
+      totamjungTheme: 'totamjung',
       fontNo: DEFAULT_FONT_NO,
     };
 
@@ -515,6 +524,7 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
       [STORAGE_KEY.TOTAMJUNG_THEME]: DEFAULT_TOTAMJUNG_THEME,
       [STORAGE_KEY.HIDER_OPTIONS]: DEFAULT_HIDER_OPTIONS,
       [STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: DEFAULT_RANDOM_DEFENSE_HISTORY,
+      [STORAGE_KEY.TIMERS]: DEFAULT_TIMERS,
       [STORAGE_KEY.IS_TIER_HIDDEN]: DEFAULT_IS_TIER_HIDDEN,
       [STORAGE_KEY.FONT_NO]: DEFAULT_FONT_NO,
       [STORAGE_KEY.DATA_VERSION]: 'v1.2',

--- a/domains/dataHandlers/legacyDataUpdater.ts
+++ b/domains/dataHandlers/legacyDataUpdater.ts
@@ -37,8 +37,8 @@ export const updateAllLegacyData = async () => {
   const checkedAlgorithmIds = sanitizeCheckedAlgorithmIds(
     legacySyncData[LEGACY_SYNC_STORAGE_KEY.CHECKED_ALGORITHM_IDS],
   );
-  const totamjungTheme = convertLegacyToLatestTotamjungTheme(
-    legacySyncData[LEGACY_SYNC_STORAGE_KEY.TOTAMJUNG_THEME],
+  const totamjungTheme = convertLegacyToLatestTotamjungThemeBySettings(
+    legacySyncData[LEGACY_SYNC_STORAGE_KEY.SETTINGS],
   );
   const hiderOptions = convertLegacyToLatestHiderOptions(
     legacySyncData[LEGACY_SYNC_STORAGE_KEY.TIMER],

--- a/domains/dataHandlers/legacyDataUpdater.ts
+++ b/domains/dataHandlers/legacyDataUpdater.ts
@@ -10,8 +10,9 @@ import { sanitizeIsTierHidden } from './sanitizers/isTierHiddenSanitizer';
 import { convertLegacyToLatestQuickSlots } from './converters/legacyToLatestQuickSlotsConverter';
 import { convertLegacyToLatestRandomDefenseHistory } from './converters/legacyToLatestRandomDefenseHistory';
 import { convertLegacyToLatestHiderOptions } from './converters/legacyToLatestHiderOptionsConverter';
-import { convertLegacyToLatestTotamjungTheme } from './converters/legacyToLatestTotamjungThemeConverter';
+import { convertLegacyToLatestTotamjungThemeBySettings } from './converters/legacyToLatestTotamjungThemeConverter';
 import { convertLegacyToLatestFontNoBySettings } from './converters/legacyToLatestFontNo';
+import { convertLegacyToLatestTimers } from './converters/legacyToLatestTimers';
 
 export const updateAllLegacyData = async () => {
   const { dataVersion } = await browser.storage.local.get(
@@ -33,10 +34,13 @@ export const updateAllLegacyData = async () => {
   const legacyRandomDefenseHistory = sanitizeLegacyRandomDefenseHistory(
     legacyLocalData[LEGACY_LOCAL_STORAGE_KEY.RANDOM_DEFENSE_HISTORY],
   );
-
   const checkedAlgorithmIds = sanitizeCheckedAlgorithmIds(
     legacySyncData[LEGACY_SYNC_STORAGE_KEY.CHECKED_ALGORITHM_IDS],
   );
+  const isTierHidden = sanitizeIsTierHidden(
+    legacySyncData[STORAGE_KEY.IS_TIER_HIDDEN],
+  );
+
   const totamjungTheme = convertLegacyToLatestTotamjungThemeBySettings(
     legacySyncData[LEGACY_SYNC_STORAGE_KEY.SETTINGS],
   );
@@ -48,11 +52,11 @@ export const updateAllLegacyData = async () => {
   const randomDefenseHistory = convertLegacyToLatestRandomDefenseHistory(
     legacyRandomDefenseHistory,
   );
-  const isTierHidden = sanitizeIsTierHidden(
-    legacySyncData[STORAGE_KEY.IS_TIER_HIDDEN],
-  );
   const fontNo = convertLegacyToLatestFontNoBySettings(
     legacySyncData[LEGACY_SYNC_STORAGE_KEY.SETTINGS],
+  );
+  const timers = convertLegacyToLatestTimers(
+    legacySyncData[LEGACY_SYNC_STORAGE_KEY.TIMER],
   );
 
   browser.storage.local.set({
@@ -63,6 +67,7 @@ export const updateAllLegacyData = async () => {
     [STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: randomDefenseHistory,
     [STORAGE_KEY.IS_TIER_HIDDEN]: isTierHidden,
     [STORAGE_KEY.FONT_NO]: fontNo,
+    [STORAGE_KEY.TIMERS]: timers,
     [STORAGE_KEY.DATA_VERSION]: 'v1.2',
   });
 };

--- a/domains/dataHandlers/validators/hiderOptionsValidator.ts
+++ b/domains/dataHandlers/validators/hiderOptionsValidator.ts
@@ -1,7 +1,7 @@
 import { isObject, isRatedTier } from '@/types/typeGuards';
 import type {
   HiderOptionsResponse,
-  LegacyHiderOptions,
+  LegacySettings,
   LegacyTimer,
 } from '@/types/algorithm';
 import {
@@ -66,13 +66,12 @@ export const isLegacyTimer = (data: unknown): data is LegacyTimer => {
     isNumericStringAllowsLeadingZeroes(data.hour) &&
     data.minute.length >= 1 &&
     data.minute.length <= 2 &&
-    isNumericStringAllowsLeadingZeroes(data.minute)
+    isNumericStringAllowsLeadingZeroes(data.minute) &&
+    ((data.problem >= 1_000 && data.problem % 1 === 0) || data.problem === -1)
   );
 };
 
-export const isLegacyHiderOptions = (
-  data: unknown,
-): data is LegacyHiderOptions => {
+export const isLegacySettings = (data: unknown): data is LegacySettings => {
   if (
     !(
       isObject(data) &&

--- a/types/algorithm.ts
+++ b/types/algorithm.ts
@@ -33,7 +33,7 @@ export interface LegacyTimer {
   problem: number;
 }
 
-export interface LegacyHiderOptions {
+export interface LegacySettings {
   font: `font-${number}` | 'none';
   lock: 'click' | 'always';
   predict: 'click' | 'always';


### PR DESCRIPTION
## PR 설명
본 PR에서는 아래의 두 가지 변경사항을 냈습니다.

1. 진행중인 구버전(`v1.1.*`) 잠금 타이머를 최신 버전(`v1.2`)으로 업데이트했을 때 자동으로 마이그레이션이 진행되도록 구현하였습니다.
2. 구버전 테마 데이터를 추출하는 방식이 잘못된 점을 수정하여, 테마가 올바르게 마이그레이션되도록 수정하였습니다.
