### PR TITLE
[FIX] 새로 배포를 할 때 이전 버전의 배포가 남아있는 문제를 해결

### DIFF
--- a/.github/workflows/project-deploy.yml
+++ b/.github/workflows/project-deploy.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./.output/chrome-mv3
-          destination_dir: v${{ env.VERSION }}-chrome-mv3
+          destination_dir: ./totamjung/v${{ env.VERSION }}-chrome-mv3
           publish_branch: deploy
 
       - name: Deploy MV2 Project (for Firefox)
@@ -51,6 +51,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./.output/firefox-mv2
-          destination_dir: v${{ env.VERSION }}-firefox-mv2
+          destination_dir: ./totamjung/v${{ env.VERSION }}-firefox-mv2
           publish_branch: deploy
-          keep_files: true


### PR DESCRIPTION
## PR 설명
본 PR에서는 프로젝트가 `main` 브랜치에 머지되어 새롭게 빌드를 할 때 이전 버전의 배포가 남는 문제를 해결하기 위해, 워크플로우를 수정하고 배포되는 폴더의 구조를 바꿨습니다.

새로운 배포된 파일의 폴더 구조는 아래와 같습니다.

```
totamjung/
├─ {버전명}-chrome-mv3/
├─ {버전명}-firefox-mv2/
```

