### PR TITLE
[FEAT] v1.1.2.5 기준과 동일한 알고리즘 분류를 지니기 위해 5개의 알고리즘 분류를 추가

### DIFF
--- a/constants/algorithmInfos.ts
+++ b/constants/algorithmInfos.ts
@@ -554,7 +554,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
   },
   {
     id: 82,
-    name: '가장 긴 증가하는 부분 수열: O(log n)',
+    name: '가장 긴 증가하는 부분 수열: O(n log n)',
     englishName: 'Longest Increasing Sequence In O(n Log N)',
     tag: 'lis',
     alias: [],
@@ -591,8 +591,8 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
     id: 87,
     name: '최대 유량 최소 컷 정리',
     englishName: 'Max-flow Min-cut Theorem',
-    tag: 'mfmc',
-    alias: ['Max-Flow Min-Cut Theorem'],
+    tag: 'mcmf',
+    alias: [],
   },
   {
     id: 88,

--- a/constants/algorithmInfos.ts
+++ b/constants/algorithmInfos.ts
@@ -1369,6 +1369,41 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
     tag: 'shortest_path',
     alias: [],
   },
+  {
+    id: 203,
+    name: '린드스트롬-게셀-비엔노 보조정리',
+    englishName: 'Lindström-gessel-viennot Lemma',
+    tag: 'lgv',
+    alias: [],
+  },
+  {
+    id: 204,
+    name: '지수승강 보조정리',
+    englishName: 'Lifting The Exponent Lemma',
+    tag: 'lte',
+    alias: [],
+  },
+  {
+    id: 205,
+    name: '유리 등차수열의 내림 합',
+    englishName: 'Sum Of Floor Of Rational Arithmetic Sequence',
+    tag: 'floor_sum',
+    alias: [],
+  },
+  {
+    id: 206,
+    name: '자릿수를 이용한 다이나믹 프로그래밍',
+    englishName: 'Digit Dp',
+    tag: 'dp_digit',
+    alias: [],
+  },
+  {
+    id: 207,
+    name: '덱을 이용한 구간 최댓값 트릭',
+    englishName: 'Deque Range Maximum Trick',
+    tag: 'deque_trick',
+    alias: ['덱 트릭'],
+  },
 ];
 
 export const ALGORITHMS_COUNT = ALGORITHM_INFOS.length;

--- a/constants/algorithmInfos.ts
+++ b/constants/algorithmInfos.ts
@@ -331,7 +331,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
     name: '에라토스테네스의 체',
     englishName: 'Sieve Of Eratosthenes',
     tag: 'sieve',
-    alias: ['에테체'],
+    alias: ['에테체', '에라체'],
   },
   {
     id: 49,

--- a/domains/algorithm/getSearchResults.test.ts
+++ b/domains/algorithm/getSearchResults.test.ts
@@ -44,7 +44,7 @@ const testcases: [string, Algorithm[]][] = [
       },
       {
         id: 82,
-        name: '가장 긴 증가하는 부분 수열: O(log n)',
+        name: '가장 긴 증가하는 부분 수열: O(n log n)',
       },
       {
         id: 124,


### PR DESCRIPTION
## 관련 커밋
- 0f9561b8604a4721fd7cf9aac657d4f4de33f4dc
- 3bfb37cec7a6f7ad549fdfeb8fa1fabfb5132632

## PR 설명
본 PR에서는 `v1.1.2.5` 기준으로 최신 상태의 알고리즘 분류를 `v1.2` 프로젝트에서도 업데이트하기 위해, 5개의 알고리즘 분류를 추가했습니다.
- 린드스트롬-게셀-비엔노 보조정리 (Lindström–gessel–viennot Lemma) `#lgv`
- 지수승강 보조정리 (Lifting The Exponent Lemma) `#lte`
- 유리 등차수열의 내림 합 (Sum Of Floor Of Rational Arithmetic Sequence) `#floor_sum`
- 자릿수를 이용한 다이나믹 프로그래밍 (Digit Dp) `#dp_digit`
- 덱을 이용한 구간 최댓값 트릭 (Deque Range Maximum Trick) `#deque_trick`

또한, 알고리즘 분류 2개가 잘못 표기된 점을 수정하고, 1개의 알고리즘 분류에 대해 별명을 추가했습니다.
- d5fa870
- 38acc3f