### PR TITLE
[FEAT] 추첨 결과를 마크다운 텍스트 형태로 복사할 수 있는 기능을 추가

### DIFF
--- a/components/GachaModalNotification/GachaModalNotification.stories.tsx
+++ b/components/GachaModalNotification/GachaModalNotification.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import GachaModalNotification from './GachaModalNotification';
+
+/**
+ * `GachaModalNotification`은 사용자가 즉석 추첨 모달의 추첨 결과 화면에서 하단의 메뉴 버튼을 눌렀을 때에 대한 시각적 피드백을 제공하기 위한 알림 컴포넌트입니다.
+ * 알림이 나타날 때 짧은 시간 동안 밝은 색으로 점멸하여 같은 버튼을 여러 번 눌러 같은 안내 메시지를 보여줘야 하는 상황에서도 사용자가 버튼을 여러 번 눌렀음을 알 수 있도록 구현하였습니다.
+ */
+const meta = {
+  title: 'components/GachaModalNotification',
+  component: GachaModalNotification,
+  argTypes: {
+    children: {
+      description: '알림 컴포넌트에 보여질 안내 메시지입니다.',
+    },
+    shouldFadeOut: {
+      description:
+        '등장 시 밝아졌다가 잠시 후 서서히 사라지는 애니메이션이 진행 중이어야 하는지의 여부입니다. 이 값을 `false`로 두어 메시지를 보이게 한 후, 즉시 `true`로 바꾸면 메시지가 밝아졌다가 잠시 후 사라지므로 종합적으로 메시지가 등장했다 사라지는 효과를 부여할 수 있습니다.',
+    },
+  },
+} satisfies Meta<typeof GachaModalNotification>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: '테스트 알림 메시지입니다.',
+    shouldFadeOut: false,
+  },
+};

--- a/components/GachaModalNotification/GachaModalNotification.styled.ts
+++ b/components/GachaModalNotification/GachaModalNotification.styled.ts
@@ -1,0 +1,58 @@
+import { styled, keyframes } from 'styled-components';
+
+export const highlightAndFadeOut = keyframes`
+  0% {
+    opacity: 1;
+    filter: brightness(200%);
+  }
+
+  20% {
+    opacity: 1;
+    filter: brightness(100%);
+  }
+
+  80% {
+    opacity: 1;
+    filter: brightness(100%);
+  }
+
+  100% {
+    opacity: 0;
+    filter: brightness(100%);
+  }
+`;
+
+export const Container = styled.div`
+  display: flex;
+  column-gap: 5px;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 40px;
+  margin-bottom: -20px;
+
+  user-select: none;
+
+  &.fading {
+    animation: ${highlightAndFadeOut} 2s forwards;
+  }
+`;
+
+export const NotificationIconWrapper = styled.div`
+  width: 20px;
+  height: 20px;
+
+  & > svg {
+    width: 100%;
+    height: 100%;
+
+    color: ${({ theme }) => theme.color.GOLD};
+  }
+`;
+
+export const NotificationText = styled.div`
+  font-size: 16px;
+  color: ${({ theme }) => theme.color.GOLD};
+  font-weight: 600;
+`;

