### PR TITLE
[CHORE] Jest의 테스트 환경의 타임존을 대한민국/서울로 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@wxt-dev/module-react": "^1.1.0",
         "babel-jest": "^29.7.0",
         "chrome-launcher": "^1.1.2",
+        "cross-env": "^7.0.3",
         "eslint": "^8.54.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.1",
@@ -7626,6 +7627,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "lint": "eslint .",
-    "test": "jest --watchAll"
+    "test": "cross-env TZ='Asia/Seoul' jest --watchAll",
+    "test:ci": "cross-env TZ='Asia/Seoul' jest --ci"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@wxt-dev/module-react": "^1.1.0",
     "babel-jest": "^29.7.0",
     "chrome-launcher": "^1.1.2",
+    "cross-env": "^7.0.3",
     "eslint": "^8.54.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.1",


### PR DESCRIPTION
## PR 설명
본 PR에서는 Jest의 테스트 환경의 타임존을 대한민국/서울로 변경했습니다.
- 환경변수 사용을 위해 `cross-env` 를 설치했습니다.
- Jest의 테스트를 실행할 시의 스크립트를 `jest --watchAll` 에서 `cross-env TZ='Asia/Seoul' jest --watchAll` 로 변경했습니다.
- #112 에서의 테스트 자동화를 위해 `test:ci` 스크립트를 추가했습니다.
