### PR TITLE
[FEAT] 마우스를 티어 아이콘 위에 올리면 숨겨진 티어를 공개할 수 있는 설정을 추가

### DIFF
--- a/assets/css/tierHider.css
+++ b/assets/css/tierHider.css
@@ -7,6 +7,24 @@ html[hideTier='true']
   content: url('/public/solvedac-tier-hidden.svg');
 }
 
+html[hideTier='true']
+  .page-header:has(#problem_title):not(:has(.problem-label-ac))
+  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']).warn {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
+html[hideTier='revealOnHover']
+  .page-header:has(#problem_title):not(:has(.problem-label-ac))
+  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='revealOnHover']
+  .page-header:has(#problem_title):not(:has(.problem-label-ac))
+  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']).warn:not(:hover) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
 html[hideTier='loading']
   .page-header:has(#problem_title):not(:has(.problem-label-ac))
   .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
@@ -32,6 +50,22 @@ html[hideTier='true']
   content: '어려운 문제 경고';
 }
 
+html[hideTier='revealOnHover']
+  .row:has(#problem_title):not(:has(.problem-label-ac))
+  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover)
+  + span::after {
+  color: #a4a4a4;
+  content: '난이도 숨겨짐';
+}
+
+html[hideTier='revealOnHover']
+  .row:has(#problem_title):not(:has(.problem-label-ac))
+  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover)
+  + span.warn::after {
+  color: #b72929;
+  content: '어려운 문제 경고';
+}
+
 html[hideTier='loading']
   .row:has(#problem_title):not(:has(.problem-label-ac))
   .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg'])
@@ -47,6 +81,27 @@ html[hideTier='true']
   tr:not(:has(.problem-label-ac))
   .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
   content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='true']
+  #problemset
+  tr:not(:has(.problem-label-ac))
+  .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
+html[hideTier='revealOnHover']
+  #problemset
+  tr:not(:has(.problem-label-ac))
+  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='revealOnHover']
+  #problemset
+  tr:not(:has(.problem-label-ac))
+  .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-warn.svg');
 }
 
 html[hideTier='loading']
@@ -66,6 +121,27 @@ html[hideTier='true']
   content: url('/public/solvedac-tier-hidden.svg');
 }
 
+html[hideTier='true']
+  #status-table
+  td:nth-child(3):not(:has(.result-ac))
+  .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
+html[hideTier='revealOnHover']
+  #status-table
+  td:nth-child(3):not(:has(.result-ac))
+  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='revealOnHover']
+  #status-table
+  td:nth-child(3):not(:has(.result-ac))
+  .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
 html[hideTier='loading']
   #status-table
   td:nth-child(3):not(:has(.result-ac))
@@ -83,6 +159,33 @@ html[hideTier='true']
   td:nth-child(2):not(:has(.result-ac))
   > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
   content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='true']
+  .col-md-12:has(a[href='/board/list/solvedac'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  td:nth-child(2):not(:has(.result-ac))
+  > .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
+html[hideTier='revealOnHover']
+  .col-md-12:has(a[href='/board/list/solvedac'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  td:nth-child(2):not(:has(.result-ac))
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='revealOnHover']
+  .col-md-12:has(a[href='/board/list/solvedac'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  td:nth-child(2):not(:has(.result-ac))
+  > .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-warn.svg');
 }
 
 html[hideTier='loading']
@@ -105,6 +208,30 @@ html[hideTier='true']
   content: url('/public/solvedac-tier-hidden.svg');
 }
 
+html[hideTier='true']
+  .col-md-12:has(a[href='/board/list/solvedac'])
+  ~ .col-md-12
+  blockquote
+  > .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
+html[hideTier='revealOnHover']
+  .col-md-12:has(a[href='/board/list/solvedac'])
+  ~ .col-md-12
+  blockquote
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='revealOnHover']
+  .col-md-12:has(a[href='/board/list/solvedac'])
+  ~ .col-md-12
+  blockquote
+  > .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
 html[hideTier='loading']
   .col-md-12:has(a[href='/board/list/solvedac'])
   ~ .col-md-12
@@ -119,6 +246,21 @@ html[hideTier='loading']
 html[hideTier='true'] .nav.nav-pills.no-print.problem-menu:not(:has(a[href^="https://solved.ac/contribute/"]))
  .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
   content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='true'] .nav.nav-pills.no-print.problem-menu:not(:has(a[href^="https://solved.ac/contribute/"]))
+ .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
+html[hideTier='revealOnHover'] .nav.nav-pills.no-print.problem-menu:not(:has(a[href^="https://solved.ac/contribute/"]))
+ .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='revealOnHover'] .nav.nav-pills.no-print.problem-menu:not(:has(a[href^="https://solved.ac/contribute/"]))
+ .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-warn.svg');
 }
 
 html[hideTier='loading'] .nav.nav-pills.no-print.problem-menu:not(:has(a[href^="https://solved.ac/contribute/"]))