--- a/components/GachaModalNotification/GachaModalNotification.styled.ts
+++ b/components/GachaModalNotification/GachaModalNotification.styled.ts
@@ -29,8 +29,7 @@ export const Container = styled.div`
   align-items: center;
 
   width: 100%;
-  height: 40px;
-  margin-bottom: -20px;
+  height: 20px;
 
   user-select: none;
 

--- a/components/GachaModalNotification/GachaModalNotification.tsx
+++ b/components/GachaModalNotification/GachaModalNotification.tsx
@@ -1,0 +1,24 @@
+import { CheckIcon } from '@/assets/svg';
+import * as S from './GachaModalNotification.styled';
+
+interface GachaModalNotificationProps {
+  children: string;
+  shouldFadeOut: boolean;
+}
+
+const GachaModalNotification = (props: GachaModalNotificationProps) => {
+  const { children, shouldFadeOut } = props;
+
+  return (
+    <S.Container className={shouldFadeOut ? 'fading' : ''}>
+      {children !== '' && (
+        <S.NotificationIconWrapper>
+          <CheckIcon />
+        </S.NotificationIconWrapper>
+      )}
+      <S.NotificationText>{children}</S.NotificationText>
+    </S.Container>
+  );
+};
+
+export default GachaModalNotification;

--- a/components/GachaModalNotification/index.ts
+++ b/components/GachaModalNotification/index.ts
@@ -1,0 +1,3 @@
+import GachaModalNotification from './GachaModalNotification';
+
+export default GachaModalNotification;

--- a/components/ProblemCardGrid/ProblemCardGrid.styled.ts
+++ b/components/ProblemCardGrid/ProblemCardGrid.styled.ts
@@ -1,10 +1,13 @@
 import { styled } from 'styled-components';
 
-export const Container = styled.div<{ $visible: boolean }>`
+export const Container = styled.div<{
+  $visible: boolean;
+  $overflowY: 'visible' | 'auto';
+}>`
   display: flex;
   visibility: ${({ $visible }) => ($visible ? 'visible' : 'hidden')};
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow-x: visible;
+  overflow-y: ${({ $overflowY }) => $overflowY};
   justify-content: center;
 
   width: 100%;
@@ -31,6 +34,7 @@ export const DynamicGrid = styled.div.attrs<{ $gap: number }>(({ $gap }) => ({
   style: { rowGap: `${$gap}px` },
 }))`
   display: flex;
+  overflow: visible;
   flex-direction: column;
   justify-content: center;
   align-items: center;
@@ -41,6 +45,7 @@ export const Row = styled.div.attrs<{ $gap: number }>(({ $gap }) => ({
   style: { columnGap: `${$gap}px` },
 }))`
   display: flex;
+  overflow: visible;
   justify-content: center;
 
   width: 100%;

--- a/components/ProblemCardGrid/ProblemCardGrid.tsx
+++ b/components/ProblemCardGrid/ProblemCardGrid.tsx
@@ -19,7 +19,11 @@ const ProblemCardGrid = (props: ProblemCardGridProps) => {
   let renderingCardIndex = 0;
 
   return (
-    <S.Container ref={cardGridRef} $visible={isLoaded}>
+    <S.Container
+      ref={cardGridRef}
+      $visible={isLoaded}
+      $overflowY={isOverflow ? 'auto' : 'visible'}
+    >
       {isOverflow ? (
         <S.StaticGrid
           $width={cardGridInfo.innerGridWidth}

--- a/components/RandomDefenseGachaModal/RandomDefenseGachaModal.styled.ts
+++ b/components/RandomDefenseGachaModal/RandomDefenseGachaModal.styled.ts
@@ -359,6 +359,15 @@ export const ProblemCardGridWrapper = styled.div`
   animation: ${zoomIn} cubic-bezier(0.165, 0.84, 0.44, 1) 0.7s 0.3s forwards;
 `;
 
+export const GachaModalNotificationWrapper = styled.div`
+  position: absolute;
+  left: 0;
+  bottom: 65px;
+
+  width: 100%;
+  height: 20px;
+`;
+
 export const ResultBottomControlList = styled.div`
   display: flex;
   justify-content: center;

--- a/components/RandomDefenseGachaModal/RandomDefenseGachaModal.tsx
+++ b/components/RandomDefenseGachaModal/RandomDefenseGachaModal.tsx
@@ -17,6 +17,7 @@ import type { FilledSlot } from '@/types/randomDefense';
 import CardBox from '@/components/CardBox';
 import ProblemCardGrid from '@/components/ProblemCardGrid';
 import useRandomDefenseGachaModal from '@/hooks/gacha/useRandomDefenseGachaModal';
