### PR TITLE
[FEAT] 문제 카드 그리드 컴포넌트를 구현

### DIFF
--- a/components/ProblemCard/ProblemCard.tsx
+++ b/components/ProblemCard/ProblemCard.tsx
@@ -1,5 +1,5 @@
 import { solvedAcRankIcons, solvedAcNumericTierIcons } from '@/assets/svg/tier';
-import type { ProblemInfo } from '@/types/gacha';
+import type { ProblemInfo } from '@/types/randomDefense';
 import useCardTweak from '@/hooks/gacha/useCardTweak';
 import * as S from './ProblemCard.styled';
 

--- a/components/ProblemCard/ProblemCard.tsx
+++ b/components/ProblemCard/ProblemCard.tsx
@@ -1,5 +1,5 @@
 import { solvedAcRankIcons, solvedAcNumericTierIcons } from '@/assets/svg/tier';
-import type { Tier } from '@/types/randomDefense';
+import type { ProblemInfo } from '@/types/gacha';
 import useCardTweak from '@/hooks/gacha/useCardTweak';
 import * as S from './ProblemCard.styled';
 
@@ -7,12 +7,6 @@ interface ProblemCardProps {
   problemInfo: ProblemInfo;
   isHidden: boolean;
   width: number;
-}
-
-interface ProblemInfo {
-  problemId: number;
-  title: string;
-  tier: Tier;
 }
 
 const ProblemCard = (props: ProblemCardProps) => {

--- a/components/ProblemCardGrid/ProblemCardGrid.stories.tsx
+++ b/components/ProblemCardGrid/ProblemCardGrid.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ProblemCardGrid from './ProblemCardGrid';
+import type { Tier } from '@/types/randomDefense';
+
+/**
+ * `ProblemCardGrid`
+ */
+const meta = {
+  title: 'components/QuickSlotMenu/ProblemCardGrid',
+  component: ProblemCardGrid,
+} satisfies Meta<typeof ProblemCardGrid>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+interface ProblemInfo {
+  problemId: number;
+  title: string;
+  tier: Tier;
+}
+
+const getSampleProblemInfos = (problemCount: number): ProblemInfo[] => {
+  return Array.from({ length: problemCount }).map((_, index) => ({
+    problemId: 40000 + index,
+    title: `${40000 + index}번 문제`,
+    tier: 0,
+  }));
+};
+
+export const CardCount6: Story = {
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ height: '80vh' }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  args: {
+    problemInfos: getSampleProblemInfos(6),
+  },
+};
+
+export const CardCount1: Story = {
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ height: '80vh' }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  args: {
+    problemInfos: getSampleProblemInfos(1),
+  },
+};
+
+export const CardCount2: Story = {
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ height: '80vh' }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  args: {
+    problemInfos: getSampleProblemInfos(2),
+  },
+};
+
+export const CardCount5: Story = {
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ height: '80vh' }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  args: {
+    problemInfos: getSampleProblemInfos(5),
+  },
+};
+
+export const CardCount10: Story = {
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ height: '80vh' }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  args: {
+    problemInfos: getSampleProblemInfos(10),
+  },
+};
+
+export const CardCount25: Story = {
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ height: '80vh' }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  args: {
+    problemInfos: getSampleProblemInfos(25),
+  },
+};
+
+export const CardCount50: Story = {
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ height: '80vh' }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  args: {
+    problemInfos: getSampleProblemInfos(50),
+  },
+};

--- a/components/ProblemCardGrid/ProblemCardGrid.stories.tsx
+++ b/components/ProblemCardGrid/ProblemCardGrid.stories.tsx
@@ -3,11 +3,16 @@ import ProblemCardGrid from './ProblemCardGrid';
 import type { ProblemInfo } from '@/types/randomDefense';
 
 /**
- * `ProblemCardGrid`
+ * `ProblemCardGrid`는 즉석 추첨 결과를 의미하는 카드들을 그리드 형태로 보여주는 컴포넌트입니다. 그리드의 크기와 카드의 수에 따라 최적의 레이아웃을 보여주도록 자동으로 변경됩니다.
  */
 const meta = {
   title: 'components/QuickSlotMenu/ProblemCardGrid',
   component: ProblemCardGrid,
+  argTypes: {
+    problemInfos: {
+      description: '카드 형태로 보여줄 문제들의 정보 목록입니다.',
+    },
+  },
 } satisfies Meta<typeof ProblemCardGrid>;
 
 export default meta;

