### PR TITLE
[DOCS] 웨일 스토어 링크를 추가하고, 누락된 토탐정 라이선스를 추가

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,5 +1,9 @@
 ![토탐정_배너](https://user-images.githubusercontent.com/87642422/162562353-f28461f1-e563-4121-8187-493af1ee150e.png)
 
+> [!NOTE]
+> 이 가이드 문서는 `v1.1.*` 버전 사용자분들을 위한 구버전 가이드입니다.
+> 만약 `v1.2` 이상의 버전을 이용하신다면, 새로 나온 [토탐정 사용 가이드](https://github.com/wzrabbit/boj-totamjung/wiki/%ED%86%A0%ED%83%90%EC%A0%95-%EC%82%AC%EC%9A%A9-%EA%B0%80%EC%9D%B4%EB%93%9C)를 참고해 주세요.
+
 # 사용 방법
 
 이 페이지에서는 토탐정의 기본적인 사용법을 설명합니다. 설치 방법은 [README](https://github.com/wzrabbit/boj-totamjung/blob/main/README.md) 페이지를 참고해 주세요.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 요술토끼
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ https://github.com/user-attachments/assets/a17af3ef-435d-48a9-bcce-1b00fb442121
 
 토탐정은 [MIT License](https://opensource.org/license/mit) 를 따릅니다. 그러나 아래의 항목에 대해서는 해당 저작권자 분들이 명시하신 라이선스를 따릅니다.
 
-- `./assets/svg` 디렉토리 내에 있으면서, `.src/assets/svg/tier` 디렉토리에 포함되지 않은 아이콘들은 각 저작권자가 명시한 라이선스를 따르며, 관련 라이선스는 [여기](./src/assets/svg/README)에서 확인하실 수 있습니다.
+- `./assets/svg` 디렉토리 내에 있으면서, `./assets/svg/tier` 디렉토리에 포함되지 않은 아이콘들은 각 저작권자가 명시한 라이선스를 따르며, 관련 라이선스는 [여기](./assets/svg/README.md)에서 확인하실 수 있습니다.
 - `./assets/svg/tier` 디렉토리에 있는 티어 뱃지 관련 아이콘들의 저작권은 [솔브드](https://solved.ac)에 있습니다.
 
 ## ❤️ 기여자들

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
     <a href="https://chromewebstore.google.com/detail/%ED%86%A0%ED%83%90%EC%A0%95/hannhecbnjnnbbafffmogdlnajpcomek?hl=ko">
       <img src="https://github.com/user-attachments/assets/2438162f-68d0-41be-89f5-fa9084d2e50e" alt="Chrome 웹 스토어에서 다운로드" width="206px" height="58px" />
     </a>
+      <a href="https://store.whale.naver.com/detail/pkigleffcifanlafphnjkdpkfippibcm">
+      <img src="https://github.com/user-attachments/assets/7415a6ef-fc26-4978-809d-159fa2133d88" alt="Whale 스토어에서 다운로드" width="206px" height="58px" />
+    </a>
     <a href="https://addons.mozilla.org/ko/firefox/addon/%ED%86%A0%ED%83%90%EC%A0%95/">
       <img src="https://github.com/user-attachments/assets/32da6f06-805d-48e3-8303-afd5ffce4c4b" alt="Firefox 애드온에서 다운로드" width="206px" height="58px" />
     </a>


### PR DESCRIPTION
## PR 설명
본 PR에서는 아래의 작업들을 수행했습니다.

- 웨일 스토어로부터의 심사가 승인됨에 따라, 웨일 스토어에 등록된 토탐정 확장 프로그램의 링크를 추가하였습니다.
- 누락되었던 토탐정 라이선스를 추가했습니다.
- 아이콘 리소스의 라이선스를 가리키는 디렉토리가 잘못된 점을 수정했습니다.
- 기존 토탐정의 가이드 문서인 `GUIDE.md` 문서가 구버전 문서임을 표시했습니다.