+import GachaModalNotification from '../GachaModalNotification/GachaModalNotification';
 
 interface RandomDefenseGachaModalProps {
   open: boolean;
@@ -36,7 +37,8 @@ const RandomDefenseGachaModal = (props: RandomDefenseGachaModalProps) => {
     errorDescriptions,
     isTierHidden,
     isAudioMuted,
-    setGachaStatus,
+    notificationMessage,
+    shouldNotificationFadeOut,
     restartGacha,
     toggleIsTierHidden,
     toggleIsAudioMuted,
@@ -44,6 +46,7 @@ const RandomDefenseGachaModal = (props: RandomDefenseGachaModalProps) => {
     playGachaAudio,
     stopGachaAudio,
     copyProblemInfosMarkdownToClipboard,
+    showResultScreenAndResetNotificationMessage,
   } = useRandomDefenseGachaModal({ open, slot, problemCount });
 
   return (
@@ -78,7 +81,7 @@ const RandomDefenseGachaModal = (props: RandomDefenseGachaModalProps) => {
                 isTierHidden={isTierHidden}
                 cardRanks={previewCardRanks}
                 onFirstClick={playGachaAudio}
-                onOpenAnimationEnd={() => setGachaStatus('showingResult')}
+                onOpenAnimationEnd={showResultScreenAndResetNotificationMessage}
               />
             </S.CardBoxWrapper>
             <S.BottomControlList>
@@ -130,6 +133,7 @@ const RandomDefenseGachaModal = (props: RandomDefenseGachaModalProps) => {
             </S.BottomControlList>
           </S.ErrorScreen>
         )}
+
         {gachaStatus === 'showingResult' && (
           <S.ResultScreen>
             <S.ProblemCardGridWrapper>
@@ -139,6 +143,9 @@ const RandomDefenseGachaModal = (props: RandomDefenseGachaModalProps) => {
                 isTierHidden={isTierHidden}
               />
             </S.ProblemCardGridWrapper>
+            <GachaModalNotification shouldFadeOut={shouldNotificationFadeOut}>
+              {notificationMessage}
+            </GachaModalNotification>
             <S.ResultBottomControlList>
               <IconButton
                 type="button"

--- a/components/RandomDefenseGachaModal/RandomDefenseGachaModal.tsx
+++ b/components/RandomDefenseGachaModal/RandomDefenseGachaModal.tsx
@@ -9,6 +9,7 @@ import {
   DicesIcon,
   VolumeOffIcon,
   VolumeOnIcon,
+  CopyIcon,
 } from '@/assets/svg';
 import { hiddenTierBadgeIcon, tier1BadgeIcon } from '@/assets/png';
 import { theme } from '@/styles/theme';
@@ -42,6 +43,7 @@ const RandomDefenseGachaModal = (props: RandomDefenseGachaModalProps) => {
     playCardSlideAudio,
     playGachaAudio,
     stopGachaAudio,
+    copyProblemInfosMarkdownToClipboard,
   } = useRandomDefenseGachaModal({ open, slot, problemCount });
 
   return (
@@ -138,6 +140,16 @@ const RandomDefenseGachaModal = (props: RandomDefenseGachaModalProps) => {
               />
             </S.ProblemCardGridWrapper>
             <S.ResultBottomControlList>
+              <IconButton
+                type="button"
+                name="문제 목록 복사"
+                size="large"
+                color={theme.color.LIGHT_GRAY}
+                iconSrc={<CopyIcon />}
+                disabled={false}
+                ariaLabel="문제 목록 복사"
+                onClick={copyProblemInfosMarkdownToClipboard}
+              />
               <IconButton
                 type="button"
                 name="다시 추첨하기!"

--- a/components/RandomDefenseGachaModal/RandomDefenseGachaModal.tsx
+++ b/components/RandomDefenseGachaModal/RandomDefenseGachaModal.tsx
@@ -143,9 +143,11 @@ const RandomDefenseGachaModal = (props: RandomDefenseGachaModalProps) => {
                 isTierHidden={isTierHidden}
               />
             </S.ProblemCardGridWrapper>
-            <GachaModalNotification shouldFadeOut={shouldNotificationFadeOut}>
-              {notificationMessage}
-            </GachaModalNotification>
+            <S.GachaModalNotificationWrapper>
+              <GachaModalNotification shouldFadeOut={shouldNotificationFadeOut}>
+                {notificationMessage}
+              </GachaModalNotification>
+            </S.GachaModalNotificationWrapper>
             <S.ResultBottomControlList>
               <IconButton
                 type="button"

--- a/domains/gacha/getProblemInfosInMarkdownText.test.ts
+++ b/domains/gacha/getProblemInfosInMarkdownText.test.ts
@@ -1,0 +1,42 @@
+import type { ProblemInfo } from '@/types/randomDefense';
+import { getProblemInfosInMarkdownText } from './getProblemInfosInMarkdownText';
+
+describe('Test #1 - 마크다운 텍스트 생성 테스트', () => {
+  test('문제 정보들이 주어지면, 문제 정보르 마크다운으로 나타낸 텍스트를 올바르게 반환하여야 한다.', () => {
+    const problemInfos: ProblemInfo[] = [
+      {
+        problemId: 22289,
+        title: '큰 수 곱셈 (3)',
+        tier: 20,
+      },
+      {
+        problemId: 1064,
+        title: '평행사변형',
+        tier: 6,
+      },
+      {
+        problemId: 31002,
+        title: '그래프 변환',
+        tier: 14,
+      },
+    ];
+
+    const expectedMarkdownText = `
+# 추첨 결과 \u{1F3B2}
+
+## 추첨 정보 \u2705
+
+- 추첨 이름: 테스트용 연습
+- 문제 수: 3
+
+## 문제 목록 \u{1f4dc}
+- 22289번 - 큰 수 곱셈 (3) (https://acmicpc.net/problem/22289)
+- 1064번 - 평행사변형 (https://acmicpc.net/problem/1064)
+- 31002번 - 그래프 변환 (https://acmicpc.net/problem/31002)
+`.trim();
+
+    expect(getProblemInfosInMarkdownText('테스트용 연습', problemInfos)).toBe(
+      expectedMarkdownText,
+    );
+  });
+});

--- a/domains/gacha/getProblemInfosInMarkdownText.ts
+++ b/domains/gacha/getProblemInfosInMarkdownText.ts
@@ -1,0 +1,29 @@
+import type { ProblemInfo } from '@/types/randomDefense';
+
+const diceEmoji = '\u{1F3B2}';
+const greenCheckEmoji = '\u2705';
+const scrollEmoji = '\u{1f4dc}';
+
+export const getProblemInfosInMarkdownText = (
+  slotTitle: string,
+  problemInfos: ProblemInfo[],
+) => {
+  const problemListInMarkdownText = problemInfos
+    .map(
+      ({ problemId, title }) =>
+        `- ${problemId}번 - ${title} (https://acmicpc.net/problem/${problemId})`,
+    )
+    .join('\n');
+
+  return `
+# 추첨 결과 ${diceEmoji}
+
+## 추첨 정보 ${greenCheckEmoji}
+
+- 추첨 이름: ${slotTitle}
+- 문제 수: ${problemInfos.length}
+
+## 문제 목록 ${scrollEmoji}
+${problemListInMarkdownText}
+`.trim();
+};

--- a/hooks/gacha/useRandomDefenseGachaModal.ts
+++ b/hooks/gacha/useRandomDefenseGachaModal.ts
@@ -9,6 +9,7 @@ import type { FilledSlot } from '@/types/randomDefense';
 import type { ProblemInfo } from '@/types/randomDefense';
 import type { PreviewCardRanks } from '@/types/gacha';
 import { isGachaOptionsResponse } from '@/domains/dataHandlers/validators/gachaOptionsValidator';
+import { getProblemInfosInMarkdownText } from '@/domains/gacha/getProblemInfosInMarkdownText';
 
 interface UseRandomDefenseGachaModalParams {
   open: boolean;
@@ -145,6 +146,12 @@ const useRandomDefenseGachaModal = (
     gachaAudioRef.current.currentTime = 0;
   };
 
+  const copyProblemInfosMarkdownToClipboard = () => {
+    navigator.clipboard.writeText(
+      getProblemInfosInMarkdownText(slot.title, problemInfos),
+    );
+  };
+
   useEffect(() => {
     restartGacha();
   }, [open, slot, problemCount]);
@@ -177,6 +184,7 @@ const useRandomDefenseGachaModal = (
     playCardSlideAudio,
     playGachaAudio,
     stopGachaAudio,
+    copyProblemInfosMarkdownToClipboard,
   };
 };
 

--- a/hooks/gacha/useRandomDefenseGachaModal.ts
+++ b/hooks/gacha/useRandomDefenseGachaModal.ts
@@ -110,6 +110,7 @@ const useRandomDefenseGachaModal = (
     const { isTierHidden, isAudioMuted } = gachaOptions;
     setIsTierHidden(isTierHidden);
     setIsAudioMuted(isAudioMuted);
+    gachaAudioRef.current.muted = isAudioMuted;
   }, []);
 
   const restartGacha = () => {

--- a/hooks/gacha/useRandomDefenseGachaModal.ts
+++ b/hooks/gacha/useRandomDefenseGachaModal.ts
@@ -59,6 +59,9 @@ const useRandomDefenseGachaModal = (
   );
   const [isTierHidden, setIsTierHidden] = useState(false);
   const [isAudioMuted, setIsAudioMuted] = useState(true);
+  const [notificationMessage, setNotificationMessage] = useState('');
+  const [shouldNotificationFadeOut, setShouldNotificationFadeOut] =
+    useState(true);
   const gachaAudioRef = useRef<HTMLAudioElement>(new Audio(gachaAudio));
 
   const previewCardRanks: PreviewCardRanks =
@@ -151,6 +154,14 @@ const useRandomDefenseGachaModal = (
     navigator.clipboard.writeText(
       getProblemInfosInMarkdownText(slot.title, problemInfos),
     );
+    setNotificationMessage('문제 목록을 클립보드에 복사했어요!');
+    setShouldNotificationFadeOut(false);
+    setTimeout(() => setShouldNotificationFadeOut(true));
+  };
+
+  const showResultScreenAndResetNotificationMessage = () => {
+    setGachaStatus('showingResult');
+    setNotificationMessage('');
   };
 
   useEffect(() => {
@@ -178,7 +189,8 @@ const useRandomDefenseGachaModal = (
     errorDescriptions,
     isTierHidden,
     isAudioMuted,
-    setGachaStatus,
+    notificationMessage,
+    shouldNotificationFadeOut,
     restartGacha,
     toggleIsTierHidden,
     toggleIsAudioMuted,
@@ -186,6 +198,7 @@ const useRandomDefenseGachaModal = (
     playGachaAudio,
     stopGachaAudio,
     copyProblemInfosMarkdownToClipboard,
+    showResultScreenAndResetNotificationMessage,
   };
 };
 


### PR DESCRIPTION
## 관련 이슈
- #76 

## PR 설명
본 PR에서는 즉석 추첨 모달에 아래 기능들을 추가했습니다.

### 1️⃣ 추첨 결과 화면에서 결과를 마크다운 텍스트 형태로 복사할 수 있는 기능 추가
- **"문제 목록 복사"** 버튼이 추첨 결과 화면에서 보이게 되며, 클릭 시 마크다운 형태로 추첨 결과가 복사됩니다.

### 2️⃣ 모달 알림 컴포넌트를 구현하고 복사 시마다 복사가 완료되었다는 내용이 보이도록 적용
- 알림이 등장할 때마다 글자 색이 일시적으로 밝아지는 효과가 있어 여러 번 복사 버튼을 눌러 안내 메시지가 같은 경우에도 사용자가 여러 번 적용되었다는 것을 쉽게 알 수 있습니다.

## 참고 자료

![image](https://github.com/user-attachments/assets/389566e2-8d59-4ed5-9aea-867d989fb553)


![image](https://github.com/user-attachments/assets/641b106a-b5fd-4c2c-969b-50739e9e2ee8)
