### PR TITLE
[FEAT] 랜덤 디펜스를 위한 비동기 요청 로직을 개선하고, 랜덤 디펜스 기록에서 Not Ratable 티어가 Unrated 티어로 보이는 문제를 해결

### DIFF
--- a/constants/randomDefense.ts
+++ b/constants/randomDefense.ts
@@ -2,6 +2,8 @@ export const MIN_TIER = 0;
 
 export const MAX_TIER = 30;
 
+export const MAX_TIER_INCLUDING_NOT_RATABLE = 31;
+
 export const MIN_PROBLEM_ID = 1_000;
 
 export const MAX_PROBLEM_ID = 99_999;

--- a/domains/dataHandlers/sanitizers/randomDefenseHistorySanitizer.ts
+++ b/domains/dataHandlers/sanitizers/randomDefenseHistorySanitizer.ts
@@ -2,7 +2,7 @@ import {
   MAX_HISTORY_LIMIT,
   MAX_PROBLEM_ID,
   MAX_PROBLEM_NAME_LENGTH,
-  MAX_TIER,
+  MAX_TIER_INCLUDING_NOT_RATABLE,
   MIN_PROBLEM_ID,
   MIN_TIER,
 } from '@/constants/randomDefense';
@@ -28,7 +28,7 @@ const isValidRandomDefenseHistoryInfo = (item: unknown) => {
     isValidIsoString(item.createdAt) &&
     item.tier % 1 === 0 &&
     item.tier >= MIN_TIER &&
-    item.tier <= MAX_TIER
+    item.tier <= MAX_TIER_INCLUDING_NOT_RATABLE
   );
 };
 
@@ -42,7 +42,7 @@ const isValidLegacyRandomDefenseHistoryInfo = (item: unknown) => {
     isValidDate(item.date) &&
     item.tier % 1 === 0 &&
     item.tier >= MIN_TIER &&
-    item.tier <= MAX_TIER
+    item.tier <= MAX_TIER_INCLUDING_NOT_RATABLE
   );
 };
 

--- a/domains/dataHandlers/sanitizers/randomDefenseHistorySanitizer.ts
+++ b/domains/dataHandlers/sanitizers/randomDefenseHistorySanitizer.ts
@@ -5,6 +5,7 @@ import {
   MAX_TIER_INCLUDING_NOT_RATABLE,
   MIN_PROBLEM_ID,
   MIN_TIER,
+  MAX_TIER,
 } from '@/constants/randomDefense';
 import {
   isLegacyRandomDefenseHistoryInfo,
@@ -42,7 +43,7 @@ const isValidLegacyRandomDefenseHistoryInfo = (item: unknown) => {
     isValidDate(item.date) &&
     item.tier % 1 === 0 &&
     item.tier >= MIN_TIER &&
-    item.tier <= MAX_TIER_INCLUDING_NOT_RATABLE
+    item.tier <= MAX_TIER
   );
 };
 

