### PR TITLE
[FIX] 잘못된 알고리즘 철자명 변경

### DIFF
--- a/constants/algorithmInfos.ts
+++ b/constants/algorithmInfos.ts
@@ -893,7 +893,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
   },
   {
     id: 133,
-    name: 'Aliens 트릭',
+    name: 'aliens 트릭',
     englishName: 'Aliens Trick',
     tag: 'aliens',
     alias: [],
@@ -1175,7 +1175,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
   },
   {
     id: 175,
-    name: '크누스 X',
+    name: '크누스 x',
     englishName: "Knuth's X",
     tag: 'knuth_x',
     alias: [],


### PR DESCRIPTION
## PR 설명
본 PR에서는 잘못된 알고리즘들의 철자명을 변경했습니다.

- 크누스 X $\rightarrow$ 크누스 x
- Aliens 트릭 $\rightarrow$ aliens 트릭