--- a/components/ProblemCardGrid/ProblemCardGrid.stories.tsx
+++ b/components/ProblemCardGrid/ProblemCardGrid.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import ProblemCardGrid from './ProblemCardGrid';
-import type { ProblemInfo } from '@/types/gacha';
+import type { ProblemInfo } from '@/types/randomDefense';
 
 /**
  * `ProblemCardGrid`

--- a/components/ProblemCardGrid/ProblemCardGrid.stories.tsx
+++ b/components/ProblemCardGrid/ProblemCardGrid.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import ProblemCardGrid from './ProblemCardGrid';
-import type { Tier } from '@/types/randomDefense';
+import type { ProblemInfo } from '@/types/gacha';
 
 /**
  * `ProblemCardGrid`
@@ -13,12 +13,6 @@ const meta = {
 export default meta;
 
 type Story = StoryObj<typeof meta>;
-
-interface ProblemInfo {
-  problemId: number;
-  title: string;
-  tier: Tier;
-}
 
 const getSampleProblemInfos = (problemCount: number): ProblemInfo[] => {
   return Array.from({ length: problemCount }).map((_, index) => ({

--- a/components/ProblemCardGrid/ProblemCardGrid.styled.ts
+++ b/components/ProblemCardGrid/ProblemCardGrid.styled.ts
@@ -1,0 +1,46 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  overflow-x: hidden;
+  overflow-y: auto;
+  justify-content: center;
+
+  width: 100%;
+  height: 100%;
+`;
+
+export const StaticGrid = styled.div.attrs<{
+  $gap: number;
+  $width: number;
+  $height: number;
+}>(({ $gap, $width, $height }) => ({
+  style: {
+    gap: `${$gap}px`,
+    padding: `${$gap}px`,
+    width: `${$width}px`,
+    height: `${$height}px`,
+  },
+}))`
+  display: inline-flex;
+  flex-wrap: wrap;
+`;
+
+export const DynamicGrid = styled.div.attrs<{ $gap: number }>(({ $gap }) => ({
+  style: { rowGap: `${$gap}px` },
+}))`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  align-content: center;
+`;
+
+export const Row = styled.div.attrs<{ $gap: number }>(({ $gap }) => ({
+  style: { columnGap: `${$gap}px` },
+}))`
+  display: flex;
+  justify-content: center;
+
+  width: 100%;
+`;

--- a/components/ProblemCardGrid/ProblemCardGrid.styled.ts
+++ b/components/ProblemCardGrid/ProblemCardGrid.styled.ts
@@ -1,7 +1,8 @@
 import { styled } from 'styled-components';
 
-export const Container = styled.div`
+export const Container = styled.div<{ $visible: boolean }>`
   display: flex;
+  visibility: ${({ $visible }) => ($visible ? 'visible' : 'hidden')};
   overflow-x: hidden;
   overflow-y: auto;
   justify-content: center;

--- a/components/ProblemCardGrid/ProblemCardGrid.tsx
+++ b/components/ProblemCardGrid/ProblemCardGrid.tsx
@@ -11,12 +11,13 @@ const ProblemCardGrid = (props: ProblemCardGridProps) => {
   const { problemInfos } = props;
   const cardCount = problemInfos.length;
   const cardGridInfo = useProblemCardGrid({ cardCount });
-  const { cardWidth, cardGridGap, isOverflow, cardGridRef } = cardGridInfo;
+  const { cardWidth, cardGridGap, isOverflow, isLoaded, cardGridRef } =
+    cardGridInfo;
 
   let renderingCardIndex = 0;
 
   return (
-    <S.Container ref={cardGridRef}>
+    <S.Container ref={cardGridRef} $visible={isLoaded}>
       {isOverflow ? (
         <S.StaticGrid
           $width={cardGridInfo.innerGridWidth}

--- a/components/ProblemCardGrid/ProblemCardGrid.tsx
+++ b/components/ProblemCardGrid/ProblemCardGrid.tsx
@@ -1,7 +1,7 @@
 import * as S from './ProblemCardGrid.styled';
 import ProblemCard from '@/components/ProblemCard';
 import useProblemCardGrid from '@/hooks/gacha/useProblemCardGrid';
-import type { ProblemInfo } from '@/types/gacha';
+import type { ProblemInfo } from '@/types/randomDefense';
 
 interface ProblemCardGridProps {
   problemInfos: ProblemInfo[];

--- a/components/ProblemCardGrid/ProblemCardGrid.tsx
+++ b/components/ProblemCardGrid/ProblemCardGrid.tsx
@@ -1,0 +1,70 @@
+import * as S from './ProblemCardGrid.styled';
+import ProblemCard from '@/components/ProblemCard';
+import useProblemCardGrid from '@/hooks/gacha/useProblemCardGrid';
+import type { Tier } from '@/types/randomDefense';
+
+interface ProblemInfo {
+  problemId: number;
+  title: string;
+  tier: Tier;
+}
+
+interface ProblemCardGridProps {
+  problemInfos: ProblemInfo[];
+}
+
+const ProblemCardGrid = (props: ProblemCardGridProps) => {
+  const { problemInfos } = props;
+  const cardCount = problemInfos.length;
+  const cardGridInfo = useProblemCardGrid({ cardCount });
+  const { cardWidth, cardGridGap, isOverflow, cardGridRef } = cardGridInfo;
+
+  let renderingCardIndex = 0;
+
+  return (
+    <S.Container ref={cardGridRef}>
+      {isOverflow ? (
+        <S.StaticGrid
+          $width={cardGridInfo.innerGridWidth}
+          $height={cardGridInfo.innerGridHeight}
+          $gap={cardGridGap}
+        >
+          {problemInfos.map((problemInfo) => (
+            <ProblemCard
+              key={problemInfo.problemId}
+              width={cardWidth}
+              problemInfo={problemInfo}
+              isHidden={false}
+            />
+          ))}
+        </S.StaticGrid>
+      ) : (
+        <S.DynamicGrid $gap={cardGridGap}>
+          {cardGridInfo.rowCardCounts.map((rowCardCount, rowIndex) => (
+            <S.Row key={rowIndex} $gap={cardGridGap}>
+              {Array.from({ length: rowCardCount }).map(() => {
+                if (!problemInfos[renderingCardIndex]) {
+                  return null;
+                }
+
+                const problemInfo = problemInfos[renderingCardIndex];
+                renderingCardIndex += 1;
+
+                return (
+                  <ProblemCard
+                    key={problemInfo.problemId}
+                    width={cardWidth}
+                    problemInfo={problemInfo}
+                    isHidden={false}
+                  />
+                );
+              })}
+            </S.Row>
+          ))}
+        </S.DynamicGrid>
+      )}
+    </S.Container>
+  );
+};
+
+export default ProblemCardGrid;

--- a/components/ProblemCardGrid/ProblemCardGrid.tsx
+++ b/components/ProblemCardGrid/ProblemCardGrid.tsx
@@ -1,13 +1,7 @@
 import * as S from './ProblemCardGrid.styled';
 import ProblemCard from '@/components/ProblemCard';
 import useProblemCardGrid from '@/hooks/gacha/useProblemCardGrid';
-import type { Tier } from '@/types/randomDefense';
-
-interface ProblemInfo {
-  problemId: number;
-  title: string;
-  tier: Tier;
-}
+import type { ProblemInfo } from '@/types/gacha';
 
 interface ProblemCardGridProps {
   problemInfos: ProblemInfo[];

--- a/components/ProblemCardGrid/index.ts
+++ b/components/ProblemCardGrid/index.ts
@@ -1,0 +1,3 @@
+import ProblemCardGrid from './ProblemCardGrid';
+
+export default ProblemCardGrid;

--- a/domains/gacha/calculateCardGridLayout.ts
+++ b/domains/gacha/calculateCardGridLayout.ts
@@ -33,8 +33,6 @@ export const calculateCardGridLayout = (
     isOverflow,
   } = calculateBestGridInfo(cardGridWidth, cardGridHeight, cardCount);
 
-  console.log({ rowCount, columnCount, innerGridWidth, innerGridHeight });
-
   if (isOverflow) {
     return {
       cardWidth,

--- a/domains/gacha/calculateCardGridLayout.ts
+++ b/domains/gacha/calculateCardGridLayout.ts
@@ -1,0 +1,172 @@
+type CardGridLayoutInfo = DynamicGridLayoutInfo | StaticGridLayoutInfo;
+
+interface DynamicGridLayoutInfo {
+  cardWidth: number;
+  cardGridGap: number;
+  rowCardCounts: number[];
+  isOverflow: false;
+}
+
+interface StaticGridLayoutInfo {
+  cardWidth: number;
+  cardGridGap: number;
+  innerGridWidth: number;
+  innerGridHeight: number;
+  isOverflow: true;
+}
+
+const minCardWidth = 120;
+const cardRatio = 1 / 1.36;
+
+export const calculateCardGridLayout = (
+  cardGridWidth: number,
+  cardGridHeight: number,
+  cardCount: number,
+): CardGridLayoutInfo => {
+  const {
+    rowCount,
+    columnCount,
+    cardGridGap,
+    cardWidth,
+    innerGridWidth,
+    innerGridHeight,
+    isOverflow,
+  } = calculateBestGridInfo(cardGridWidth, cardGridHeight, cardCount);
+
+  console.log({ rowCount, columnCount, innerGridWidth, innerGridHeight });
+
+  if (isOverflow) {
+    return {
+      cardWidth,
+      cardGridGap,
+      innerGridWidth,
+      innerGridHeight,
+      isOverflow,
+    };
+  }
+
+  const rowCardCounts = calculateRowCardCounts(
+    rowCount,
+    columnCount,
+    cardCount,
+  );
+
+  return {
+    cardWidth,
+    cardGridGap,
+    rowCardCounts,
+    isOverflow,
+  };
+};
+
+const calculateBestGridInfo = (
+  cardGridWidth: number,
+  cardGridHeight: number,
+  cardCount: number,
+) => {
+  let bestGridInfo = {
+    rowCount: 0,
+    columnCount: 0,
+    cardWidth: 0,
+    cardGridGap: 0,
+    isOverflow: true,
+  };
+
+  for (let columnCount = 1; columnCount <= cardCount; columnCount += 1) {
+    const rowCount = Math.ceil(cardCount / columnCount);
+
+    const { cardWidth, cardGridGap, isOverflow } = calculateCardSizeInfo(
+      cardGridWidth,
+      cardGridHeight,
+      rowCount,
+      columnCount,
+    );
+
+    if (!isOverflow && cardWidth > bestGridInfo.cardWidth) {
+      bestGridInfo = {
+        rowCount,
+        columnCount,
+        cardWidth,
+        cardGridGap,
+        isOverflow,
+      };
+    }
+  }
+
+  if (bestGridInfo.isOverflow) {
+    const columnCount = Math.max(
+      1,
+      Math.floor((cardGridWidth - minCardWidth / 10) / (minCardWidth * 1.1)),
+    );
+
+    bestGridInfo = {
+      rowCount: Math.ceil(cardCount / columnCount),
+      columnCount,
+      cardWidth: minCardWidth,
+      cardGridGap: minCardWidth / 10,
+      isOverflow: true,
+    };
+  }
+
+  const { rowCount, columnCount, cardWidth, cardGridGap, isOverflow } =
+    bestGridInfo;
+  const cardHeight = cardWidth / cardRatio;
+  const innerGridWidth =
+    columnCount * cardWidth + (columnCount + 1) * cardGridGap;
+  const innerGridHeight = rowCount * cardHeight + (rowCount + 1) * cardGridGap;
+
+  return {
+    rowCount,
+    columnCount,
+    cardWidth,
+    cardGridGap,
+    innerGridWidth,
+    innerGridHeight,
+    isOverflow,
+  };
+};
+
+const calculateCardSizeInfo = (
+  cardGridWidth: number,
+  cardGridHeight: number,
+  rowCount: number,
+  columnCount: number,
+) => {
+  const cardWidthBasedOnHorizontal =
+    (cardGridWidth * 10) / (11 * columnCount + 1);
+  const cardWidthBasedOnVertical =
+    cardGridHeight / (rowCount * (1 / cardRatio + 0.1) + 0.1);
+  const cardWidth = Math.max(
+    minCardWidth,
+    Math.min(cardWidthBasedOnHorizontal, cardWidthBasedOnVertical) - 1,
+  );
+
+  const cardGap = cardWidth / 10;
+  const cardHeight = cardWidth / cardRatio;
+  const cardTotalWidth = columnCount * cardWidth + (columnCount + 1) * cardGap;
+  const cardTotalHeight = rowCount * cardHeight + (rowCount + 1) * cardGap;
+
+  const isOverflow =
+    cardTotalWidth > cardGridWidth || cardTotalHeight > cardGridHeight;
+
+  return {
+    cardWidth,
+    cardGridGap: cardWidth / 10,
+    isOverflow,
+  };
+};
+
+const calculateRowCardCounts = (
+  rowCount: number,
+  columnCount: number,
+  cardCount: number,
+) => {
+  const rowCardCounts = Array.from({ length: rowCount }).map(() => columnCount);
+  const emptySpaceCount = rowCount * columnCount - cardCount;
+
+  for (let rowIndex = 0; rowIndex < emptySpaceCount; rowIndex += 1) {
+    rowCardCounts[rowCount - (rowIndex % rowCount) - 1] -= 1;
+  }
+
+  return rowCardCounts;
+};

--- a/hooks/gacha/useProblemCardGrid.ts
+++ b/hooks/gacha/useProblemCardGrid.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect, useRef } from 'react';
+import { calculateCardGridLayout } from '@/domains/gacha/calculateCardGridLayout';
+
+interface UseProblemCardGridParams {
+  cardCount: number;
+}
+
+const useProblemCardGrid = (params: UseProblemCardGridParams) => {
+  const { cardCount: initCardCount } = params;
+  const [cardCount, setCardCount] = useState(initCardCount);
+  const [cardGridWidth, setCardGridWidth] = useState(0);
+  const [cardGridHeight, setCardGridHeight] = useState(0);
+  const cardGridRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setCardCount(cardCount);
+  }, [initCardCount]);
+
+  useEffect(() => {
+    const cardGridElement = cardGridRef.current;
+
+    if (!cardGridElement) {
+      return;
+    }
+
+    const updateCardGridSize = () => {
+      const { clientWidth, clientHeight } = cardGridElement;
+      setCardGridWidth(clientWidth);
+      setCardGridHeight(clientHeight);
+    };
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateCardGridSize();
+    });
+
+    resizeObserver.observe(cardGridRef.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return {
+    ...calculateCardGridLayout(cardGridWidth, cardGridHeight, cardCount),
+    cardGridRef,
+  };
+};
+
+export default useProblemCardGrid;

--- a/hooks/gacha/useProblemCardGrid.ts
+++ b/hooks/gacha/useProblemCardGrid.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import { calculateCardGridLayout } from '@/domains/gacha/calculateCardGridLayout';
 
 interface UseProblemCardGridParams {
@@ -10,13 +10,14 @@ const useProblemCardGrid = (params: UseProblemCardGridParams) => {
   const [cardCount, setCardCount] = useState(initCardCount);
   const [cardGridWidth, setCardGridWidth] = useState(0);
   const [cardGridHeight, setCardGridHeight] = useState(0);
+  const [isLoaded, setIsLoaded] = useState(false);
   const cardGridRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setCardCount(cardCount);
   }, [initCardCount]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const cardGridElement = cardGridRef.current;
 
     if (!cardGridElement) {
@@ -27,6 +28,7 @@ const useProblemCardGrid = (params: UseProblemCardGridParams) => {
       const { clientWidth, clientHeight } = cardGridElement;
       setCardGridWidth(clientWidth);
       setCardGridHeight(clientHeight);
+      setIsLoaded(true);
     };
 
     const resizeObserver = new ResizeObserver(() => {
@@ -42,6 +44,7 @@ const useProblemCardGrid = (params: UseProblemCardGridParams) => {
 
   return {
     ...calculateCardGridLayout(cardGridWidth, cardGridHeight, cardCount),
+    isLoaded,
     cardGridRef,
   };
 };

--- a/types/gacha.ts
+++ b/types/gacha.ts
@@ -1,2 +1,0 @@
-import type { Tier } from './randomDefense';
-

--- a/types/gacha.ts
+++ b/types/gacha.ts
@@ -1,0 +1,7 @@
+import type { Tier } from './randomDefense';
+
+export interface ProblemInfo {
+  problemId: number;
+  title: string;
+  tier: Tier;
+}

--- a/types/gacha.ts
+++ b/types/gacha.ts
@@ -1,7 +1,2 @@
 import type { Tier } from './randomDefense';
 
-export interface ProblemInfo {
-  problemId: number;
-  title: string;
-  tier: Tier;
-}

--- a/types/randomDefense.ts
+++ b/types/randomDefense.ts
@@ -159,6 +159,7 @@ interface RandomDefenseFailureResult {
 interface RandomDefenseSuccessResult {
   success: true;
   problemInfo: SolvedAcSearchProblemInfo;
+}
 
 export interface ProblemInfo {
   problemId: number;

--- a/types/randomDefense.ts
+++ b/types/randomDefense.ts
@@ -159,4 +159,9 @@ interface RandomDefenseFailureResult {
 interface RandomDefenseSuccessResult {
   success: true;
   problemInfo: SolvedAcSearchProblemInfo;
+
+export interface ProblemInfo {
+  problemId: number;
+  title: string;
+  tier: Tier;
 }


### PR DESCRIPTION
## 관련 이슈
- #76 

## PR 설명
본 PR에서는 **문제 카드 그리드 컴포넌트**인 `<ProblemCardGrid>` 컴포넌트를 생성 및 구현했습니다. 이 컴포넌트는 즉석 추첨 기능의 결과 화면에서 사용될 것이며, 추첨된 모든 문제의 정보를 그리드 형태로 보여주는 역할을 수행합니다.

본 그리드 컴포넌트는 크게 두 가지 특징을 지닙니다.

### 1️⃣ 레이아웃이 정해져 있지 않으며, 그리드의 가로/세로 길이와 보여주어야 할 카드의 수를 고려해 최적의 레이아웃을 계산하여 결정합니다
- 각 카드의 크기를 크게 하고, 과도하게 치우쳐지지 않은 레이아웃을 보여줍니다

![image](https://github.com/user-attachments/assets/2aef6362-57fe-4021-998c-c6c554d449cd)


### 2️⃣ 카드들을 오버플로우 없이 배치할 수 있는지에 따라 두 가지의 렌더링 방법 중 하나가 결정됩니다
- 그리드에서 보여주는 각 카드의 최소 가로 길이는 정해져 있습니다
- **각 카드의 최소 크기를 지키며 사용자에게 오버플로우 없이 레이아웃을 제공할 수 있다면**: 그 레이아웃을 제공하며 카드들은 가운데 정렬됩니다. 레이아웃 내의 카드들의 배치는 자유로운 편이며 카드의 크기는 상황에 따라 유동적으로 달라집니다.
- **각 카드의 최소 크기를 지키는 것이 불가능하다면**: 각 카드를 최소 크기로 렌더링하고 세로 스크롤 바를 추가해 사용자가 스크롤해 카드들을 볼 수 있도록 렌더링하며 카드들은 왼쪽 정렬됩니다. 레이아웃 내의 카드들의 배치는 엄격하게 격자에 맞추어져 있습니다.

![image](https://github.com/user-attachments/assets/9595af95-4ac7-4a5c-920f-4dd51d4a309a)

## 참고 자료

https://github.com/user-attachments/assets/e47d57e6-31c3-435a-b4c3-3600adba602e

