### PR TITLE
[FEAT] 추첨 결과를 기록에 저장할 수 있는 기능을 추가

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -78,6 +78,7 @@
     SAVE_GACHA_OPTIONS: 'saveGachaOptions',
     SAVE_AND_GET_REMAINING_LOCK_TIME: 'saveAndGetRemainingLockTime',
     GET_RANDOM_DEFENSE_RESULT: 'getRandomDefenseResult',
+    ADD_RANDOM_DEFENSE_HISTORY_INFOS: 'addRandomDefenseHistoryInfos',
     OPEN_OPTIONS_PAGE: 'openOptionsPage',
     FETCH_SHOULD_SHOW_WELCOME_MESSAGE: 'fetchShouldShowWelcomeMessage',
     SAVE_SHOULD_SHOW_WELCOME_MESSAGE: 'saveShouldShowWelcomeMessage',
@@ -248,6 +249,8 @@
           case COMMANDS.SAVE_SHOULD_SHOW_WELCOME_MESSAGE:
             return null;
           case COMMANDS.SAVE_GACHA_OPTIONS:
+            return null;
+          case COMMANDS.ADD_RANDOM_DEFENSE_HISTORY_INFOS:
             return null;
           default:
             console.error(

--- a/components/RandomDefenseGachaModal/RandomDefenseGachaModal.tsx
+++ b/components/RandomDefenseGachaModal/RandomDefenseGachaModal.tsx
@@ -10,6 +10,8 @@ import {
   VolumeOffIcon,
   VolumeOnIcon,
   CopyIcon,
+  DownloadIcon,
+  CheckIcon,
 } from '@/assets/svg';
 import { hiddenTierBadgeIcon, tier1BadgeIcon } from '@/assets/png';
 import { theme } from '@/styles/theme';
@@ -37,6 +39,7 @@ const RandomDefenseGachaModal = (props: RandomDefenseGachaModalProps) => {
     errorDescriptions,
     isTierHidden,
     isAudioMuted,
+    isSavedToHistory,
     notificationMessage,
     shouldNotificationFadeOut,
     restartGacha,
@@ -47,6 +50,7 @@ const RandomDefenseGachaModal = (props: RandomDefenseGachaModalProps) => {
     stopGachaAudio,
     copyProblemInfosMarkdownToClipboard,
     showResultScreenAndResetNotificationMessage,
+    saveGachaResultToStorage,
   } = useRandomDefenseGachaModal({ open, slot, problemCount });
 
   return (
@@ -158,6 +162,16 @@ const RandomDefenseGachaModal = (props: RandomDefenseGachaModalProps) => {
                 disabled={false}
                 ariaLabel="문제 목록 복사"
                 onClick={copyProblemInfosMarkdownToClipboard}
+              />
+              <IconButton
+                type="button"
+                name="추첨 기록 저장"
+                size="large"
+                color={theme.color.LEMON}
+                iconSrc={isSavedToHistory ? <CheckIcon /> : <DownloadIcon />}
+                disabled={isSavedToHistory}
+                ariaLabel="추첨 기록 저장"
+                onClick={saveGachaResultToStorage}
               />
               <IconButton
                 type="button"

--- a/constants/commands.ts
+++ b/constants/commands.ts
@@ -20,7 +20,7 @@ export const COMMANDS = {
   REMOVE_SINGLE_TIMER: 'removeSingleTimer',
   IS_USER_SOLVED_PROBLEM: 'isUserSolvedProblem',
   GET_RANDOM_DEFENSE_RESULT: 'getRandomDefenseResult',
-  APPEND_RANDOM_DEFENSE_HISTORY_INFO: 'appendRandomDefenseHistoryInfo',
+  ADD_RANDOM_DEFENSE_HISTORY_INFOS: 'addRandomDefenseHistoryInfos',
   FETCH_GACHA_OPTIONS: 'fetchGachaOptions',
   SAVE_GACHA_OPTIONS: 'saveGachaOptions',
   FETCH_SHOULD_SHOW_WELCOME_MESSAGE: 'fetchShouldShowWelcomeMessage',

--- a/domains/dataHandlers/randomDefenseHistoryDataHandler.test.ts
+++ b/domains/dataHandlers/randomDefenseHistoryDataHandler.test.ts
@@ -1,4 +1,5 @@
 import {
+  addRandomDefenseInfosToHistory,
   fetchRandomDefenseHistory,
   saveRandomDefenseHistory,
 } from './randomDefenseHistoryDataHandler';
@@ -683,4 +684,94 @@ describe('Test #6 - 잘못된 추첨 기록 저장에 대응하기', () => {
       expect(browser.storage.local.set).not.toHaveBeenCalled();
     },
   );
+});
+
+describe('Test #7 - 추첨 기록 추가하기', () => {
+  test('추가해야 하는 올바른 추첨 기록들이 주어진 경우 그 추첨 기록들이 전체 추첨 기록에 시간순으로 정렬된 채로 추가되어야 한다.', async () => {
+    const randomDefenseHistory = [
+      {
+        problemId: 27959,
+        title: '초코바',
+        tier: 1,
+        createdAt: '2025-01-01T23:35:00.123Z',
+      },
+      {
+        problemId: 27964,
+        title: '콰트로치즈피자',
+        tier: 6,
+        createdAt: '2025-01-01T23:34:00.123Z',
+      },
+      {
+        problemId: 27943,
+        title: '가지 사진 찾기',
+        tier: 11,
+        createdAt: '2025-01-01T23:33:00.123Z',
+      },
+    ];
+
+    const additionalRandomDefenseHistory = [
+      {
+        problemId: 27470,
+        title: '멋진 부분집합',
+        tier: 2,
+        createdAt: '2024-05-03T23:35:00.123Z',
+      },
+      {
+        problemId: 27959,
+        title: '초코바',
+        tier: 1,
+        createdAt: '2025-01-04T23:35:00.713Z',
+      },
+    ];
+
+    const expectedRandomDefenseHistory = [
+      {
+        problemId: 27959,
+        title: '초코바',
+        tier: 1,
+        createdAt: '2025-01-04T23:35:00.713Z',
+      },
+      {
+        problemId: 27959,
+        title: '초코바',
+        tier: 1,
+        createdAt: '2025-01-01T23:35:00.123Z',
+      },
+      {
+        problemId: 27964,
+        title: '콰트로치즈피자',
+        tier: 6,
+        createdAt: '2025-01-01T23:34:00.123Z',
+      },
+      {
+        problemId: 27943,
+        title: '가지 사진 찾기',
+        tier: 11,
+        createdAt: '2025-01-01T23:33:00.123Z',
+      },
+      {
+        problemId: 27470,
+        title: '멋진 부분집합',
+        tier: 2,
+        createdAt: '2024-05-03T23:35:00.123Z',
+      },
+    ];
+
+    jest.spyOn(browser.storage.local, 'get').mockImplementation(() =>
+      Promise.resolve({
+        randomDefenseHistory,
+        isTierHidden: false,
+      }),
+    );
+    jest
+      .spyOn(browser.storage.local, 'set')
+      .mockImplementation(() => Promise.resolve());
+    addRandomDefenseInfosToHistory(additionalRandomDefenseHistory);
+    await Promise.resolve();
+
+    expect(await browser.storage.local.set).toHaveBeenCalledWith({
+      randomDefenseHistory: expectedRandomDefenseHistory,
+      isTierHidden: false,
+    });
+  });
 });

--- a/domains/dataHandlers/randomDefenseHistoryDataHandler.ts
+++ b/domains/dataHandlers/randomDefenseHistoryDataHandler.ts
@@ -5,6 +5,7 @@ import type {
   RandomDefenseHistoryInfo,
   RandomDefenseHistoryResponse,
 } from '@/types/randomDefense';
+import { isRandomDefenseHistoryInfos } from './validators/randomDefenseHistoryValidator';
 
 const getSortedRandomDefenseHistory = (
   randomDefenseHistory: RandomDefenseHistoryInfo[],
@@ -35,7 +36,7 @@ export const fetchRandomDefenseHistory =
     };
   };
 
-export const saveRandomDefenseHistory = (
+export const saveRandomDefenseHistory = async (
   randomDefenseHistory: unknown,
   isHidden: unknown,
 ) => {
@@ -55,13 +56,20 @@ export const saveRandomDefenseHistory = (
   });
 };
 
-export const appendRandomDefenseInfoToHistory = async (
-  randomDefenseHistoryInfo: unknown,
+export const addRandomDefenseInfosToHistory = async (
+  newRandomDefenseHistoryInfos: unknown,
 ) => {
   const { randomDefenseHistory, isHidden } = await fetchRandomDefenseHistory();
 
+  if (
+    !isRandomDefenseHistoryInfos(randomDefenseHistory) ||
+    !isRandomDefenseHistoryInfos(newRandomDefenseHistoryInfos)
+  ) {
+    return;
+  }
+
   saveRandomDefenseHistory(
-    [...randomDefenseHistory, randomDefenseHistoryInfo],
+    [...randomDefenseHistory, ...newRandomDefenseHistoryInfos],
     isHidden,
   );
 };

--- a/entrypoints/background/main.ts
+++ b/entrypoints/background/main.ts
@@ -10,7 +10,7 @@ import {
   saveQuickSlots,
 } from '@/domains/dataHandlers/quickSlotsDataHandler';
 import {
-  appendRandomDefenseInfoToHistory,
+  addRandomDefenseInfosToHistory,
   fetchRandomDefenseHistory,
   saveRandomDefenseHistory,
 } from '@/domains/dataHandlers/randomDefenseHistoryDataHandler';
@@ -296,12 +296,12 @@ const executeBackground = () => {
         return true;
       }
 
-      if (command === COMMANDS.APPEND_RANDOM_DEFENSE_HISTORY_INFO) {
-        if (!('randomDefenseHistoryInfo' in message)) {
+      if (command === COMMANDS.ADD_RANDOM_DEFENSE_HISTORY_INFOS) {
+        if (!('randomDefenseHistoryInfos' in message)) {
           return;
         }
 
-        appendRandomDefenseInfoToHistory(message.randomDefenseHistoryInfo);
+        addRandomDefenseInfosToHistory(message.randomDefenseHistoryInfos);
       }
 
       if (command === COMMANDS.FETCH_SHOULD_SHOW_WELCOME_MESSAGE) {

--- a/hooks/gacha/useRandomDefenseGachaModal.ts
+++ b/hooks/gacha/useRandomDefenseGachaModal.ts
@@ -62,6 +62,7 @@ const useRandomDefenseGachaModal = (
   const [notificationMessage, setNotificationMessage] = useState('');
   const [shouldNotificationFadeOut, setShouldNotificationFadeOut] =
     useState(true);
+  const [isSavedToHistory, setIsSavedToHistory] = useState(false);
   const gachaAudioRef = useRef<HTMLAudioElement>(new Audio(gachaAudio));
 
   const previewCardRanks: PreviewCardRanks =
@@ -118,6 +119,7 @@ const useRandomDefenseGachaModal = (
 
   const restartGacha = () => {
     setGachaStatus('loading');
+    setIsSavedToHistory(false);
     setCardBoxColor(chooseByProbability(cardBoxColorChoices));
     fetchRandomDefenseResult();
   };
@@ -164,6 +166,24 @@ const useRandomDefenseGachaModal = (
     setNotificationMessage('');
   };
 
+  const saveGachaResultToStorage = () => {
+    const currentIsoString = new Date().toISOString();
+    const randomDefenseHistoryInfos = problemInfos.map((problemInfo) => ({
+      ...problemInfo,
+      createdAt: currentIsoString,
+    }));
+
+    browser.runtime.sendMessage({
+      command: COMMANDS.ADD_RANDOM_DEFENSE_HISTORY_INFOS,
+      randomDefenseHistoryInfos,
+    });
+
+    setIsSavedToHistory(true);
+    setNotificationMessage('문제 목록을 추첨 기록에 저장했어요!');
+    setShouldNotificationFadeOut(false);
+    setTimeout(() => setShouldNotificationFadeOut(true));
+  };
+
   useEffect(() => {
     restartGacha();
   }, [open, slot, problemCount]);
@@ -191,6 +211,7 @@ const useRandomDefenseGachaModal = (
     isAudioMuted,
     notificationMessage,
     shouldNotificationFadeOut,
+    isSavedToHistory,
     restartGacha,
     toggleIsTierHidden,
     toggleIsAudioMuted,
@@ -199,6 +220,7 @@ const useRandomDefenseGachaModal = (
     stopGachaAudio,
     copyProblemInfosMarkdownToClipboard,
     showResultScreenAndResetNotificationMessage,
+    saveGachaResultToStorage,
   };
 };
 

--- a/hooks/widget/useRandomDefense.ts
+++ b/hooks/widget/useRandomDefense.ts
@@ -188,11 +188,13 @@ const useRandomDefense = (params: UseRandomDefenseParams) => {
     const { problemId } = problemInfos[0];
 
     browser.runtime.sendMessage({
-      command: COMMANDS.APPEND_RANDOM_DEFENSE_HISTORY_INFO,
-      randomDefenseHistoryInfo: {
-        ...problemInfos[0],
-        createdAt: new Date().toISOString(),
-      },
+      command: COMMANDS.ADD_RANDOM_DEFENSE_HISTORY_INFOS,
+      randomDefenseHistoryInfos: [
+        {
+          ...problemInfos[0],
+          createdAt: new Date().toISOString(),
+        },
+      ],
     });
 
     location.href = `https://acmicpc.net/problem/${problemId}`;


### PR DESCRIPTION
## 관련 이슈
- #76 

## PR 설명
본 PR에서는 즉석 추첨 모달에 아래 기능들을 추가했습니다. 유저가 눈으로 볼 수 있는 컴포넌트 화면과 내부에서 여러 문제를 저장하기 위한 서비스 워커 로직을 모두 포함합니다.

### 1️⃣ 추첨 결과 화면에서 결과를 추첨 기록에 저장할 수 있는 기능 추가
- 결과 당 한 번만 클릭할 수 있는 『추첨 기록 저장』 버튼을 클릭해 결과를 저장할 수 있습니다. 이 때 여러 문제가 한꺼번에 저장됩니다.
- 저장한 결과는 추첨 기록에서 확인 가능합니다.

## 참고 자료
![image](https://github.com/user-attachments/assets/76df02aa-e751-47e2-9b7e-9ff8b8cf7466)