--- a/domains/dataHandlers/validators/RandomDefenseResultResponseValidator.ts
+++ b/domains/dataHandlers/validators/RandomDefenseResultResponseValidator.ts
@@ -1,6 +1,8 @@
-import { isObject } from '@/types/typeGuards';
-import { isSolvedAcSearchProblemInfo } from './solvedAcSearchProblemResponseValidator';
-import type { RandomDefenseResultResponse } from '@/types/randomDefense';
+import { isObject, isTier } from '@/types/typeGuards';
+import type {
+  ProblemInfo,
+  RandomDefenseResultResponse,
+} from '@/types/randomDefense';
 
 export const isRandomDefenseResultResponse = (
   data: unknown,
@@ -14,9 +16,7 @@ export const isRandomDefenseResultResponse = (
   const { success } = data;
 
   if (success) {
-    return (
-      'problemInfo' in data && isSolvedAcSearchProblemInfo(data.problemInfo)
-    );
+    return 'problemInfos' in data && isProblemInfos(data.problemInfos);
   }
 
   if ('statusCode' in data && typeof data.statusCode !== 'number') {
@@ -30,6 +30,7 @@ export const isRandomDefenseResultResponse = (
   if (!('errorDescriptions' in data)) {
     return true;
   }
+
   const { errorDescriptions } = data;
 
   return (
@@ -39,4 +40,20 @@ export const isRandomDefenseResultResponse = (
         (errorDescription) => typeof errorDescription === 'string',
       ))
   );
+};
+
+const isProblemInfo = (data: unknown): data is ProblemInfo => {
+  return (
+    isObject(data) &&
+    'problemId' in data &&
+    'title' in data &&
+    'tier' in data &&
+    typeof data.problemId === 'number' &&
+    typeof data.title === 'string' &&
+    isTier(data.tier)
+  );
+};
+
+const isProblemInfos = (data: unknown): data is ProblemInfo[] => {
+  return Array.isArray(data) && data.every((item) => isProblemInfo(item));
 };

--- a/domains/dataHandlers/validators/solvedAcSearchProblemResponseValidator.ts
+++ b/domains/dataHandlers/validators/solvedAcSearchProblemResponseValidator.ts
@@ -1,5 +1,5 @@
 import { isObject } from '@/types/typeGuards';
-import { isTierWithoutNotRatable } from '@/types/typeGuards';
+import { isTier } from '@/types/typeGuards';
 import type {
   SolvedAcSearchProblemResponse,
   SolvedAcSearchProblemInfo,
@@ -33,9 +33,11 @@ export const isSolvedAcSearchProblemInfo = (
     isObject(data) &&
     'problemId' in data &&
     'titleKo' in data &&
+    'isLevelLocked' in data &&
     'level' in data &&
     typeof data.problemId === 'number' &&
     typeof data.titleKo === 'string' &&
-    isTierWithoutNotRatable(data.level)
+    typeof data.isLevelLocked === 'boolean' &&
+    isTier(data.level)
   );
 };

--- a/domains/randomDefense/randomDefenseProblemChooser.ts
+++ b/domains/randomDefense/randomDefenseProblemChooser.ts
@@ -1,8 +1,9 @@
 import { isSolvedAcSearchProblemResponse } from '@/domains/dataHandlers/validators/solvedAcSearchProblemResponseValidator';
-import { RandomDefenseResultResponse } from '@/types/randomDefense';
+import type { RandomDefenseResultResponse } from '@/types/randomDefense';
 
 export const getRandomDefenseResult = async (
   query: string,
+  problemCount: number,
 ): Promise<RandomDefenseResultResponse> => {
   try {
     const response = await fetch(
@@ -71,12 +72,13 @@ export const getRandomDefenseResult = async (
       };
     }
 
-    const { count, items } = parsedResponse;
+    const { items } = parsedResponse;
+    const count = items.length;
 
     if (count === 0) {
       return {
         success: false,
-        errorMessage: '해당 추첨의 쿼리를 만족하는 문제가 없습니다.',
+        errorMessage: '추첨 조건을 만족하는 문제가 없습니다.',
         errorDescriptions: [
           '쿼리에 오타가 있는 지 확인해 보세요.',
           '다른 주제의 쿼리나, 좀 더 넓은 검색범위의 쿼리를 사용해 보세요.',
@@ -84,16 +86,38 @@ export const getRandomDefenseResult = async (
       };
     }
 
+    if (count < problemCount) {
+      return {
+        success: false,
+        errorMessage: '추첨 조건을 만족하는 문제가 부족합니다.',
+        errorDescriptions: [
+          `검색된 문제 수가 총 ${count}문제로, 요청하신 ${problemCount}문제보다 더 적어 추첨을 진행하지 못했습니다.`,
+          `더 넓은 검색범위의 쿼리를 사용해 보시거나, 추첨할 문제 수를 ${count} 문제 이하로 줄여보세요.`,
+        ],
+      };
+    }
+
+    const problemInfos = items.map((item) => {
+      const { problemId, titleKo, level, isLevelLocked } = item;
+
+      return {
+        problemId,
+        title: titleKo,
+        tier: level === 0 && isLevelLocked ? 31 : level,
+      };
+    });
+
     return {
       success: true,
-      problemInfo: items[0],
+      problemInfos,
     };
   } catch (error) {
     return {
       success: false,
       errorMessage: '문제 추첨 중 에러가 발생했습니다.',
       errorDescriptions: [
-        '네트워크 연결이 불안정한 것 같습니다. 네트워크 연결이 원활한지 확인해 주세요.',
+        '네트워크 연결이 불안정한 것이 원인일 수 있습니다. 네트워크 연결이 원활한지 확인해 주세요.',
+        '네트워크에 문제가 없다면, 솔브드의 API 서버가 일시적으로 불안정한 것이 원인일 수 있습니다. 이 경우 잠시 후 다시 시도해보세요.',
       ],
     };
   }

--- a/entrypoints/background/main.ts
+++ b/entrypoints/background/main.ts
@@ -259,11 +259,18 @@ const executeBackground = () => {
       }
 
       if (command === COMMANDS.GET_RANDOM_DEFENSE_RESULT) {
-        if (!('query' in message) || typeof message.query !== 'string') {
+        if (
+          !('query' in message) ||
+          typeof message.query !== 'string' ||
+          !('problemCount' in message) ||
+          typeof message.problemCount !== 'number'
+        ) {
           return;
         }
 
-        getRandomDefenseResult(message.query).then((result) => {
+        const { query, problemCount } = message;
+
+        getRandomDefenseResult(query, problemCount).then((result) => {
           sendResponse(result);
         });
         return true;

--- a/hooks/widget/useRandomDefense.ts
+++ b/hooks/widget/useRandomDefense.ts
@@ -150,6 +150,7 @@ const useRandomDefense = (params: UseRandomDefenseParams) => {
     const randomDefenseResultResponse = await browser.runtime.sendMessage({
       command: COMMANDS.GET_RANDOM_DEFENSE_RESULT,
       query: selectedSlot.query,
+      problemCount: 1,
     });
 
     if (!isRandomDefenseResultResponse(randomDefenseResultResponse)) {
@@ -183,15 +184,12 @@ const useRandomDefense = (params: UseRandomDefenseParams) => {
       return;
     }
 
-    const { problemInfo } = randomDefenseResultResponse;
-    const { problemId, titleKo, level } = problemInfo;
+    const { problemInfos } = randomDefenseResultResponse;
 
     browser.runtime.sendMessage({
       command: COMMANDS.APPEND_RANDOM_DEFENSE_HISTORY_INFO,
       randomDefenseHistoryInfo: {
-        problemId,
-        title: titleKo,
-        tier: level,
+        ...problemInfos[0],
         createdAt: new Date().toISOString(),
       },
     });

--- a/hooks/widget/useRandomDefense.ts
+++ b/hooks/widget/useRandomDefense.ts
@@ -185,6 +185,7 @@ const useRandomDefense = (params: UseRandomDefenseParams) => {
     }
 
     const { problemInfos } = randomDefenseResultResponse;
+    const { problemId } = problemInfos[0];
 
     browser.runtime.sendMessage({
       command: COMMANDS.APPEND_RANDOM_DEFENSE_HISTORY_INFO,

--- a/types/randomDefense.ts
+++ b/types/randomDefense.ts
@@ -1,5 +1,4 @@
 import type { solvedAcNumericTierIcons } from '@/assets/svg/tier';
-import type { SolvedAcSearchProblemInfo } from '@/types/solvedAcApi';
 import type { IsoString } from '@/types/utils';
 
 export interface RandomDefenseHistoryInfo {

--- a/types/randomDefense.ts
+++ b/types/randomDefense.ts
@@ -158,7 +158,7 @@ interface RandomDefenseFailureResult {
 
 interface RandomDefenseSuccessResult {
   success: true;
-  problemInfo: SolvedAcSearchProblemInfo;
+  problemInfos: ProblemInfo[];
 }
 
 export interface ProblemInfo {

--- a/types/solvedAcApi.ts
+++ b/types/solvedAcApi.ts
@@ -1,4 +1,4 @@
-import { TierWithoutNotRatable } from '@/types/randomDefense';
+import { Tier } from '@/types/randomDefense';
 
 /**
  * `solved.ac/api/v3/search/problem`으로 solved.ac API에 쿼리 요청을 했을 경우 예상되는 정상 응답값입니다.
@@ -12,5 +12,6 @@ export interface SolvedAcSearchProblemResponse {
 export interface SolvedAcSearchProblemInfo {
   problemId: number;
   titleKo: string;
-  level: TierWithoutNotRatable;
+  level: Tier;
+  isLevelLocked: boolean;
 }


### PR DESCRIPTION
## PR 설명
본 PR에서는 크게 아래의 두 가지 작업을 수행하였습니다.

### 1️⃣ solved.ac API 응답 로직을 개선
- **응답 타입에 `isLevelLocked` 프로퍼티를 추가하였습니다.** `tier`의 값이 `0`인 경우 해당 문제는 Unrated이거나 Not Ratable인데, 이 상태로는 두 난이도를 비교할 수 있는 수단이 없습니다. 그래서 응답으로 오는 `isLevelLocked` 프로퍼티를 같이 이용해 두 난이도를 구별하도록 개선하였고, `tier`의 값을 `0`과 `31`로 구별하여 반환하도록 변경하였습니다.

### 2️⃣ 추첨 기록에 Unrated와 Not Ratable 난이도가 구별하여 등장하도록 버그 수정
- 1️⃣ 에서의 문제로 인해 추첨 기록에 들어오는 데이터는 이 둘을 구분할 수 있는 문제가 있었습니다. 1️⃣ 을 개선하면서 바뀐 데이터 로직을 추첨 기록 컴포넌트에 적용하였고, 이를 통해 난이도가 올바르게 표시되도록 변경하였습니다.