### PR TITLE
[FIX] 잘못된 기하학 알고리즘 영문 분류명을 수정

### DIFF
--- a/constants/algorithmInfos.ts
+++ b/constants/algorithmInfos.ts
@@ -83,7 +83,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
   {
     id: 14,
     name: '기하학',
-    englishName: ' Geometry',
+    englishName: 'Geometry',
     tag: 'geometry',
     alias: ['기하싫어', '기하시러'],
   },


### PR DESCRIPTION
## PR 설명
본 PR에서는 **기하학** 알고리즘 분류의 오탈자를 수정했습니다.
- `" Geometry"` $\rightarrow$ `"Geometry"`