### PR TITLE
[FEAT] 마우스를 길게 누르거나 단축키를 길게 눌러 즉석 추첨을 진행할 수 있는 기능을 추가

### DIFF
--- a/components/ProblemCard/ProblemCard.styled.ts
+++ b/components/ProblemCard/ProblemCard.styled.ts
@@ -150,6 +150,7 @@ export const ProblemId = styled.div.attrs<{ $cardWidth: number }>(
   ({ $cardWidth }) => ({
     style: {
       fontSize: `${$cardWidth / 7.531}px`,
+      lineHeight: `${$cardWidth / 7.531}px`,
     },
   }),
 )<{

--- a/components/RandomDefenseGachaModal/RandomDefenseGachaModal.styled.ts
+++ b/components/RandomDefenseGachaModal/RandomDefenseGachaModal.styled.ts
@@ -98,6 +98,11 @@ export const Container = styled.div`
   & > div {
     flex-grow: 1;
   }
+
+  &,
+  & * {
+    font-family: Pretendard;
+  }
 `;
 
 export const ToggleButtonContainer = styled.div<{ $align: 'left' | 'right' }>`

--- a/components/Widget/Widget.stories.tsx
+++ b/components/Widget/Widget.stories.tsx
@@ -34,6 +34,7 @@ export const Default: Story = {
     ),
   ],
   args: {
+    rootElement: document.body,
     theme: 'none',
     onChangeTheme: fn(),
     onToast: fn(),

--- a/components/Widget/Widget.styled.ts
+++ b/components/Widget/Widget.styled.ts
@@ -1,4 +1,4 @@
-import { styled, keyframes } from 'styled-components';
+import { styled, keyframes, css } from 'styled-components';
 
 export const Container = styled.div`
   padding-top: 10px;
@@ -150,9 +150,7 @@ export const DropdownMenuItem = styled.li`
   height: 32px;
 `;
 
-export const DropdownMenuButton = styled.button<{
-  $widgetTheme: 'none' | 'totamjung';
-}>`
+const dropdownMenuButtonStyles = css`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -163,16 +161,9 @@ export const DropdownMenuButton = styled.button<{
   background: transparent;
 
   transition: background-color 0.3s;
-
-  & > img {
-    filter: ${({ theme, $widgetTheme }) =>
-      $widgetTheme === 'none'
-        ? theme.filter.BOJ_BLUE_FILTER
-        : theme.filter.LIGHT_BROWN_FILTER};
-  }
 `;
 
-export const DropdownButtonIcon = styled.img`
+export const DropdownButtonIcon = styled.img.attrs({ draggable: false })`
   width: auto;
   height: 26px;
 
@@ -182,12 +173,68 @@ export const DropdownButtonIcon = styled.img`
     opacity: 0.6;
   }
 
-  button:not(:disabled) > &:hover {
+  button:not(:disabled):hover > & {
     transform: scale(1.1);
   }
 
-  button:not(:disabled) > &:active {
+  button:not(:disabled):active > & {
     transform: scale(1);
+  }
+`;
+
+export const DropdownMenuButton = styled.button<{
+  $widgetTheme: 'none' | 'totamjung';
+}>`
+  ${dropdownMenuButtonStyles}
+
+  & > ${DropdownButtonIcon} {
+    filter: ${({ theme, $widgetTheme }) => {
+      return $widgetTheme === 'none'
+        ? theme.filter.BOJ_BLUE_FILTER
+        : theme.filter.LIGHT_BROWN_FILTER;
+    }};
+  }
+`;
+
+const maskFillUp = keyframes`
+  from {
+    mask-position: 0% 0%;
+  }
+
+  to {
+    mask-position: 0% 100%;
+  }
+`;
+
+export const RandomDefenseButton = styled.button<{
+  $widgetTheme: 'none' | 'totamjung';
+}>`
+  ${dropdownMenuButtonStyles}
+
+  & > ${DropdownButtonIcon} {
+    filter: ${({ theme, $widgetTheme }) => {
+      return $widgetTheme === 'none'
+        ? theme.filter.BOJ_BLUE_FILTER
+        : theme.filter.LIGHT_BROWN_FILTER;
+    }};
+  }
+
+  &.pressing:after {
+    content: '';
+    position: absolute;
+
+    width: 24.79px;
+    height: 26px;
+
+    background-image: url(${browser.runtime.getURL('/dice.png')});
+    background-size: 24.79px 26px;
+    filter: ${({ theme }) => theme.filter.LIGHT_GRAY_FILTER};
+    mix-blend-mode: color-dodge;
+    opacity: 0.4;
+    mask-image: linear-gradient(to bottom, transparent 50%, black 50%);
+    mask-size: 100% 200%;
+
+    animation: ${maskFillUp} 0.8s 0.2s forwards linear;
   }
 `;
 

--- a/components/Widget/Widget.tsx
+++ b/components/Widget/Widget.tsx
@@ -7,35 +7,45 @@ import type { TotamjungTheme } from '@/types/totamjungTheme';
 import type { ToastInfo } from '@/types/toast';
 import { createPortal } from 'react-dom';
 import { $ } from '@/utils/querySelector';
+import GachaProblemCountInputModal from '@/components/GachaProblemCountInputModal';
+import RandomDefenseGachaModal from '../RandomDefenseGachaModal';
 
 interface WidgetProps {
   theme: TotamjungTheme;
+  rootElement: HTMLElement;
   onChangeTheme: (theme: TotamjungTheme) => void;
   onToast: (toastInfo: ToastInfo, duration: number) => void;
 }
 
 const Widget = (props: WidgetProps) => {
-  const { theme } = props;
+  const { theme, rootElement } = props;
   const {
     isExpanded,
     isScrollingToTop,
     hasUnknownAlgorithms,
     isRandomDefenseButtonDisabled,
+    isRandomDefenseButtonPressing,
+    gachaProblemCount,
+    gachaSlot,
     isInspectButtonDisabled,
     isLockButtonDisabled,
     shouldShowInspectIcon,
     shouldShowWelcomeMessage,
+    activeModalName,
     isLoaded,
     scrollToTop,
     endScrollingAnimation,
     toggleWidgetOpen,
     openOptionsPage,
     toggleTotamjungTheme,
-    performRandomDefenseByClick,
+    openGachaModalWithProblemCount,
+    suspendGacha,
     showInspectResultUsingPopup,
     toggleTimer,
     closeWelcomeMessage,
+    randomDefenseButtonRef,
   } = useWidget(props);
+
   const problemTitleElement = $('#problem_title');
 
   return (
@@ -83,17 +93,18 @@ const Widget = (props: WidgetProps) => {
               </S.DropdownMenuButton>
             </S.DropdownMenuItem>
             <S.DropdownMenuItem>
-              <S.DropdownMenuButton
+              <S.RandomDefenseButton
+                ref={randomDefenseButtonRef}
                 type="button"
+                className={isRandomDefenseButtonPressing ? 'pressing' : ''}
                 $widgetTheme={theme}
                 aria-label="랜덤 디펜스 진행하기"
                 disabled={isRandomDefenseButtonDisabled}
-                onClick={performRandomDefenseByClick}
               >
                 <S.DropdownButtonIcon
                   src={browser.runtime.getURL('/dice.png')}
                 />
-              </S.DropdownMenuButton>
+              </S.RandomDefenseButton>
             </S.DropdownMenuItem>
             <S.DropdownMenuItem>
               <S.DropdownMenuButton
@@ -157,6 +168,24 @@ const Widget = (props: WidgetProps) => {
                 onClose={closeWelcomeMessage}
               />
             </S.SpeechBubbleWrapper>
+          )}
+          <GachaProblemCountInputModal
+            open={activeModalName === 'gachaProblemCount'}
+            portalTarget={rootElement}
+            theme={theme}
+            shouldShowHotkeyMessage={false}
+            onClose={suspendGacha}
+            onSubmitProblemCount={openGachaModalWithProblemCount}
+          />
+          {gachaSlot && (
+            <RandomDefenseGachaModal
+              open={activeModalName === 'gacha'}
+              portalTarget={rootElement}
+              theme={theme}
+              slot={gachaSlot}
+              problemCount={gachaProblemCount}
+              onClose={suspendGacha}
+            />
           )}
         </>
       )}

--- a/components/core/ContentScript/ContentScript.tsx
+++ b/components/core/ContentScript/ContentScript.tsx
@@ -7,22 +7,26 @@ const ContentScript = () => {
   const { totamjungTheme, isLoaded, updateTotamjungTheme } =
     useTotamjungThemeState();
   const { toastState, showToast, closeToast } = useToastState();
+  const totamjungRootRef = useRef<HTMLDivElement>(null);
 
   return (
-    isLoaded && (
-      <div style={{ position: 'relative', zIndex: 10000 }}>
-        <Widget
-          theme={totamjungTheme}
-          onChangeTheme={updateTotamjungTheme}
-          onToast={showToast}
-        />
-        <LeftSlideToast
-          theme={totamjungTheme}
-          onClose={closeToast}
-          {...toastState}
-        />
-      </div>
-    )
+    <div ref={totamjungRootRef} style={{ position: 'relative', zIndex: 10000 }}>
+      {isLoaded && totamjungRootRef.current && (
+        <>
+          <Widget
+            theme={totamjungTheme}
+            rootElement={totamjungRootRef.current}
+            onChangeTheme={updateTotamjungTheme}
+            onToast={showToast}
+          />
+          <LeftSlideToast
+            theme={totamjungTheme}
+            onClose={closeToast}
+            {...toastState}
+          />
+        </>
+      )}
+    </div>
   );
 };
 

--- a/hooks/useHotkeyLongPress.ts
+++ b/hooks/useHotkeyLongPress.ts
@@ -1,0 +1,155 @@
+import type { Hotkey } from '@/types/randomDefense';
+import { useState, useRef, useEffect } from 'react';
+import type { SlotNo } from '@/types/randomDefense';
+import { isSlotNo } from '@/domains/dataHandlers/validators/quickSlotsValidator';
+
+interface UseHotkeyLongPressParams {
+  requiredLongPressTimeInMilliseconds: number;
+  baseKey: Hotkey;
+  onPress: (numberKey: SlotNo) => void;
+  onLongPress: (numberKey: SlotNo) => void;
+}
+
+type PressingBaseKey = 'F2' | 'AltLeft' | 'AltRight';
+
+const isHotkeyRelatedKey = (key: string, code: string, altKey: boolean) => {
+  return (
+    key === 'Alt' ||
+    code === 'AltLeft' ||
+    code === 'AltRight' ||
+    key === 'F2' ||
+    code === 'F2' ||
+    altKey ||
+    !isNaN(Number(key)) ||
+    code.startsWith('Digit')
+  );
+};
+
+const useHotKeyLongPress = (params: UseHotkeyLongPressParams) => {
+  const {
+    requiredLongPressTimeInMilliseconds,
+    baseKey: initBaseKey,
+    onPress,
+    onLongPress,
+  } = params;
+  const [baseKey, setBaseKey] = useState<Hotkey>(initBaseKey);
+  const [isHotkeyLocked, setIsHotkeyLocked] = useState(false);
+  const pressingBaseKeyRef = useRef<PressingBaseKey | null>(null);
+  const pressingNumberKeyRef = useRef<number | null>(null);
+  const isHotkeyPressingRef = useRef(false);
+  const keyPressTimerRef = useRef<NodeJS.Timeout | undefined>(undefined);
+
+  const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+    const { key, code, altKey } = event;
+
+    if (
+      isHotkeyPressingRef.current ||
+      isHotkeyLocked ||
+      !isHotkeyRelatedKey(key, code, altKey)
+    ) {
+      return;
+    }
+
+    if (
+      pressingBaseKeyRef.current === null &&
+      baseKey === 'Alt' &&
+      (key === 'Alt' || code === 'AltLeft' || code === 'AltRight' || altKey)
+    ) {
+      pressingBaseKeyRef.current = code === 'AltRight' ? 'AltRight' : 'AltLeft';
+    }
+
+    if (
+      pressingBaseKeyRef.current === null &&
+      baseKey === 'F2' &&
+      (key === 'F2' || code === 'F2')
+    ) {
+      pressingBaseKeyRef.current = 'F2';
+    }
+
+    if (
+      pressingNumberKeyRef.current === null &&
+      pressingBaseKeyRef.current !== null
+    ) {
+      if (!isNaN(Number(key))) {
+        pressingNumberKeyRef.current = Number(key);
+      }
+
+      if (code.startsWith('Digit')) {
+        pressingNumberKeyRef.current = Number(code.at(-1));
+      }
+
+      const triggeredNumberKey = pressingNumberKeyRef.current;
+
+      if (
+        typeof triggeredNumberKey === 'number' &&
+        isSlotNo(triggeredNumberKey)
+      ) {
+        isHotkeyPressingRef.current = true;
+
+        keyPressTimerRef.current = setTimeout(() => {
+          setIsHotkeyLocked(true);
+          onLongPress(triggeredNumberKey);
+        }, requiredLongPressTimeInMilliseconds);
+      }
+    }
+  };
+
+  const handleKeyUp = (event: globalThis.KeyboardEvent) => {
+    const { key, code, altKey } = event;
+
+    if (isHotkeyLocked || !isHotkeyRelatedKey(key, code, altKey)) {
+      return;
+    }
+
+    const isAltKeyRelease =
+      (baseKey === 'Alt' && code === pressingBaseKeyRef.current) ||
+      (pressingBaseKeyRef.current === 'AltLeft' &&
+        (key === 'Alt' || key === 'AltLeft'));
+    const isF2KeyRelease =
+      baseKey === 'F2' && (key === 'F2' || code === pressingBaseKeyRef.current);
+    const isNumberKeyRelease =
+      pressingNumberKeyRef.current === Number(key) ||
+      pressingNumberKeyRef.current === Number(code.at(-1));
+
+    if (isAltKeyRelease || isF2KeyRelease || isNumberKeyRelease) {
+      const triggeredNumberKey = pressingNumberKeyRef.current;
+
+      pressingBaseKeyRef.current = null;
+      pressingNumberKeyRef.current = null;
+      clearTimeout(keyPressTimerRef.current);
+      isHotkeyPressingRef.current = false;
+
+      if (
+        typeof triggeredNumberKey === 'number' &&
+        isSlotNo(triggeredNumberKey) &&
+        !isHotkeyLocked
+      ) {
+        onPress(triggeredNumberKey);
+        setIsHotkeyLocked(true);
+      }
+    }
+  };
+
+  /**
+   * 랜덤 디펜스 실행 조건이 만족되는 경우에는 중복 실행을 방지하도록 잠금이 설정됩니다.
+   * 랜덤 디펜스에 실패했거나 다른 처리를 해야하는 이유로 이 잠금을 해제하고 싶은 경우에 사용해 주세요.
+   */
+  const unlockHotkey = () => {
+    setIsHotkeyLocked(false);
+  };
+
+  useEffect(() => {
+    setBaseKey(initBaseKey);
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('keyup', handleKeyUp);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [initBaseKey, isHotkeyLocked]);
+
+  return { unlockHotkey };
+};
+
+export default useHotKeyLongPress;

--- a/hooks/useMouseLongPress.ts
+++ b/hooks/useMouseLongPress.ts
@@ -1,0 +1,64 @@
+import { useState, useEffect, useRef } from 'react';
+
+interface UseMouseLongPressParams {
+  requiredLongPressTimeInMilliseconds: number;
+  onClick: () => void;
+  onLongPress: () => void;
+}
+
+const useMouseLongPress = (params: UseMouseLongPressParams) => {
+  const { requiredLongPressTimeInMilliseconds, onClick, onLongPress } = params;
+  const [isPressing, setIsPressing] = useState(false);
+  const isPressingRef = useRef(false);
+  const mousePressTimerRef = useRef<NodeJS.Timeout | undefined>(undefined);
+  const longPressRef = useRef<HTMLButtonElement>(null);
+
+  const handleMouseDown = () => {
+    clearTimeout(mousePressTimerRef.current);
+
+    mousePressTimerRef.current = setTimeout(() => {
+      onLongPress();
+      isPressingRef.current = false;
+      setIsPressing(false);
+    }, requiredLongPressTimeInMilliseconds);
+
+    setIsPressing(true);
+    isPressingRef.current = true;
+  };
+
+  const handleMouseUp = () => {
+    if (isPressingRef.current) {
+      onClick();
+      clearTimeout(mousePressTimerRef.current);
+    }
+
+    setIsPressing(false);
+    isPressingRef.current = false;
+  };
+
+  const handleMouseLeave = () => {
+    clearTimeout(mousePressTimerRef.current);
+    setIsPressing(false);
+    isPressingRef.current = false;
+  };
+
+  useEffect(() => {
+    const longPressElement = longPressRef.current;
+
+    if (!longPressElement) {
+      return;
+    }
+
+    longPressElement.addEventListener('mousedown', handleMouseDown);
+    longPressElement.addEventListener('mouseup', handleMouseUp);
+    longPressElement.addEventListener('mouseleave', handleMouseLeave);
+
+    return () => {
+      clearTimeout(mousePressTimerRef.current);
+    };
+  }, [longPressRef.current]);
+
+  return { isPressing, longPressRef };
+};
+
+export default useMouseLongPress;

--- a/hooks/widget/useWidget.ts
+++ b/hooks/widget/useWidget.ts
@@ -5,11 +5,13 @@ import { isValidCheckedAlgorithmIdsResponse } from '@/domains/dataHandlers/valid
 import { isHiderOptionsResponse } from '@/domains/dataHandlers/validators/hiderOptionsValidator';
 import useInjectedProblemTags from './useInjectedProblemTags';
 import useRandomDefense from './useRandomDefense';
+import useModal from '@/hooks/useModal';
 import { changeNormalToWarnTier } from '@/domains/tierHider/normalToWarnTierChanger';
+import { isShouldShowWelcomeMessage } from '@/domains/dataHandlers/validators/isShouldShowWelcomeMessageDataValidator';
 import type { ToastInfo } from '@/types/toast';
 import type { TotamjungTheme } from '@/types/totamjungTheme';
 import type { HiderOptionsResponse } from '@/types/algorithm';
-import { isShouldShowWelcomeMessage } from '@/domains/dataHandlers/validators/isShouldShowWelcomeMessageDataValidator';
+import { FilledSlot } from '@/types/randomDefense';
 
 interface UseWidgetParams {
   theme: TotamjungTheme;
@@ -28,13 +30,31 @@ const useWidget = (params: UseWidgetParams) => {
   const [inspectIconState, setInspectIconState] = useState(false);
   const [shouldShowWelcomeMessage, setShouldShowWelcomeMessage] =
     useState(false);
+  const [gachaSlot, setGachaSlot] = useState<FilledSlot | null>(null);
+  const [gachaProblemCount, setGachaProblemCount] = useState(0);
   const [isLoaded, setIsLoaded] = useState(false);
   const { hasUnknownAlgorithms, isSpoilerExist, isSpoilerOpened, toggleTimer } =
     useInjectedProblemTags({ checkedIds, hiderOptions });
-  const { isRandomDefenseAvailable, performRandomDefenseByClick } =
-    useRandomDefense({
-      onToast,
-    });
+  const { activeModalName, openModal, closeModal } = useModal<
+    'gachaProblemCount' | 'gacha'
+  >();
+  const {
+    isRandomDefenseAvailable,
+    performRandomDefenseByClick,
+    performRandomDefenseByMouseLongPress,
+    enableRandomDefense,
+  } = useRandomDefense({
+    onToast,
+    onGachaStart: (slot) => openGachaProblemCountModalWithSlotInfo(slot),
+  });
+  const {
+    isPressing: isRandomDefenseButtonPressing,
+    longPressRef: randomDefenseButtonRef,
+  } = useMouseLongPress({
+    requiredLongPressTimeInMilliseconds: 1000,
+    onClick: performRandomDefenseByClick,
+    onLongPress: performRandomDefenseByMouseLongPress,
+  });
 
   const isRandomDefenseButtonDisabled = !isRandomDefenseAvailable;
   const isInspectButtonDisabled =
@@ -156,6 +176,26 @@ const useWidget = (params: UseWidgetParams) => {
     }
   };
 
+  const openGachaProblemCountModalWithSlotInfo = (slot: FilledSlot) => {
+    openModal('gachaProblemCount');
+    setGachaSlot(slot);
+  };
+
+  const openGachaModalWithProblemCount = (problemCount: number) => {
+    if (!gachaSlot) {
+      return;
+    }
+
+    openModal('gacha');
+    setGachaProblemCount(problemCount);
+  };
+
+  const suspendGacha = () => {
+    closeModal();
+    setGachaSlot(null);
+    enableRandomDefense();
+  };
+
   const closeWelcomeMessage = () => {
     setShouldShowWelcomeMessage(false);
     browser.runtime.sendMessage({
@@ -169,20 +209,26 @@ const useWidget = (params: UseWidgetParams) => {
     isScrollingToTop,
     hasUnknownAlgorithms,
     isRandomDefenseButtonDisabled,
+    isRandomDefenseButtonPressing,
+    gachaProblemCount,
+    gachaSlot,
     isInspectButtonDisabled,
     isLockButtonDisabled,
     shouldShowInspectIcon,
     shouldShowWelcomeMessage,
+    activeModalName,
     isLoaded,
     scrollToTop,
     endScrollingAnimation,
     toggleWidgetOpen,
     openOptionsPage,
     toggleTotamjungTheme,
-    performRandomDefenseByClick,
+    openGachaModalWithProblemCount,
+    suspendGacha,
     showInspectResultUsingPopup,
     toggleTimer,
     closeWelcomeMessage,
+    randomDefenseButtonRef,
   };
 };
 

--- a/hooks/widget/useWidget.ts
+++ b/hooks/widget/useWidget.ts
@@ -6,6 +6,7 @@ import { isHiderOptionsResponse } from '@/domains/dataHandlers/validators/hiderO
 import useInjectedProblemTags from './useInjectedProblemTags';
 import useRandomDefense from './useRandomDefense';
 import useModal from '@/hooks/useModal';
+import useMouseLongPress from '@/hooks/useMouseLongPress';
 import { changeNormalToWarnTier } from '@/domains/tierHider/normalToWarnTierChanger';
 import { isShouldShowWelcomeMessage } from '@/domains/dataHandlers/validators/isShouldShowWelcomeMessageDataValidator';
 import type { ToastInfo } from '@/types/toast';


### PR DESCRIPTION
## 관련 이슈
- #76 

## PR 설명
본 PR에서는 백준 사이트 내에서도 마우스를 길게 누르거나 단축키를 길게 눌러 즉석 추첨을 진행할 수 있는 기능을 추가하였습니다.
- 랜덤 디펜스 단축키를 **길게** 누르는 경우 슬롯에 대응하는 문제를 한 문제 추첨하는 대신 즉석 추첨 기능을 실행합니다.
- 위젯에서 랜덤 디펜스 버튼을 **길게** 누르는 경우 게이지가 차오르며, 게이지가 꽉 차면 역시 슬롯에 대응하는 문제를 한 문제 추첨하는 대신 즉석 추첨 기능을 실행합니다.


https://github.com/user-attachments/assets/22f5b60e-3aa9-4786-930c-c634fa2b8633

