### PR TITLE
[FEAT] 대회 페이지의 테마를 개선하고, "오이", "배추" 확장 프로그램을 지원

### DIFF
--- a/assets/css/palette.css
+++ b/assets/css/palette.css
@@ -311,14 +311,26 @@
 
   --label-yellow-gradient-color: linear-gradient(
     120deg,
-    rgb(219, 162, 20) 0%,
-    rgb(102, 76, 10) 100%
+    rgb(239, 188, 49) 0%,
+    rgb(136, 106, 26) 100%
+  );
+
+  --label-mango-gradient-color: linear-gradient(
+    120deg,
+    rgb(239, 165, 46) 0%,
+    rgb(145, 101, 30) 100%
   );
 
   --label-sky-gradient-color: linear-gradient(
     120deg,
     rgb(35, 141, 174) 0%,
     rgb(17, 68, 84) 100%
+  );
+
+  --label-purple-gradient-color: linear-gradient(
+    120deg,
+    rgb(110, 23, 177) 0%,
+    rgb(56, 8, 68) 100%
   );
 
   --label-gray-gradient-color: linear-gradient(

--- a/assets/css/totamjungTheme.css
+++ b/assets/css/totamjungTheme.css
@@ -655,6 +655,24 @@ html[totamjungTheme='totamjung']
   background-color: var(--secondary-menu-color);
 }
 
+html[totamjungTheme='totamjung'] #contest_statistics a {
+  color: var(--link-color) !important;
+}
+
+html[totamjungTheme='totamjung'] #contest_statistics > thead > tr {
+  border-bottom: 1px solid var(--menu-line-color);
+}
+
+html[totamjungTheme='totamjung'] #contest_statistics > tfoot > tr:nth-child(1) {
+  background-color: var(--dark-menu-color);
+  border-top: 1px solid var(--menu-line-color);
+}
+
+html[totamjungTheme='totamjung'] #contest_statistics > tfoot > tr:nth-child(2) {
+  background-color: var(--dark-menu-color);
+  border-top: 1px solid var(--secondary-menu-color);
+}
+
 html[totamjungTheme='totamjung'] #problem-body .table-bordered tr > td,
 html[totamjungTheme='totamjung'] #problem-body .table-bordered tr > th {
   border: 0.75px solid var(--table-border-color);

--- a/assets/css/totamjungTheme.css
+++ b/assets/css/totamjungTheme.css
@@ -2548,3 +2548,12 @@ html[totamjungTheme='totamjung'] .boj-ext-alert > .title > a {
 html[totamjungTheme='totamjung'] .problem-list span[style='color:#000000'] {
   color: var(--text-color) !important;
 }
+
+/* FOR BAECHU */
+html[totamjungTheme='totamjung'] .label.label-badge {
+  background: var(--label-mango-gradient-color);
+}
+
+html[totamjungTheme='totamjung'] .label.label-background {
+  background: var(--label-purple-gradient-color);
+}

--- a/assets/css/totamjungTheme.css
+++ b/assets/css/totamjungTheme.css
@@ -730,6 +730,17 @@ html[totamjungTheme='totamjung']
   background-color: var(--table-contest-color-light);
 }
 
+html[totamjungTheme='totamjung']
+  .row:has(.list-group-item.active a[href^='/contest/notice'])
+  .table-responsive
+  td,
+html[totamjungTheme='totamjung']
+  .row:has(.list-group-item.active a[href^='/contest/qna'])
+  .table-responsive
+  td {
+  border-top: 2px solid var(--menu-line-color);
+}
+
 html[totamjungTheme='totamjung'] .table-condensed th,
 html[totamjungTheme='totamjung'] .table-condensed td {
   border-color: var(--bright-menu-line-color);

--- a/assets/css/totamjungTheme.css
+++ b/assets/css/totamjungTheme.css
@@ -2281,6 +2281,7 @@ html[totamjungTheme='totamjung'] .problem-label.problem-label-full,
 html[totamjungTheme='totamjung'] .problem-label.problem-label-class,
 html[totamjungTheme='totamjung'] .problem-label.problem-label-feedback,
 html[totamjungTheme='totamjung'] .label.label-primary,
+html[totamjungTheme='totamjung'] .label.label-info,
 html[totamjungTheme='totamjung'] .problem-label-challenging {
   background: var(--label-sky-gradient-color);
 }

--- a/assets/css/totamjungTheme.css
+++ b/assets/css/totamjungTheme.css
@@ -2557,3 +2557,8 @@ html[totamjungTheme='totamjung'] .label.label-badge {
 html[totamjungTheme='totamjung'] .label.label-background {
   background: var(--label-purple-gradient-color);
 }
+
+/* FOR O-EY */
+html[totamjungTheme='totamjung'] .problem-label.problem-label-tr {
+  background: var(--label-purple-gradient-color);
+}


### PR DESCRIPTION
## PR 설명
본 PR에서는 아래의 두 작업을 수행했습니다.

1. 대회 페이지의 테마를 개선했습니다.
    - 대회 페이지의 통계 페이지 내부의 데이터들에 테마가 적용이 되어 있지 않아 가시성이 떨어지는 문제를 해결했습니다.
    - 대회 페이지의 공지사항 · 질문 페이지의 테마를 개선했습니다.
2. 확장 프로그램 "오이", "배추" 사용자를 위한 테마를 지원합니다.
    - 각 확장 프로그램으로 인해 백준에 생성되는 레이블을 토탐정에서 인식하고 색상을 토탐정 테마에 어울리도록 변경합니다.

## 참고 자료
- 통계 페이지 (이전)
![image](https://github.com/user-attachments/assets/2bab538c-1bf1-45ea-8079-2e7521f1ef6e)

- 통계 페이지 (이후) 
![image](https://github.com/user-attachments/assets/acde7f1a-4e5f-48bd-be54-aa56edc74600)

- 공지사항 페이지 (이전)
![image](https://github.com/user-attachments/assets/845fc44d-131c-4d0e-8ba0-1b676753083e)

- 공지사항 페이지 (이후) 
![image](https://github.com/user-attachments/assets/e5a697ef-25b0-4d14-84aa-560263341bc4)

- 배추에서의 뱃지/배경 레이블
![image](https://github.com/user-attachments/assets/ed796fae-e136-46b9-bb68-66be44ec3410)

- 오이에서의 번역 언어 레이블
![image](https://github.com/user-attachments/assets/f030834b-b605-4068-a8a3-403d8594827f)
