### PR TITLE
[FIX] 즉석 추첨 기능에서 발생하는 버그들을 해결

### DIFF
--- a/components/CardBox/CardBox.tsx
+++ b/components/CardBox/CardBox.tsx
@@ -45,7 +45,7 @@ const CardBox = (props: CardBoxProps) => {
           {firstCardRank && (
             <S.InsideCard
               src={
-                isTierHidden
+                firstCardRank !== 'unrated' && isTierHidden
                   ? PROBLEM_CARDS.hidden
                   : PROBLEM_CARDS[firstCardRank]
               }
@@ -59,7 +59,7 @@ const CardBox = (props: CardBoxProps) => {
           {secondCardRank && (
             <S.InsideCard
               src={
-                isTierHidden
+                secondCardRank !== 'unrated' && isTierHidden
                   ? PROBLEM_CARDS.hidden
                   : PROBLEM_CARDS[secondCardRank]
               }
@@ -73,7 +73,7 @@ const CardBox = (props: CardBoxProps) => {
           {thirdCardRank && (
             <S.InsideCard
               src={
-                isTierHidden
+                thirdCardRank !== 'unrated' && isTierHidden
                   ? PROBLEM_CARDS.hidden
                   : PROBLEM_CARDS[thirdCardRank]
               }

--- a/components/ProblemCardGrid/ProblemCardGrid.tsx
+++ b/components/ProblemCardGrid/ProblemCardGrid.tsx
@@ -35,7 +35,7 @@ const ProblemCardGrid = (props: ProblemCardGridProps) => {
               key={problemInfo.problemId}
               width={cardWidth}
               problemInfo={problemInfo}
-              isTierHidden={isTierHidden}
+              isTierHidden={![0, 31].includes(problemInfo.tier) && isTierHidden}
               onHover={onCardHover}
             />
           ))}
@@ -57,7 +57,9 @@ const ProblemCardGrid = (props: ProblemCardGridProps) => {
                     key={problemInfo.problemId}
                     width={cardWidth}
                     problemInfo={problemInfo}
-                    isTierHidden={isTierHidden}
+                    isTierHidden={
+                      ![0, 31].includes(problemInfo.tier) && isTierHidden
+                    }
                     onHover={onCardHover}
                   />
                 );

--- a/components/ProblemCardGrid/ProblemCardGrid.tsx
+++ b/components/ProblemCardGrid/ProblemCardGrid.tsx
@@ -35,7 +35,7 @@ const ProblemCardGrid = (props: ProblemCardGridProps) => {
               key={problemInfo.problemId}
               width={cardWidth}
               problemInfo={problemInfo}
-              isTierHidden={false}
+              isTierHidden={isTierHidden}
               onHover={onCardHover}
             />
           ))}

--- a/components/RandomDefenseHistoryMenu/RandomDefenseHistoryList/RandomDefenseHistoryList.tsx
+++ b/components/RandomDefenseHistoryMenu/RandomDefenseHistoryList/RandomDefenseHistoryList.tsx
@@ -15,11 +15,12 @@ const RandomDefenseHistoryList = (props: RandomDefenseHistoryList) => {
     <S.Container>
       {items.map((item) => {
         const id = `${item.problemId}-${item.createdAt}`;
+        const isCurrentTierHidden = ![0, 31].includes(item.tier) && isHidden;
 
         return (
           <RandomDefenseHistoryItem
             key={id}
-            isHidden={isHidden}
+            isHidden={isCurrentTierHidden}
             onDelete={() => {
               onDelete(id);
             }}

--- a/components/RandomDefenseHistoryMenu/RandomDefenseHistoryMenu.styled.ts
+++ b/components/RandomDefenseHistoryMenu/RandomDefenseHistoryMenu.styled.ts
@@ -73,15 +73,12 @@ export const Indicator = styled.div`
   display: flex;
   column-gap: 4px;
 
-  width: 80px;
   height: 20px;
   margin-bottom: 16px;
   margin-right: auto;
 `;
 
-export const IndicatorText = styled.p`
-  display: inline-block;
-
+export const IndicatorText = styled.div`
   color: ${({ theme }) => theme.color.WHITE};
   font-size: 14px;
   line-height: 20px;

--- a/domains/dataHandlers/gachaOptionsHandler.ts
+++ b/domains/dataHandlers/gachaOptionsHandler.ts
@@ -5,8 +5,9 @@ import type { GachaOptionsResponse } from '@/types/gacha';
 
 export const fetchGachaOptions = async (): Promise<GachaOptionsResponse> => {
   const data = await browser.storage.local.get(STORAGE_KEY.GACHA_OPTIONS);
+  const gachaOptions = data[STORAGE_KEY.GACHA_OPTIONS];
 
-  return sanitizeGachaOptionsResponse(data);
+  return sanitizeGachaOptionsResponse(gachaOptions);
 };
 
 export const saveGachaOptions = (gachaOptions: unknown) => {
@@ -15,6 +16,6 @@ export const saveGachaOptions = (gachaOptions: unknown) => {
   }
 
   browser.storage.local.set({
-    [STORAGE_KEY.FONT_NO]: gachaOptions,
+    [STORAGE_KEY.GACHA_OPTIONS]: gachaOptions,
   });
 };

--- a/domains/dataHandlers/randomDefenseHistoryDataHandler.test.ts
+++ b/domains/dataHandlers/randomDefenseHistoryDataHandler.test.ts
@@ -462,7 +462,7 @@ describe('Test #3 - 추첨 기록 한도 대응', () => {
       createdAt: new Date(index).toISOString(),
     }));
 
-    const expectedResult = randomDefenseHistory.slice(0, -123).reverse();
+    const expectedResult = randomDefenseHistory.slice(123).reverse();
 
     jest.spyOn(browser.storage.local, 'get').mockImplementation(() =>
       Promise.resolve({

--- a/domains/dataHandlers/randomDefenseHistoryDataHandler.ts
+++ b/domains/dataHandlers/randomDefenseHistoryDataHandler.ts
@@ -1,19 +1,8 @@
 import { STORAGE_KEY } from '@/constants/commands';
 import { sanitizeRandomDefenseHistory } from './sanitizers/randomDefenseHistorySanitizer';
 import { sanitizeIsTierHidden } from './sanitizers/isTierHiddenSanitizer';
-import type {
-  RandomDefenseHistoryInfo,
-  RandomDefenseHistoryResponse,
-} from '@/types/randomDefense';
+import type { RandomDefenseHistoryResponse } from '@/types/randomDefense';
 import { isRandomDefenseHistoryInfos } from './validators/randomDefenseHistoryValidator';
-
-const getSortedRandomDefenseHistory = (
-  randomDefenseHistory: RandomDefenseHistoryInfo[],
-) => {
-  return [...randomDefenseHistory].sort((a, b) =>
-    a.createdAt > b.createdAt ? -1 : 1,
-  );
-};
 
 export const fetchRandomDefenseHistory =
   async (): Promise<RandomDefenseHistoryResponse> => {
@@ -25,13 +14,10 @@ export const fetchRandomDefenseHistory =
     const isTierHidden = data[STORAGE_KEY.IS_TIER_HIDDEN];
     const sanitizedRandomDefenseHistory =
       sanitizeRandomDefenseHistory(randomDefenseHistory);
-    const sortedRandomDefenseHistory = getSortedRandomDefenseHistory(
-      sanitizedRandomDefenseHistory,
-    );
     const sanitizedIsTierHidden = sanitizeIsTierHidden(isTierHidden);
 
     return {
-      randomDefenseHistory: sortedRandomDefenseHistory,
+      randomDefenseHistory: sanitizedRandomDefenseHistory,
       isHidden: sanitizedIsTierHidden,
     };
   };
@@ -46,12 +32,9 @@ export const saveRandomDefenseHistory = async (
 
   const sanitizedRandomDefenseHistory =
     sanitizeRandomDefenseHistory(randomDefenseHistory);
-  const sortedRandomDefenseHistory = getSortedRandomDefenseHistory(
-    sanitizedRandomDefenseHistory,
-  );
 
   browser.storage.local.set({
-    [STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: sortedRandomDefenseHistory,
+    [STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: sanitizedRandomDefenseHistory,
     [STORAGE_KEY.IS_TIER_HIDDEN]: isHidden,
   });
 };

--- a/domains/dataHandlers/sanitizers/randomDefenseHistorySanitizer.ts
+++ b/domains/dataHandlers/sanitizers/randomDefenseHistorySanitizer.ts
@@ -47,6 +47,14 @@ const isValidLegacyRandomDefenseHistoryInfo = (item: unknown) => {
   );
 };
 
+const getSortedRandomDefenseHistory = (
+  randomDefenseHistory: RandomDefenseHistoryInfo[],
+) => {
+  return [...randomDefenseHistory].sort((a, b) =>
+    a.createdAt > b.createdAt ? -1 : 1,
+  );
+};
+
 export const sanitizeRandomDefenseHistory = (
   randomDefenseHistory: unknown,
 ): RandomDefenseHistoryInfo[] => {
@@ -65,7 +73,10 @@ export const sanitizeRandomDefenseHistory = (
     }
   });
 
-  return sanitizedRandomDefenseHistory.slice(0, MAX_HISTORY_LIMIT);
+  return getSortedRandomDefenseHistory(sanitizedRandomDefenseHistory).slice(
+    0,
+    MAX_HISTORY_LIMIT,
+  );
 };
 
 export const sanitizeLegacyRandomDefenseHistory = (

--- a/domains/randomDefense/randomDefenseProblemChooser.ts
+++ b/domains/randomDefense/randomDefenseProblemChooser.ts
@@ -97,7 +97,7 @@ export const getRandomDefenseResult = async (
       };
     }
 
-    const problemInfos = items.map((item) => {
+    const problemInfos = items.slice(0, problemCount).map((item) => {
       const { problemId, titleKo, level, isLevelLocked } = item;
 
       return {

--- a/hooks/gacha/useRandomDefenseGachaModal.ts
+++ b/hooks/gacha/useRandomDefenseGachaModal.ts
@@ -185,7 +185,9 @@ const useRandomDefenseGachaModal = (
   };
 
   useEffect(() => {
-    restartGacha();
+    if (open) {
+      restartGacha();
+    }
   }, [open, slot, problemCount]);
 
   useEffect(() => {

--- a/hooks/gacha/useRandomDefenseGachaModal.ts
+++ b/hooks/gacha/useRandomDefenseGachaModal.ts
@@ -63,6 +63,7 @@ const useRandomDefenseGachaModal = (
   const [shouldNotificationFadeOut, setShouldNotificationFadeOut] =
     useState(true);
   const [isSavedToHistory, setIsSavedToHistory] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
   const gachaAudioRef = useRef<HTMLAudioElement>(new Audio(gachaAudio));
 
   const previewCardRanks: PreviewCardRanks =
@@ -114,6 +115,7 @@ const useRandomDefenseGachaModal = (
     const { isTierHidden, isAudioMuted } = gachaOptions;
     setIsTierHidden(isTierHidden);
     setIsAudioMuted(isAudioMuted);
+    setIsLoaded(true);
     gachaAudioRef.current.muted = isAudioMuted;
   }, []);
 
@@ -195,12 +197,16 @@ const useRandomDefenseGachaModal = (
   }, []);
 
   useEffect(() => {
+    if (!isLoaded) {
+      return;
+    }
+
     browser.runtime.sendMessage({
       command: COMMANDS.SAVE_GACHA_OPTIONS,
       isTierHidden,
       isAudioMuted,
     });
-  }, [isTierHidden, isAudioMuted]);
+  }, [isLoaded, isTierHidden, isAudioMuted]);
 
   return {
     gachaStatus,

--- a/hooks/gacha/useRandomDefenseGachaModal.ts
+++ b/hooks/gacha/useRandomDefenseGachaModal.ts
@@ -97,7 +97,7 @@ const useRandomDefenseGachaModal = (
     const problemInfos = randomDefenseResult.problemInfos;
     setProblemInfos(problemInfos);
     setGachaStatus('ready');
-  }, []);
+  }, [slot, problemCount]);
 
   const fetchGachaOptions = useCallback(async () => {
     const gachaOptions = await browser.runtime.sendMessage({


### PR DESCRIPTION
## 관련 이슈
- #76 

## PR 설명
본 PR에서는 즉석 추첨 기능 전반에 있어서 발생하는 여러 버그들을 해결했습니다.

#### 1️⃣ [슬롯 및 문제 수가 변경될 때에도 이전의 슬롯으로 랜덤 디펜스를 진행하는 문제를 해결](https://github.com/wzrabbit/boj-totamjung/commit/bda34a53ab1b878bc1364bdefcd025838971bd89)

#### 2️⃣ [모달이 닫혀있을 때 불필요하게 비동기 요청을 하지 않도록 변경](https://github.com/wzrabbit/boj-totamjung/commit/984e2280b893985f2bc8ca0faa9f1c5c6fa7cedd)

#### 3️⃣ [랜덤 디펜스 진행 로직에서 잘못된 문제 수를 반환하는 문제를 해결](https://github.com/wzrabbit/boj-totamjung/commit/d6ef20479fffaf32460a7fcc00f182cd98bfb576)

#### 4️⃣ [카드의 배치가 오버플로우 상태일 때 티어 공개가 OFF임에도 불구하고 티어가 보이는 문제를 해결](https://github.com/wzrabbit/boj-totamjung/commit/450361e3a9c3a1b2f098c159e362f170647d9c05)

#### 5️⃣ [난이도가 UR이거나 NR임에도 티어를 가리는 문제를 해결 (랜덤 디펜스 기록, 즉석 추첨 결과)](https://github.com/wzrabbit/boj-totamjung/commit/45e84e0540a01d2d54674faf6c24dd2dd0ac32e5)

#### 6️⃣ [즉석 추첨 모달의 설정을 불러오기 전 저장을 진행해 기본 설정이 덮어씌워지는 문제를 해결](https://github.com/wzrabbit/boj-totamjung/commit/a25fa832f0c880f0757267b809c86ce69b37aa4a)

#### 7️⃣ [즉석 추첨 설정의 데이터를 잘못 가공하고 있는 문제를 해결](https://github.com/wzrabbit/boj-totamjung/commit/ac46be64d96928533752e11709a71706eca6b6d5)

#### 8️⃣ [난이도가 UR이거나 NR임에도 티어를 가리는 문제를 해결 (카드 상자)](https://github.com/wzrabbit/boj-totamjung/commit/90aa61172873ecc1917ee3d20e1d518aa31ddeb7)

#### 9️⃣ [랜덤 디펜스 기록 컴포넌트에서 저장 문제 수를 표시하는 UI가 다음 줄로 넘어가는 문제를 해결](https://github.com/wzrabbit/boj-totamjung/commit/5773a3e60087d3c35a80f1ac6291a016208cbd4e)

#### 🔟 [랜덤 디펜스 기록이 저장 한도 수를 넘을 경우 최신 데이터가 손실되는 문제를 해결](https://github.com/wzrabbit/boj-totamjung/commit/260d2747003d3814ca010d8981bca2efee94ca58)
