### PR TITLE
[FEAT] 추첨 기록에 남은 문제 용량 수에 따라 UI를 변화시키고 경고하는 기능을 추가

### DIFF
--- a/components/RandomDefenseHistoryMenu/RandomDefenseHistoryMenu.styled.ts
+++ b/components/RandomDefenseHistoryMenu/RandomDefenseHistoryMenu.styled.ts
@@ -78,8 +78,8 @@ export const Indicator = styled.div`
   margin-right: auto;
 `;
 
-export const IndicatorText = styled.div`
-  color: ${({ theme }) => theme.color.WHITE};
+export const IndicatorText = styled.div<{ $color: string }>`
+  color: ${({ $color }) => $color};
   font-size: 14px;
   line-height: 20px;
 `;

--- a/components/RandomDefenseHistoryMenu/RandomDefenseHistoryMenu.tsx
+++ b/components/RandomDefenseHistoryMenu/RandomDefenseHistoryMenu.tsx
@@ -4,9 +4,41 @@ import * as S from './RandomDefenseHistoryMenu.styled';
 import Switch from '@/components/common/Switch';
 import NamedFrame from '@/components/common/NamedFrame/NamedFrame';
 import { TrashIcon, PackageIcon } from '@/assets/svg';
-import { MAX_HISTORY_LIMIT } from '@/constants/randomDefense';
+import {
+  MAX_HISTORY_LIMIT,
+  MAX_PROBLEM_COUNT_PER_RANDOM_DEFENSE,
+} from '@/constants/randomDefense';
 import SimpleModal from '@/components/common/SimpleModal';
 import useModal from '@/hooks/useModal';
+import { theme } from '@/styles/theme';
+
+const getIndicatorMessageInfo = (itemsCount: number) => {
+  const historyCapacityLeftSpaceCount = MAX_HISTORY_LIMIT - itemsCount;
+  const historyCapacityStatus =
+    historyCapacityLeftSpaceCount >= MAX_PROBLEM_COUNT_PER_RANDOM_DEFENSE
+      ? 'normal'
+      : historyCapacityLeftSpaceCount > 0
+        ? 'warn'
+        : 'danger';
+
+  const indicatorDefaultMessage = `현재 ${itemsCount}문제가 기록에 저장되어 있으며, 저장할 수 있는 최대 문제 수는 ${MAX_HISTORY_LIMIT}문제입니다.\n저장할 수 있는 최대 문제 수를 넘을 경우 오래된 문제 순으로 기록에서 삭제됩니다.`;
+  const indicatorExtraMessage =
+    historyCapacityStatus === 'warn'
+      ? '\n\n저장된 문제 수가 최대 문제 수에 가까워지고 있습니다. 원치 않는 기록 삭제를 방지하려면 문제 공간을 확보해 주세요.'
+      : historyCapacityStatus === 'danger'
+        ? '\n\n저장된 문제 수가 최대 문제 수에 도달했습니다. 이 상태에서는 추첨 진행 시 오래된 기록들이 삭제될 것입니다. 원치 않는 기록 삭제를 방지하려면 문제 공간을 확보해 주세요.'
+        : '';
+
+  const indicatorMessage = `${indicatorDefaultMessage}${indicatorExtraMessage}`;
+  const indicatorColor =
+    historyCapacityStatus === 'normal'
+      ? theme.color.WHITE
+      : historyCapacityStatus === 'warn'
+        ? theme.color.ORANGE
+        : theme.color.LIGHT_RED;
+
+  return { indicatorMessage, indicatorColor };
+};
 
 const RandomDefenseHistoryMenu = () => {
   const {
@@ -20,6 +52,9 @@ const RandomDefenseHistoryMenu = () => {
   } = useRandomDefenseHistoryMenu();
   const { activeModalName, openModal, closeModal } =
     useModal<'confirmClearHistory'>();
+  const { indicatorMessage, indicatorColor } = getIndicatorMessageInfo(
+    items.length,
+  );
 
   return (
     <NamedFrame width="370px" height="553px" padding="10px" title="추첨 기록">
@@ -43,11 +78,13 @@ const RandomDefenseHistoryMenu = () => {
               />
             </S.HistoryListContainer>
             <S.HistoryManagePanel>
-              <S.Indicator>
+              <S.Indicator title={indicatorMessage}>
                 <S.PackageIconWrapper>
                   <PackageIcon />
                 </S.PackageIconWrapper>
-                <S.IndicatorText>{`${items.length} / ${MAX_HISTORY_LIMIT}`}</S.IndicatorText>
+                <S.IndicatorText
+                  $color={indicatorColor}
+                >{`${items.length} / ${MAX_HISTORY_LIMIT}`}</S.IndicatorText>
               </S.Indicator>
               <S.Text>추첨 기록 비우기</S.Text>
               <S.DeleteButton


### PR DESCRIPTION
## PR 설명

본 PR에서는 추첨 기록에 있는 남은 문제 용량 수에 따라 UI를 변화시키고 경고하는 기능을 추가했습니다.
- 50문제 미만으로 용량이 남았을 경우 **주황색**, 꽉 찼을 경우 **빨간색** 글씨로 현재 저장된 문제 수를 표시합니다.
- 인디케이터에 마우스를 가져다대면 기본 툴팁이 표시되며, 용량이 얼마 남지 않았을 경우에는 경고의 의미가 담긴 다른 툴팁이 보여집니다.

![image](https://github.com/user-attachments/assets/c8d2e685-ad90-4ee0-98b2-9466c9527d65)
