### PR TITLE
[FEAT] 토탐정 설치 시 가이드 페이지를 표시

### DIFF
--- a/entrypoints/background/main.ts
+++ b/entrypoints/background/main.ts
@@ -43,10 +43,14 @@ import { isUserSolvedProblem } from '@/domains/tierHider/userSolvedChecker';
 import { getRandomDefenseResult } from '@/domains/randomDefense/randomDefenseProblemChooser';
 import { initializeDataOnFirstInstall } from '@/domains/dataHandlers/dataInitializer';
 
+const totamjungGuideUrl =
+  'https://github.com/wzrabbit/boj-totamjung/wiki/%ED%86%A0%ED%83%90%EC%A0%95-%EC%82%AC%EC%9A%A9-%EA%B0%80%EC%9D%B4%EB%93%9C';
+
 const executeBackground = () => {
   browser.runtime.onInstalled.addListener(({ reason }) => {
     if (reason === 'install') {
       initializeDataOnFirstInstall();
+      browser.tabs.create({ url: totamjungGuideUrl });
       return;
     }
 


### PR DESCRIPTION
## 관련 PR
- #8 

## PR 설명
본 PR에서는 토탐정 설치 시 가이드 페이지를 표시하는 기능을 구현하였습니다. By @junah201 

토탐정을 다시 구현하면서, 그리고 가이드 페이지를 Wiki에 다시 작성하면서, 가이드 페이지의 주소를 옮겨야 할 일이 생겼으며, 현재의 `main` 브랜치를 이제 다른 브랜치로 변경할 예정이므로, 기여 기록을 복원하고자 합니다.