@@ -137,6 +279,36 @@ html[hideTier='true']
   > td:nth-child(3)
   > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
   content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='true']
+  .row:has(li[class='active'] > a[href='/category'])
+  ~ .row
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  > td:nth-child(3)
+  > .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
+html[hideTier='revealOnHover']
+  .row:has(li[class='active'] > a[href='/category'])
+  ~ .row
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  > td:nth-child(3)
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='revealOnHover']
+  .row:has(li[class='active'] > a[href='/category'])
+  ~ .row
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  > td:nth-child(3)
+  > .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-warn.svg');
 }
 
 html[hideTier='loading']
@@ -162,6 +334,36 @@ html[hideTier='true']
   content: url('/public/solvedac-tier-hidden.svg');
 }
 
+html[hideTier='true']
+  .col-md-12:has(a[href='/workbook/top'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  td:nth-child(2)
+  > .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
+html[hideTier='revealOnHover']
+  .col-md-12:has(a[href='/workbook/top'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  td:nth-child(2)
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='revealOnHover']
+  .col-md-12:has(a[href='/workbook/top'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  td:nth-child(2)
+  > .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
 html[hideTier='loading']
   .col-md-12:has(a[href='/workbook/top'])
   ~ .col-md-12
@@ -182,6 +384,20 @@ html[hideTier='true']
 
 html[hideTier='true']
   .problem-link-style-box.warn:not(.result-ac):not([data-tier='0'])::before {
+  content: url('/public/solvedac-tier-warn.svg') !important;
+}
+
+html[hideTier='revealOnHover']
+  .problem-link-style-box:not(.result-ac):not([data-tier='0']):not(
+    :hover
+  )::before {
+  content: url('/public/solvedac-tier-hidden.svg') !important;
+}
+
+html[hideTier='revealOnHover']
+  .problem-link-style-box.warn:not(.result-ac):not([data-tier='0']):not(
+    :hover
+  )::before {
   content: url('/public/solvedac-tier-warn.svg') !important;
 }
 

--- a/components/HiderMenu/HiderFieldsetMenu.tsx
+++ b/components/HiderMenu/HiderFieldsetMenu.tsx
@@ -3,7 +3,6 @@ import Fieldset from '@/components/common/Fieldset';
 import TierSelect from '@/components/TierSelect';
 import Text from '@/components/common/Text';
 import ProblemTagLockTimer from '@/components/ProblemTagLockTimer';
-import TextLink from '@/components/common/TextLink';
 import { ToolsIcon } from '@/assets/svg';
 import { hiddenTierBadgeIcon } from '@/assets/png';
 import useHiderFieldsetMenu from '@/hooks/algorithm/useHiderFieldsetMenu';
@@ -14,12 +13,14 @@ const HiderFieldsetMenu = () => {
     problemTagLockDuration,
     shouldHideTier,
     shouldWarnHighTier,
+    shouldRevealTierOnHover,
     warnTier,
     algorithmHiderUsage,
     problemTagLockUsage,
     updateProblemTagLockDuration,
     updateShouldHideTier,
     updateShouldWarnHighTier,
+    updateShouldRevealTierOnHover,
     updateWarnTier,
     updateAlgorithmHiderUsage,
     updateProblemTagLockUsage,
@@ -72,13 +73,17 @@ const HiderFieldsetMenu = () => {
         checkedValue={shouldWarnHighTier ? 'true' : 'false'}
         onChange={updateShouldWarnHighTier}
       />
-      <Text type="normal" fontSize="14px">
-        티어 가리개를 사용하기 위해서는 백준의{' '}
-        <TextLink href="https://www.acmicpc.net/setting/view" fontSize="14px">
-          설정 페이지
-        </TextLink>
-        에서 [보기] - [solved.ac 티어]가 "보기"로 설정되어 있어야 합니다.
-      </Text>
+      <Fieldset
+        legend="티어 아이콘에 마우스를 올릴 경우 난이도 공개하기"
+        name="shouldRevealTierOnHover"
+        disabled={!shouldHideTier}
+        options={[
+          { label: '공개', value: 'true' },
+          { label: '공개하지 않음', value: 'false' },
+        ]}
+        checkedValue={shouldRevealTierOnHover ? 'true' : 'false'}
+        onChange={updateShouldRevealTierOnHover}
+      />
       <MenuTitle title="기본 설정" iconSrc={<ToolsIcon />} />
       <Fieldset
         legend="알고 있는 알고리즘만으로 문제를 풀 수 있는지의 여부 공개 방법"

--- a/constants/defaultValues.ts
+++ b/constants/defaultValues.ts
@@ -4,6 +4,7 @@ import type {
   LegacyQuickSlotsResponse,
 } from '@/types/randomDefense';
 import { STORAGE_KEY } from './commands';
+import { HiderOptionsResponse } from '@/types/algorithm';
 
 export const DEFAULT_CHECKED_ALGORITHM_IDS = [1, 2];
 
@@ -31,13 +32,14 @@ export const DEFAULT_LEGACY_QUICK_SLOTS_RESPONSE: LegacyQuickSlotsResponse = {
   ...DEFAULT_QUICK_SLOTS,
 };
 
-export const DEFAULT_HIDER_OPTIONS = {
+export const DEFAULT_HIDER_OPTIONS: HiderOptionsResponse = {
   problemTagLockDuration: {
     hours: 0,
     minutes: 20,
   },
   shouldHideTier: false,
   shouldWarnHighTier: false,
+  shouldRevealTierOnHover: false,
   warnTier: 1,
   algorithmHiderUsage: 'click',
   problemTagLockUsage: 'click',

--- a/domains/dataHandlers/hiderOptionsDataHandler.test.ts
+++ b/domains/dataHandlers/hiderOptionsDataHandler.test.ts
@@ -13,6 +13,7 @@ describe('Test #1 - 가리개 관련 설정 불러오기', () => {
         },
         shouldHideTier: true,
         shouldWarnHighTier: true,
+        shouldRevealTierOnHover: false,
         warnTier: 30,
         algorithmHiderUsage: 'always',
         problemTagLockUsage: 'auto',
@@ -24,6 +25,7 @@ describe('Test #1 - 가리개 관련 설정 불러오기', () => {
         },
         shouldHideTier: false,
         shouldWarnHighTier: true,
+        shouldRevealTierOnHover: false,
         warnTier: 12,
         algorithmHiderUsage: 'click',
         problemTagLockUsage: 'auto',
@@ -82,6 +84,10 @@ describe('Test #2 - 유효하지 않은 가리개 관련 설정 데이터를 불
         problemTagLockUsage: 'click',
       },
       {},
+      {
+        ...DEFAULT_HIDER_OPTIONS,
+        shouldRevealTierOnHover: 'foo',
+      },
     ];
 
     test.each(testcases)('#%#', async (hiderOptions) => {
@@ -105,6 +111,7 @@ describe('Test #3 - 가리개 관련 설정 저장하기', () => {
       },
       shouldHideTier: true,
       shouldWarnHighTier: false,
+      shouldRevealTierOnHover: true,
       warnTier: 29,
       algorithmHiderUsage: 'always',
       problemTagLockUsage: 'auto',
@@ -129,6 +136,7 @@ describe('Test #4 - 유효하지 않은 가리개 관련 설정 데이터를 저
         minutes: 50,
       },
       shouldWarnHighTier: false,
+      shouldRevealTierOnHover: false,
       warnTier: 29,
     };
 

--- a/domains/dataHandlers/validators/hiderOptionsValidator.ts
+++ b/domains/dataHandlers/validators/hiderOptionsValidator.ts
@@ -19,6 +19,7 @@ export const isHiderOptionsResponse = (
       'shouldHideTier' in data &&
       'shouldWarnHighTier' in data &&
       'warnTier' in data &&
+      'shouldRevealTierOnHover' in data &&
       'algorithmHiderUsage' in data &&
       'problemTagLockUsage' in data &&
       isObject(data.problemTagLockDuration) &&
@@ -28,6 +29,7 @@ export const isHiderOptionsResponse = (
       typeof data.problemTagLockDuration.minutes === 'number' &&
       typeof data.shouldHideTier === 'boolean' &&
       typeof data.shouldWarnHighTier === 'boolean' &&
+      typeof data.shouldRevealTierOnHover === 'boolean' &&
       isRatedTier(data.warnTier) &&
       typeof data.algorithmHiderUsage === 'string' &&
       ['click', 'always'].includes(data.algorithmHiderUsage) &&

--- a/domains/tierHider/normalToWarnTierChanger.ts
+++ b/domains/tierHider/normalToWarnTierChanger.ts
@@ -1,5 +1,5 @@
 import { $, $$ } from '@/utils/querySelector';
-import { solvedAcNumericTierIcons, solvedAcRankIcons } from '@/assets/svg/tier';
+import { solvedAcNumericTierIcons } from '@/assets/svg/tier';
 import { isTierWithoutNotRatable } from '@/types/typeGuards';
 import type { RatedTier } from '@/types/tierHider';
 import { COMMANDS } from '@/constants/commands';
@@ -102,7 +102,7 @@ const changeBoardBlockquoteBadgeTier = async (
   }
 
   if (tier >= warnTier && shouldWarnHighTier) {
-    boardBlockquoteTierBadgeElement.style.content = `url(${JSON.stringify(solvedAcRankIcons.warn)}`;
+    boardBlockquoteTierBadgeElement.classList.add('warn');
   }
 };
 
@@ -117,7 +117,7 @@ const changeRegularBadgeTier = (warnTier: RatedTier) => {
       const tier = src.match(TIER_FROM_SRC_REGEX);
 
       if (tier && Number(tier) >= warnTier) {
-        tierBadgeElement.style.content = `url(${JSON.stringify(solvedAcRankIcons.warn)})`;
+        tierBadgeElement.classList.add('warn');
       }
     }
   });

--- a/entrypoints/injectionScript.content.ts
+++ b/entrypoints/injectionScript.content.ts
@@ -46,13 +46,19 @@ const executeInjectionScript = () => {
           return;
         }
 
-        const { shouldHideTier } = response;
+        const { shouldHideTier, shouldRevealTierOnHover } = response;
 
-        if (shouldHideTier) {
-          htmlElement.setAttribute('hideTier', 'true');
-        } else {
+        if (!shouldHideTier) {
           htmlElement.setAttribute('hideTier', 'false');
+          return;
         }
+
+        if (shouldRevealTierOnHover) {
+          htmlElement.setAttribute('hideTier', 'revealOnHover');
+          return;
+        }
+
+        htmlElement.setAttribute('hideTier', 'true');
       });
 
     browser.runtime

--- a/hooks/algorithm/useHiderFieldsetMenu.ts
+++ b/hooks/algorithm/useHiderFieldsetMenu.ts
@@ -13,6 +13,7 @@ const fallbackHiderOptions = {
   },
   shouldHideTier: undefined,
   shouldWarnHighTier: undefined,
+  shouldRevealTierOnHover: undefined,
   warnTier: 1 as const,
   algorithmHiderUsage: undefined,
   problemTagLockUsage: undefined,
@@ -99,6 +100,20 @@ const useHiderFieldsetMenu = () => {
     });
   };
 
+  const updateShouldRevealTierOnHover = (
+    shouldRevealTierOnHoverString: string,
+  ) => {
+    const shouldRevealTierOnHover = shouldRevealTierOnHoverString === 'true';
+
+    setHiderOptionsState((prev) => {
+      if (!prev.isLoaded) {
+        return prev;
+      }
+
+      return { ...prev, shouldRevealTierOnHover };
+    });
+  };
+
   const updateWarnTier = (warnTier: RatedTier) => {
     setHiderOptionsState((prev) => {
       if (!prev.isLoaded) {
@@ -145,6 +160,7 @@ const useHiderFieldsetMenu = () => {
     updateProblemTagLockDuration,
     updateShouldHideTier,
     updateShouldWarnHighTier,
+    updateShouldRevealTierOnHover,
     updateWarnTier,
     updateAlgorithmHiderUsage,
     updateProblemTagLockUsage,

--- a/types/algorithm.ts
+++ b/types/algorithm.ts
@@ -21,6 +21,7 @@ export interface HiderOptionsResponse {
   };
   shouldHideTier: boolean;
   shouldWarnHighTier: boolean;
+  shouldRevealTierOnHover: boolean;
   warnTier: RatedTier;
   algorithmHiderUsage: 'click' | 'always';
   problemTagLockUsage: 'click' | 'auto';


### PR DESCRIPTION
## 관련 이슈
- #146

## PR 설명
본 PR에서는 "티어 가리개" 기능에, 마우스를 티어 아이콘 위에 올릴 경우 티어를 공개할 수 있는 기능을 추가했습니다. 이 기능은 설정 페이지에서 켜고 끌 수 있습니다.

![image](https://github.com/user-attachments/assets/309c7e9f-8689-49fe-a4a1-5fffde0edb3b)


https://github.com/user-attachments/assets/4dec72ef-e94d-4ab8-b9c6-6937349dbad1


<hr>

ℹ️여러 작업을 동시에 한 상황이므로, 발생하는 테스트 실패 및 컴파일 오류는 후속 PR에서 해결합니다.

