### PR TITLE
[CHORE] 폴더명에서 버전을 제거해 여러 버전이 배포에 포함되는 것을 방지

### DIFF
--- a/.github/workflows/project-deploy.yml
+++ b/.github/workflows/project-deploy.yml
@@ -24,12 +24,6 @@ jobs:
         run: |
           npm ci
 
-      - name: Get Version from package.json
-        id: get_version
-        run: |
-          VERSION=$(jq -r '.version' package.json)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
       - name: Build MV3 Project (for Chrome)
         run: |
           npm run build
@@ -43,7 +37,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./.output/chrome-mv3
-          destination_dir: ./totamjung/v${{ env.VERSION }}-chrome-mv3
+          destination_dir: ./chrome-mv3
           publish_branch: deploy
 
       - name: Deploy MV2 Project (for Firefox)
@@ -51,5 +45,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./.output/firefox-mv2
-          destination_dir: ./totamjung/v${{ env.VERSION }}-firefox-mv2
+          destination_dir: ./firefox-mv2
           publish_branch: deploy


### PR DESCRIPTION
## PR 설명
본 PR에서는 프로젝트를 배포할 때 **버전명을 제거** 하도록 해, 배포에 여러 버전의 폴더가 생성되지 않고, 기존 폴더의 내용물을 덮어씌우도록 설정을 변경했습니다.