### PR TITLE
[FEAT] 데이터 버전을 3으로 마이그레이션하는 기능을 구현

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,7 @@
     "eqeqeq": "error",
     "no-useless-return": "error",
     "no-unreachable-loop": "error",
-    "no-console": "warn"
+    "no-console": "warn",
+    "@typescript-eslint/no-namespace": "off"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
     "no-useless-return": "error",
     "no-unreachable-loop": "error",
     "no-console": "warn",
-    "@typescript-eslint/no-namespace": "off"
+    "@typescript-eslint/no-namespace": "off",
+    "@typescript-eslint/no-unused-vars": "warn"
   }
 }

--- a/constants/commands.ts
+++ b/constants/commands.ts
@@ -28,11 +28,30 @@ export const COMMANDS = {
 } as const;
 
 /**
- * 현재 버전(v1.2) 이후 쓰일 키 값들입니다.
+ * 데이터 개편 전인 ~v1.1.2.2에서 사용되던 키들입니다.
+ * v1.2부터는 사용되지 않지만, 이전 버전에서 업데이트를 한 유저를 위해 데이터를 옮겨야 하므로
+ * 필요한 키들입니다.
+ * 이 버전의 데이터는 세이브파일 로드에 사용할 수 없으며, 마이그레이션만 가능합니다.
+ */
+export const V1_SYNC_STORAGE_KEY = {
+  CHECKED_ALGORITHM_IDS: 'algorithm',
+  QUICK_SLOTS: 'query',
+  TIMER: 'timer',
+  SETTINGS: 'settings',
+} as const;
+
+export const V1_LOCAL_STORAGE_KEY = {
+  RANDOM_DEFENSE_HISTORY: 'queryLog',
+} as const;
+
+/**
+ * v1.2.* / dataVersion 2에서 쓰이는 키 값들입니다.
  * 모든 키는 `browser.storage.local`의 키들입니다.
  * 이는 데이터의 크기가 `browser.storage.sync`에 저장할 수 있는 한도를 넘기 때문입니다.
+ * 이 버전의 데이터부터 세이브파일 로드에 사용할 수 있으며, 업로드 시 해당 토탐정 버전이 더 높은 버전의 데이터 버전을 사용하더라도
+ * 마이그레이션 진행을 동반하므로 호환이 가능합니다.
  */
-export const STORAGE_KEY = {
+export const V2_STORAGE_KEY = {
   DATA_VERSION: 'dataVersion',
   CHECKED_ALGORITHM_IDS: 'checkedAlgorithmIds',
   QUICK_SLOTS: 'quickSlots',
@@ -42,22 +61,13 @@ export const STORAGE_KEY = {
   IS_TIER_HIDDEN: 'isTierHidden',
   FONT_NO: 'fontNo',
   TIMERS: 'timers',
-  GACHA_OPTIONS: 'gachaOptions',
   SHOULD_SHOW_WELCOME_MESSAGE: 'shouldShowWelcomeMessage',
 } as const;
 
 /**
- * LEGACY가 변수명으로 붙은 키들의 경우 이전 버전(~v1.1.2.2)에서 사용되던 키들입니다.
- * v1.2부터는 사용되지 않지만, 이전 버전에서 업데이트를 한 유저를 위해 데이터를 옮겨야 하므로
- * 필요한 키들입니다.
+ * v1.3.* / dataVersion 3에서 쓰이는 키 값들입니다. **최신 버전의 키 값들입니다.**
  */
-export const LEGACY_SYNC_STORAGE_KEY = {
-  CHECKED_ALGORITHM_IDS: 'algorithm',
-  QUICK_SLOTS: 'query',
-  TIMER: 'timer',
-  SETTINGS: 'settings',
-} as const;
-
-export const LEGACY_LOCAL_STORAGE_KEY = {
-  RANDOM_DEFENSE_HISTORY: 'queryLog',
+export const STORAGE_KEY = {
+  ...V2_STORAGE_KEY,
+  GACHA_OPTIONS: 'gachaOptions',
 } as const;

--- a/constants/defaultValues.ts
+++ b/constants/defaultValues.ts
@@ -1,14 +1,11 @@
-import type {
-  Slots,
-  QuickSlots,
-  LegacyQuickSlots,
-} from '@/types/randomDefense';
+import type { Slots, QuickSlots } from '@/types/randomDefense';
+import type { V1, V2 } from '@/types/legacyData';
 import { STORAGE_KEY } from './commands';
 import { HiderOptions } from '@/types/algorithm';
 
 export const DEFAULT_CHECKED_ALGORITHM_IDS = [1, 2];
 
-const DEFAULT_QUICK_SLOTS: Slots = {
+export const DEFAULT_SLOTS: Slots = {
   1: { isEmpty: true },
   2: { isEmpty: true },
   3: { isEmpty: true },
@@ -21,28 +18,27 @@ const DEFAULT_QUICK_SLOTS: Slots = {
   0: { isEmpty: true },
 } as const;
 
-export const DEFAULT_QUICK_SLOTS_RESPONSE: QuickSlots = {
+export const DEFAULT_QUICK_SLOTS: QuickSlots = {
   hotkey: 'Alt',
   selectedSlotNo: 1,
-  slots: DEFAULT_QUICK_SLOTS,
+  slots: DEFAULT_SLOTS,
 };
 
-export const DEFAULT_LEGACY_QUICK_SLOTS_RESPONSE: LegacyQuickSlots = {
-  selectedNo: 1,
-  ...DEFAULT_QUICK_SLOTS,
-};
-
-export const DEFAULT_HIDER_OPTIONS: HiderOptions = {
+export const DEFAULT_V2_HIDER_OPTIONS: V2.HiderOptions = {
   problemTagLockDuration: {
     hours: 0,
     minutes: 20,
   },
   shouldHideTier: false,
   shouldWarnHighTier: false,
-  shouldRevealTierOnHover: false,
   warnTier: 1,
   algorithmHiderUsage: 'click',
   problemTagLockUsage: 'click',
+} as const;
+
+export const DEFAULT_HIDER_OPTIONS: HiderOptions = {
+  ...DEFAULT_V2_HIDER_OPTIONS,
+  shouldRevealTierOnHover: false,
 } as const;
 
 export const DEFAULT_TOTAMJUNG_THEME = 'none';
@@ -60,19 +56,26 @@ export const DEFAULT_GACHA_OPTIONS = {
   isAudioMuted: true,
 } as const;
 
-/**
- * 데이터를 초기화했을 때 덮어씌우게 될 빈 데이터입니다. 최초 설치 데이터와는 약간 다릅니다.
- */
-export const DEFAULT_EMPTY_DATA = {
-  [STORAGE_KEY.DATA_VERSION]: 'v1.2',
+export const DEFAULT_V1_QUICK_SLOTS: V1.QuickSlots = {
+  selectedNo: 1,
+  ...DEFAULT_SLOTS,
+};
+
+export const DEFAULT_V2_EMPTY_DATA = {
+  [STORAGE_KEY.DATA_VERSION]: 2,
   [STORAGE_KEY.CHECKED_ALGORITHM_IDS]: DEFAULT_CHECKED_ALGORITHM_IDS,
-  [STORAGE_KEY.QUICK_SLOTS]: DEFAULT_QUICK_SLOTS_RESPONSE,
+  [STORAGE_KEY.QUICK_SLOTS]: DEFAULT_QUICK_SLOTS,
   [STORAGE_KEY.TOTAMJUNG_THEME]: DEFAULT_TOTAMJUNG_THEME,
   [STORAGE_KEY.HIDER_OPTIONS]: DEFAULT_HIDER_OPTIONS,
   [STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: DEFAULT_RANDOM_DEFENSE_HISTORY,
   [STORAGE_KEY.IS_TIER_HIDDEN]: DEFAULT_IS_TIER_HIDDEN,
   [STORAGE_KEY.FONT_NO]: DEFAULT_FONT_NO,
   [STORAGE_KEY.TIMERS]: DEFAULT_TIMERS,
-  [STORAGE_KEY.GACHA_OPTIONS]: DEFAULT_GACHA_OPTIONS,
   [STORAGE_KEY.SHOULD_SHOW_WELCOME_MESSAGE]: false,
+};
+
+export const DEFAULT_EMPTY_DATA = {
+  ...DEFAULT_V2_EMPTY_DATA,
+  [STORAGE_KEY.DATA_VERSION]: 3,
+  [STORAGE_KEY.GACHA_OPTIONS]: DEFAULT_GACHA_OPTIONS,
 };

--- a/constants/validVersions.ts
+++ b/constants/validVersions.ts
@@ -1,0 +1,1 @@
+export const VALID_VERSIONS = ['v1.2', 2, 3];

--- a/domains/dataHandlers/converters/legacyToLatestFontNo.ts
+++ b/domains/dataHandlers/converters/legacyToLatestFontNo.ts
@@ -1,10 +1,10 @@
 import { isObject } from '@/types/typeGuards';
-import { isLegacyFontNo } from '../validators/fontNoValidator';
+import { isV1FontNo } from '../validators/fontNoValidator';
 
 /**
  * 이 컨버터 함수에는 유효하지 않은 구버전 설정 값이 주어져도 괜찮습니다.
  */
-export const convertLegacyToLatestFontNoBySettings = (
+export const convertV1ToLatestFontNoBySettings = (
   legacySettings: unknown,
 ): number => {
   if (!isObject(legacySettings) || !('font' in legacySettings)) {
@@ -13,7 +13,7 @@ export const convertLegacyToLatestFontNoBySettings = (
 
   const legacyFontNo = legacySettings.font;
 
-  if (!isLegacyFontNo(legacyFontNo)) {
+  if (!isV1FontNo(legacyFontNo)) {
     return 0;
   }
 

--- a/domains/dataHandlers/converters/legacyToLatestHiderOptionsConverter.ts
+++ b/domains/dataHandlers/converters/legacyToLatestHiderOptionsConverter.ts
@@ -1,5 +1,5 @@
 import { isV1Timer, isV1Settings } from '../validators/hiderOptionsValidator';
-import { DEFAULT_HIDER_OPTIONS } from '@/constants/defaultValues';
+import { DEFAULT_V2_HIDER_OPTIONS } from '@/constants/defaultValues';
 import type { HiderOptions } from '@/types/algorithm';
 import type { V2 } from '@/types/legacyData';
 
@@ -30,7 +30,7 @@ export const convertV1ToV2HiderOptions = (
       };
 
   return {
-    ...DEFAULT_HIDER_OPTIONS,
+    ...DEFAULT_V2_HIDER_OPTIONS,
     problemTagLockDuration: duration,
     ...hiderOptions,
   };

--- a/domains/dataHandlers/converters/legacyToLatestHiderOptionsConverter.ts
+++ b/domains/dataHandlers/converters/legacyToLatestHiderOptionsConverter.ts
@@ -1,9 +1,7 @@
-import {
-  isLegacyTimer,
-  isLegacySettings,
-} from '../validators/hiderOptionsValidator';
+import { isV1Timer, isV1Settings } from '../validators/hiderOptionsValidator';
 import { DEFAULT_HIDER_OPTIONS } from '@/constants/defaultValues';
 import type { HiderOptions } from '@/types/algorithm';
+import type { V2 } from '@/types/legacyData';
 
 interface HiderOptionsUsage {
   algorithmHiderUsage: 'click' | 'always';
@@ -13,14 +11,14 @@ interface HiderOptionsUsage {
 /**
  * 이 컨버터 함수에는 유효하지 않은 구버전 타이머 값, 또는 구버전 설정 값이 주어져도 괜찮습니다.
  */
-export const convertLegacyToLatestHiderOptions = (
+export const convertV1ToV2HiderOptions = (
   legacyTimer: unknown,
   legacySettings: unknown,
-): HiderOptions => {
-  const duration = isLegacyTimer(legacyTimer)
+): V2.HiderOptions => {
+  const duration = isV1Timer(legacyTimer)
     ? { hours: Number(legacyTimer.hour), minutes: Number(legacyTimer.minute) }
     : { hours: 0, minutes: 20 };
-  const hiderOptions: HiderOptionsUsage = isLegacySettings(legacySettings)
+  const hiderOptions: HiderOptionsUsage = isV1Settings(legacySettings)
     ? {
         algorithmHiderUsage: legacySettings.predict,
         problemTagLockUsage:
@@ -35,5 +33,14 @@ export const convertLegacyToLatestHiderOptions = (
     ...DEFAULT_HIDER_OPTIONS,
     problemTagLockDuration: duration,
     ...hiderOptions,
+  };
+};
+
+export const convertV2ToLatestHiderOptions = (
+  legacyHiderOptions: V2.HiderOptions,
+): HiderOptions => {
+  return {
+    ...legacyHiderOptions,
+    shouldRevealTierOnHover: false,
   };
 };

--- a/domains/dataHandlers/converters/legacyToLatestOptionsDataConverter.ts
+++ b/domains/dataHandlers/converters/legacyToLatestOptionsDataConverter.ts
@@ -1,0 +1,125 @@
+import {
+  STORAGE_KEY,
+  V1_LOCAL_STORAGE_KEY,
+  V1_SYNC_STORAGE_KEY,
+  V2_STORAGE_KEY,
+} from '@/constants/commands';
+import type { OptionsData } from '@/types/options';
+import type { V2 } from '@/types/legacyData';
+import { DEFAULT_GACHA_OPTIONS } from '@/constants/defaultValues';
+import { sanitizeV2HiderOptions } from '@/domains/dataHandlers/sanitizers/hiderOptionsSanitizer';
+import { sanitizeCheckedAlgorithmIds } from '@/domains/dataHandlers/sanitizers/checkedAlgorithmIdsSanitizer';
+import {
+  sanitizeQuickSlots,
+  sanitizeV1QuickSlots,
+} from '@/domains/dataHandlers/sanitizers/quickSlotsSanitizer';
+import { sanitizeTotamjungTheme } from '@/domains/dataHandlers/sanitizers/totamjungThemeSanitizer';
+import {
+  sanitizeRandomDefenseHistory,
+  sanitizeV1RandomDefenseHistory,
+} from '@/domains/dataHandlers/sanitizers/randomDefenseHistorySanitizer';
+import { sanitizeIsTierHidden } from '@/domains/dataHandlers/sanitizers/isTierHiddenSanitizer';
+import { sanitizeFontNo } from '@/domains/dataHandlers/sanitizers/fontNoSanitizer';
+import { sanitizeTimers } from '@/domains/dataHandlers/sanitizers/timersSanitizer';
+import { sanitizeShouldShowWelcomeMessage } from '@/domains/dataHandlers/sanitizers/shouldShowWelcomeMessageSanitizer';
+import {
+  convertV1ToV2HiderOptions,
+  convertV2ToLatestHiderOptions,
+} from './legacyToLatestHiderOptionsConverter';
+
+import { convertV1ToLatestTotamjungThemeBySettings } from '@/domains/dataHandlers/converters/legacyToLatestTotamjungThemeConverter';
+import { convertV1ToLatestQuickSlots } from '@/domains/dataHandlers/converters/legacyToLatestQuickSlotsConverter';
+import { convertV1ToLatestRandomDefenseHistory } from '@/domains/dataHandlers/converters/legacyToLatestRandomDefenseHistory';
+import { convertV1ToLatestFontNoBySettings } from '@/domains/dataHandlers/converters/legacyToLatestFontNo';
+import { convertV1ToLatestTimers } from '@/domains/dataHandlers/converters/legacyToLatestTimers';
+
+export const convertV1ToV2OptionsData = (
+  legacySyncData: Record<string, unknown>,
+  legacyLocalData: Record<string, unknown>,
+): V2.OptionsData => {
+  const legacyQuickSlots = sanitizeV1QuickSlots(
+    legacySyncData[V1_SYNC_STORAGE_KEY.QUICK_SLOTS],
+  );
+  const legacyRandomDefenseHistory = sanitizeV1RandomDefenseHistory(
+    legacyLocalData[V1_LOCAL_STORAGE_KEY.RANDOM_DEFENSE_HISTORY],
+  );
+  const checkedAlgorithmIds = sanitizeCheckedAlgorithmIds(
+    legacySyncData[V1_SYNC_STORAGE_KEY.CHECKED_ALGORITHM_IDS],
+  );
+  const isTierHidden = sanitizeIsTierHidden(
+    legacySyncData[STORAGE_KEY.IS_TIER_HIDDEN],
+  );
+
+  const totamjungTheme = convertV1ToLatestTotamjungThemeBySettings(
+    legacySyncData[V1_SYNC_STORAGE_KEY.SETTINGS],
+  );
+  const hiderOptions = convertV1ToV2HiderOptions(
+    legacySyncData[V1_SYNC_STORAGE_KEY.TIMER],
+    legacySyncData[V1_SYNC_STORAGE_KEY.SETTINGS],
+  );
+  const quickSlots = convertV1ToLatestQuickSlots(legacyQuickSlots);
+  const randomDefenseHistory = convertV1ToLatestRandomDefenseHistory(
+    legacyRandomDefenseHistory,
+  );
+  const fontNo = convertV1ToLatestFontNoBySettings(
+    legacySyncData[V1_SYNC_STORAGE_KEY.SETTINGS],
+  );
+  const timers = convertV1ToLatestTimers(
+    legacySyncData[V1_SYNC_STORAGE_KEY.TIMER],
+  );
+
+  return {
+    [V2_STORAGE_KEY.CHECKED_ALGORITHM_IDS]: checkedAlgorithmIds,
+    [V2_STORAGE_KEY.QUICK_SLOTS]: quickSlots,
+    [V2_STORAGE_KEY.TOTAMJUNG_THEME]: totamjungTheme,
+    [V2_STORAGE_KEY.HIDER_OPTIONS]: hiderOptions,
+    [V2_STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: randomDefenseHistory,
+    [V2_STORAGE_KEY.IS_TIER_HIDDEN]: isTierHidden,
+    [V2_STORAGE_KEY.FONT_NO]: fontNo,
+    [V2_STORAGE_KEY.TIMERS]: timers,
+    [V2_STORAGE_KEY.SHOULD_SHOW_WELCOME_MESSAGE]: false,
+    [V2_STORAGE_KEY.DATA_VERSION]: 2,
+  };
+};
+
+export const convertV2ToLatestOptionsData = (
+  legacyData: Record<string, unknown>,
+): OptionsData => {
+  const legacyHiderOptions = sanitizeV2HiderOptions(
+    legacyData[V2_STORAGE_KEY.HIDER_OPTIONS],
+  );
+
+  const checkedAlgorithmIds = sanitizeCheckedAlgorithmIds(
+    legacyData[V2_STORAGE_KEY.CHECKED_ALGORITHM_IDS],
+  );
+  const quickSlots = sanitizeQuickSlots(legacyData[V2_STORAGE_KEY.QUICK_SLOTS]);
+  const totamjungTheme = sanitizeTotamjungTheme(
+    legacyData[V2_STORAGE_KEY.TOTAMJUNG_THEME],
+  );
+  const hiderOptions = convertV2ToLatestHiderOptions(legacyHiderOptions);
+  const randomDefenseHistory = sanitizeRandomDefenseHistory(
+    legacyData[V2_STORAGE_KEY.RANDOM_DEFENSE_HISTORY],
+  );
+  const isTierHidden = sanitizeIsTierHidden(
+    legacyData[STORAGE_KEY.IS_TIER_HIDDEN],
+  );
+  const fontNo = sanitizeFontNo(legacyData[V2_STORAGE_KEY.FONT_NO]);
+  const timers = sanitizeTimers(legacyData[V2_STORAGE_KEY.TIMERS]);
+  const shouldShowWelcomeMessage = sanitizeShouldShowWelcomeMessage(
+    V2_STORAGE_KEY.SHOULD_SHOW_WELCOME_MESSAGE,
+  );
+
+  return {
+    [STORAGE_KEY.CHECKED_ALGORITHM_IDS]: checkedAlgorithmIds,
+    [STORAGE_KEY.QUICK_SLOTS]: quickSlots,
+    [STORAGE_KEY.TOTAMJUNG_THEME]: totamjungTheme,
+    [STORAGE_KEY.HIDER_OPTIONS]: hiderOptions,
+    [STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: randomDefenseHistory,
+    [STORAGE_KEY.IS_TIER_HIDDEN]: isTierHidden,
+    [STORAGE_KEY.FONT_NO]: fontNo,
+    [STORAGE_KEY.TIMERS]: timers,
+    [STORAGE_KEY.GACHA_OPTIONS]: DEFAULT_GACHA_OPTIONS,
+    [STORAGE_KEY.SHOULD_SHOW_WELCOME_MESSAGE]: shouldShowWelcomeMessage,
+    [STORAGE_KEY.DATA_VERSION]: 3,
+  };
+};

--- a/domains/dataHandlers/converters/legacyToLatestOptionsDataConverter.ts
+++ b/domains/dataHandlers/converters/legacyToLatestOptionsDataConverter.ts
@@ -106,7 +106,7 @@ export const convertV2ToLatestOptionsData = (
   const fontNo = sanitizeFontNo(legacyData[V2_STORAGE_KEY.FONT_NO]);
   const timers = sanitizeTimers(legacyData[V2_STORAGE_KEY.TIMERS]);
   const shouldShowWelcomeMessage = sanitizeShouldShowWelcomeMessage(
-    V2_STORAGE_KEY.SHOULD_SHOW_WELCOME_MESSAGE,
+    legacyData[V2_STORAGE_KEY.SHOULD_SHOW_WELCOME_MESSAGE],
   );
 
   return {

--- a/domains/dataHandlers/converters/legacyToLatestQuickSlotsConverter.ts
+++ b/domains/dataHandlers/converters/legacyToLatestQuickSlotsConverter.ts
@@ -1,7 +1,8 @@
-import type { QuickSlots, LegacyQuickSlots } from '@/types/randomDefense';
+import type { QuickSlots } from '@/types/randomDefense';
+import type { V1 } from '@/types/legacyData';
 
-export const convertLegacyToLatestQuickSlots = (
-  legacyQuickSlots: LegacyQuickSlots,
+export const convertV1ToLatestQuickSlots = (
+  legacyQuickSlots: V1.QuickSlots,
 ): QuickSlots => {
   const { selectedNo, ...legacyQuickSlotsWithoutSelectedNo } = legacyQuickSlots;
 

--- a/domains/dataHandlers/converters/legacyToLatestRandomDefenseHistory.ts
+++ b/domains/dataHandlers/converters/legacyToLatestRandomDefenseHistory.ts
@@ -1,11 +1,9 @@
 import { isIsoString } from '@/types/typeGuards';
-import {
-  LegacyRandomDefenseHistoryInfo,
-  RandomDefenseHistoryInfo,
-} from '@/types/randomDefense';
+import type { RandomDefenseHistoryInfo } from '@/types/randomDefense';
+import type { V1 } from '@/types/legacyData';
 
-export const convertLegacyToLatestRandomDefenseHistory = (
-  legacyRandomDefenseHistory: LegacyRandomDefenseHistoryInfo[],
+export const convertV1ToLatestRandomDefenseHistory = (
+  legacyRandomDefenseHistory: V1.RandomDefenseHistoryInfo[],
 ): RandomDefenseHistoryInfo[] => {
   const latestRandomDefenseHistory: RandomDefenseHistoryInfo[] = [];
 

--- a/domains/dataHandlers/converters/legacyToLatestTimers.ts
+++ b/domains/dataHandlers/converters/legacyToLatestTimers.ts
@@ -1,12 +1,12 @@
 import type { Timer } from '@/types/algorithm';
 import { isTimer } from '../validators/isTimersValidator';
-import { isLegacyTimer } from '../validators/hiderOptionsValidator';
+import { isV1Timer } from '../validators/hiderOptionsValidator';
 
 /**
  * 이 컨버터 함수에는 유효하지 않은 구버전 타이머 값이 주어져도 괜찮습니다.
  */
-export const convertLegacyToLatestTimers = (legacyTimer: unknown): Timer[] => {
-  if (!isLegacyTimer(legacyTimer)) {
+export const convertV1ToLatestTimers = (legacyTimer: unknown): Timer[] => {
+  if (!isV1Timer(legacyTimer)) {
     return [];
   }
 

--- a/domains/dataHandlers/converters/legacyToLatestTotamjungThemeConverter.ts
+++ b/domains/dataHandlers/converters/legacyToLatestTotamjungThemeConverter.ts
@@ -4,7 +4,7 @@ import { isObject } from '@/types/typeGuards';
 /**
  * 이 컨버터 함수에는 유효하지 않은 구버전 설정 값이 주어져도 괜찮습니다.
  */
-export const convertLegacyToLatestTotamjungThemeBySettings = (
+export const convertV1ToLatestTotamjungThemeBySettings = (
   legacySettings: unknown,
 ): TotamjungTheme => {
   if (!isObject(legacySettings) || !('theme' in legacySettings)) {

--- a/domains/dataHandlers/dataInitializer.ts
+++ b/domains/dataHandlers/dataInitializer.ts
@@ -5,7 +5,7 @@ import { STORAGE_KEY } from '@/constants/commands';
 /**
  * 최초 설치 시 덮어씌우게 될 데이터입니다. 데이터 초기화 시에 덮어씌우는 데이터와는 다소 다르며, 세 개의 범용성 높은 쿼리가 생성되어 있는채로 시작하게 됩니다.
  */
-const INITIAL_QUICK_SLOTS: Slots = {
+const INITIAL_SLOTS: Slots = {
   1: {
     isEmpty: false,
     title: '골드 랜덤 디펜스',
@@ -26,16 +26,16 @@ const INITIAL_QUICK_SLOTS: Slots = {
   0: { isEmpty: true },
 } as const;
 
-export const INITIAL_QUICK_SLOTS_RESPONSE: QuickSlots = {
+export const INITIAL_QUICK_SLOTS: QuickSlots = {
   hotkey: 'Alt',
   selectedSlotNo: 1,
-  slots: INITIAL_QUICK_SLOTS,
+  slots: INITIAL_SLOTS,
 };
 
 export const initializeDataOnFirstInstall = () => {
   browser.storage.local.set({
     ...DEFAULT_EMPTY_DATA,
-    [STORAGE_KEY.QUICK_SLOTS]: INITIAL_QUICK_SLOTS_RESPONSE,
+    [STORAGE_KEY.QUICK_SLOTS]: INITIAL_QUICK_SLOTS,
     [STORAGE_KEY.SHOULD_SHOW_WELCOME_MESSAGE]: true,
   });
 };

--- a/domains/dataHandlers/legacyDataUpdater.test.ts
+++ b/domains/dataHandlers/legacyDataUpdater.test.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_FONT_NO,
   DEFAULT_HIDER_OPTIONS,
   DEFAULT_IS_TIER_HIDDEN,
-  DEFAULT_QUICK_SLOTS_RESPONSE,
+  DEFAULT_QUICK_SLOTS,
   DEFAULT_RANDOM_DEFENSE_HISTORY,
   DEFAULT_TIMERS,
   DEFAULT_TOTAMJUNG_THEME,
@@ -478,7 +478,7 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
         warnTier: 1,
       },
       isTierHidden: DEFAULT_IS_TIER_HIDDEN,
-      quickSlots: DEFAULT_QUICK_SLOTS_RESPONSE,
+      quickSlots: DEFAULT_QUICK_SLOTS,
       randomDefenseHistory: DEFAULT_RANDOM_DEFENSE_HISTORY,
       timers: DEFAULT_TIMERS,
       totamjungTheme: 'totamjung',
@@ -520,7 +520,7 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
     expect(browser.storage.local.get).not.toThrow();
     expect(browser.storage.local.set).toHaveBeenCalledWith({
       [STORAGE_KEY.CHECKED_ALGORITHM_IDS]: DEFAULT_CHECKED_ALGORITHM_IDS,
-      [STORAGE_KEY.QUICK_SLOTS]: DEFAULT_QUICK_SLOTS_RESPONSE,
+      [STORAGE_KEY.QUICK_SLOTS]: DEFAULT_QUICK_SLOTS,
       [STORAGE_KEY.TOTAMJUNG_THEME]: DEFAULT_TOTAMJUNG_THEME,
       [STORAGE_KEY.HIDER_OPTIONS]: DEFAULT_HIDER_OPTIONS,
       [STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: DEFAULT_RANDOM_DEFENSE_HISTORY,

--- a/domains/dataHandlers/legacyDataUpdater.test.ts
+++ b/domains/dataHandlers/legacyDataUpdater.test.ts
@@ -1,8 +1,13 @@
 import { STORAGE_KEY } from '@/constants/commands';
 import { updateAllLegacyData } from './legacyDataUpdater';
 import {
+  convertV1ToV2OptionsData,
+  convertV2ToLatestOptionsData,
+} from './converters/legacyToLatestOptionsDataConverter';
+import {
   DEFAULT_CHECKED_ALGORITHM_IDS,
   DEFAULT_FONT_NO,
+  DEFAULT_GACHA_OPTIONS,
   DEFAULT_HIDER_OPTIONS,
   DEFAULT_IS_TIER_HIDDEN,
   DEFAULT_QUICK_SLOTS,
@@ -10,9 +15,11 @@ import {
   DEFAULT_TIMERS,
   DEFAULT_TOTAMJUNG_THEME,
 } from '@/constants/defaultValues';
+import { V2 } from '@/types/legacyData';
+import { OptionsData } from '@/types/options';
 
-describe('Test #1 - 구버전 데이터를 최신 버전 데이터로 변환하기', () => {
-  test('구버전 데이터가 올바를 경우 온전하게 최신 버전 데이터로 변환하여 저장을 진행해야 한다.', async () => {
+describe('Test #1 - 데이터 변환 테스트', () => {
+  test('1버전 데이터가 올바를 경우 온전하게 2버전 데이터로 변환하여 값을 반환해야 한다.', async () => {
     const legacySyncData = {
       algorithm: [1, 2, 4, 7, 14, 156, 171, 194, 200, 1234],
       query: {
@@ -105,9 +112,9 @@ describe('Test #1 - 구버전 데이터를 최신 버전 데이터로 변환하�
       ],
     };
 
-    const expected = {
+    const expected: V2.OptionsData = {
       checkedAlgorithmIds: [1, 2, 4, 7, 14, 156, 171, 194, 200, 1234],
-      dataVersion: 'v1.2',
+      dataVersion: 2,
       hiderOptions: {
         algorithmHiderUsage: 'always',
         problemTagLockDuration: { hours: 1, minutes: 30 },
@@ -152,10 +159,40 @@ describe('Test #1 - 구버전 데이터를 최신 버전 데이터로 변환하�
       },
       randomDefenseHistory: [
         {
-          createdAt: '2024-06-12T09:25:01.000Z',
-          problemId: 24141,
-          tier: 12,
-          title: 'インフルエンザ (Flu)',
+          createdAt: '2024-06-30T13:34:10.000Z',
+          problemId: 1036,
+          tier: 15,
+          title: '36진수',
+        },
+        {
+          createdAt: '2024-06-28T11:33:36.000Z',
+          problemId: 29063,
+          tier: 0,
+          title: 'Телепорты',
+        },
+        {
+          createdAt: '2024-06-12T13:51:23.000Z',
+          problemId: 28050,
+          tier: 18,
+          title: 'Kind Baker',
+        },
+        {
+          createdAt: '2024-06-12T13:44:54.000Z',
+          problemId: 30513,
+          tier: 21,
+          title: '하이퍼 삼각형 자르기',
+        },
+        {
+          createdAt: '2024-06-12T12:49:04.000Z',
+          problemId: 23912,
+          tier: 18,
+          title: 'Locked Doors',
+        },
+        {
+          createdAt: '2024-06-12T12:48:56.000Z',
+          problemId: 5751,
+          tier: 3,
+          title: 'Head or Tail',
         },
         {
           createdAt: '2024-06-12T11:26:43.000Z',
@@ -170,46 +207,16 @@ describe('Test #1 - 구버전 데이터를 최신 버전 데이터로 변환하�
           title: 'Escape Wall Maria',
         },
         {
-          createdAt: '2024-06-12T12:48:56.000Z',
-          problemId: 5751,
-          tier: 3,
-          title: 'Head or Tail',
+          createdAt: '2024-06-12T09:25:01.000Z',
+          problemId: 24141,
+          tier: 12,
+          title: 'インフルエンザ (Flu)',
         },
         {
           createdAt: '2023-06-29T10:02:25.000Z',
           problemId: 14434,
           tier: 15,
           title: '놀이기구1',
-        },
-        {
-          createdAt: '2024-06-12T12:49:04.000Z',
-          problemId: 23912,
-          tier: 18,
-          title: 'Locked Doors',
-        },
-        {
-          createdAt: '2024-06-12T13:44:54.000Z',
-          problemId: 30513,
-          tier: 21,
-          title: '하이퍼 삼각형 자르기',
-        },
-        {
-          createdAt: '2024-06-12T13:51:23.000Z',
-          problemId: 28050,
-          tier: 18,
-          title: 'Kind Baker',
-        },
-        {
-          createdAt: '2024-06-28T11:33:36.000Z',
-          problemId: 29063,
-          tier: 0,
-          title: 'Телепорты',
-        },
-        {
-          createdAt: '2024-06-30T13:34:10.000Z',
-          problemId: 1036,
-          tier: 15,
-          title: '36진수',
         },
       ],
       timers: [
@@ -220,29 +227,267 @@ describe('Test #1 - 구버전 데이터를 최신 버전 데이터로 변환하�
       ],
       totamjungTheme: 'totamjung',
       fontNo: 19,
+      shouldShowWelcomeMessage: false,
     };
 
-    jest.clearAllMocks();
-    jest
-      .spyOn(browser.storage.sync, 'get')
-      .mockImplementation(() => Promise.resolve(legacySyncData));
-    jest
-      .spyOn(browser.storage.local, 'get')
-      .mockImplementation(() =>
-        Promise.resolve(Promise.resolve(legacyLocalData)),
-      );
-    jest
-      .spyOn(browser.storage.local, 'set')
-      .mockImplementation(() => Promise.resolve());
+    expect(convertV1ToV2OptionsData(legacySyncData, legacyLocalData)).toEqual(
+      expected,
+    );
+  });
 
-    await updateAllLegacyData();
+  test('2버전 데이터가 올바른 경우 온전하게 최신 버전의 데이터로 변환하여 값을 반환해야 한다.', async () => {
+    const legacyData: V2.OptionsData = {
+      checkedAlgorithmIds: [1, 2, 4, 7, 14, 156, 171, 194, 200, 1234],
+      dataVersion: 2,
+      hiderOptions: {
+        algorithmHiderUsage: 'always',
+        problemTagLockDuration: { hours: 1, minutes: 30 },
+        problemTagLockUsage: 'click',
+        shouldHideTier: false,
+        shouldWarnHighTier: false,
+        warnTier: 1,
+      },
+      isTierHidden: false,
+      quickSlots: {
+        hotkey: 'Alt',
+        selectedSlotNo: 5,
+        slots: {
+          1: {
+            isEmpty: false,
+            query: 'tier:1..30 solvable:true',
+            title: 'All Random',
+          },
+          2: {
+            isEmpty: false,
+            query:
+              'tier:1..30 solvable:true (tag:number_theory|tag:dp|tag:bruteforcing|tag:arithmetic|tag:data_structures)',
+            title: '대충 만든 추첨',
+          },
+          3: { isEmpty: true },
+          4: {
+            isEmpty: false,
+            query: 'tier:0..0 solvable:true ',
+            title: '추첨 4',
+          },
+          '5': {
+            isEmpty: false,
+            query: 'tier:s1..g4 ratable:true solvable:true 수열',
+            title: '직접 만든 쿼리',
+          },
+          6: { isEmpty: true },
+          7: { isEmpty: true },
+          8: { isEmpty: true },
+          9: { isEmpty: true },
+          0: { isEmpty: true },
+        },
+      },
+      randomDefenseHistory: [
+        {
+          createdAt: '2024-06-30T13:34:10.000Z',
+          problemId: 1036,
+          tier: 15,
+          title: '36진수',
+        },
+        {
+          createdAt: '2024-06-28T11:33:36.000Z',
+          problemId: 29063,
+          tier: 0,
+          title: 'Телепорты',
+        },
+        {
+          createdAt: '2024-06-12T13:51:23.000Z',
+          problemId: 28050,
+          tier: 18,
+          title: 'Kind Baker',
+        },
+        {
+          createdAt: '2024-06-12T13:44:54.000Z',
+          problemId: 30513,
+          tier: 21,
+          title: '하이퍼 삼각형 자르기',
+        },
+        {
+          createdAt: '2024-06-12T12:49:04.000Z',
+          problemId: 23912,
+          tier: 18,
+          title: 'Locked Doors',
+        },
+        {
+          createdAt: '2024-06-12T12:48:56.000Z',
+          problemId: 5751,
+          tier: 3,
+          title: 'Head or Tail',
+        },
+        {
+          createdAt: '2024-06-12T11:26:43.000Z',
+          problemId: 15494,
+          tier: 4,
+          title: 'Davor',
+        },
+        {
+          createdAt: '2024-06-12T10:23:40.000Z',
+          problemId: 24819,
+          tier: 10,
+          title: 'Escape Wall Maria',
+        },
+        {
+          createdAt: '2024-06-12T09:25:01.000Z',
+          problemId: 24141,
+          tier: 12,
+          title: 'インフルエンザ (Flu)',
+        },
+        {
+          createdAt: '2023-06-29T10:02:25.000Z',
+          problemId: 14434,
+          tier: 15,
+          title: '놀이기구1',
+        },
+      ],
+      timers: [
+        {
+          problemId: 1234,
+          expiresAt: '3024-10-09T15:35:32.677Z',
+        },
+        {
+          problemId: 5678,
+          expiresAt: '3025-10-09T15:35:32.677Z',
+        },
+      ],
+      totamjungTheme: 'totamjung',
+      fontNo: 19,
+      shouldShowWelcomeMessage: false,
+    };
 
-    expect(browser.storage.local.set).toHaveBeenCalledWith(expected);
+    const expected: OptionsData = {
+      checkedAlgorithmIds: [1, 2, 4, 7, 14, 156, 171, 194, 200, 1234],
+      dataVersion: 3,
+      hiderOptions: {
+        algorithmHiderUsage: 'always',
+        problemTagLockDuration: { hours: 1, minutes: 30 },
+        problemTagLockUsage: 'click',
+        shouldHideTier: false,
+        shouldWarnHighTier: false,
+        shouldRevealTierOnHover: false,
+        warnTier: 1,
+      },
+      isTierHidden: false,
+      quickSlots: {
+        hotkey: 'Alt',
+        selectedSlotNo: 5,
+        slots: {
+          1: {
+            isEmpty: false,
+            query: 'tier:1..30 solvable:true',
+            title: 'All Random',
+          },
+          2: {
+            isEmpty: false,
+            query:
+              'tier:1..30 solvable:true (tag:number_theory|tag:dp|tag:bruteforcing|tag:arithmetic|tag:data_structures)',
+            title: '대충 만든 추첨',
+          },
+          3: { isEmpty: true },
+          4: {
+            isEmpty: false,
+            query: 'tier:0..0 solvable:true ',
+            title: '추첨 4',
+          },
+          '5': {
+            isEmpty: false,
+            query: 'tier:s1..g4 ratable:true solvable:true 수열',
+            title: '직접 만든 쿼리',
+          },
+          6: { isEmpty: true },
+          7: { isEmpty: true },
+          8: { isEmpty: true },
+          9: { isEmpty: true },
+          0: { isEmpty: true },
+        },
+      },
+      randomDefenseHistory: [
+        {
+          createdAt: '2024-06-30T13:34:10.000Z',
+          problemId: 1036,
+          tier: 15,
+          title: '36진수',
+        },
+        {
+          createdAt: '2024-06-28T11:33:36.000Z',
+          problemId: 29063,
+          tier: 0,
+          title: 'Телепорты',
+        },
+        {
+          createdAt: '2024-06-12T13:51:23.000Z',
+          problemId: 28050,
+          tier: 18,
+          title: 'Kind Baker',
+        },
+        {
+          createdAt: '2024-06-12T13:44:54.000Z',
+          problemId: 30513,
+          tier: 21,
+          title: '하이퍼 삼각형 자르기',
+        },
+        {
+          createdAt: '2024-06-12T12:49:04.000Z',
+          problemId: 23912,
+          tier: 18,
+          title: 'Locked Doors',
+        },
+        {
+          createdAt: '2024-06-12T12:48:56.000Z',
+          problemId: 5751,
+          tier: 3,
+          title: 'Head or Tail',
+        },
+        {
+          createdAt: '2024-06-12T11:26:43.000Z',
+          problemId: 15494,
+          tier: 4,
+          title: 'Davor',
+        },
+        {
+          createdAt: '2024-06-12T10:23:40.000Z',
+          problemId: 24819,
+          tier: 10,
+          title: 'Escape Wall Maria',
+        },
+        {
+          createdAt: '2024-06-12T09:25:01.000Z',
+          problemId: 24141,
+          tier: 12,
+          title: 'インフルエンザ (Flu)',
+        },
+        {
+          createdAt: '2023-06-29T10:02:25.000Z',
+          problemId: 14434,
+          tier: 15,
+          title: '놀이기구1',
+        },
+      ],
+      timers: [
+        {
+          problemId: 1234,
+          expiresAt: '3024-10-09T15:35:32.677Z',
+        },
+        {
+          problemId: 5678,
+          expiresAt: '3025-10-09T15:35:32.677Z',
+        },
+      ],
+      gachaOptions: DEFAULT_GACHA_OPTIONS,
+      totamjungTheme: 'totamjung',
+      fontNo: 19,
+      shouldShowWelcomeMessage: false,
+    };
+
+    expect(convertV2ToLatestOptionsData(legacyData)).toEqual(expected);
   });
 });
 
-describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
-  test('구버전 데이터가 일부 손상되어 있다면, 복구 가능한 범위 내에서 복구한 후 저장을 진행해야 한다.', async () => {
+describe('Test #2 - 손상된 데이터 변환 테스트', () => {
+  test('손상된 1버전 데이터를 2버전 데이터로 변환할 경우 복구 가능한 범위 내에서 복구한 데이터를 반환해야 한다.', async () => {
     const legacySyncData = {
       algorithm: [
         1,
@@ -346,9 +591,9 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
       ],
     };
 
-    const expected = {
+    const expected: V2.OptionsData = {
       checkedAlgorithmIds: [1, 2, 4, 7, 14, 171, 194, 200, 1234],
-      dataVersion: 'v1.2',
+      dataVersion: 2,
       hiderOptions: {
         algorithmHiderUsage: 'always',
         problemTagLockDuration: { hours: 0, minutes: 20 },
@@ -391,6 +636,12 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
       },
       randomDefenseHistory: [
         {
+          createdAt: '2024-06-12T12:49:04.000Z',
+          problemId: 23912,
+          tier: 18,
+          title: 'Locked Doors',
+        },
+        {
           createdAt: '2024-06-12T11:26:43.000Z',
           problemId: 15494,
           tier: 4,
@@ -402,37 +653,19 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
           tier: 10,
           title: 'Escape Wall Maria',
         },
-        {
-          createdAt: '2024-06-12T12:49:04.000Z',
-          problemId: 23912,
-          tier: 18,
-          title: 'Locked Doors',
-        },
       ],
       timers: [],
       totamjungTheme: 'none',
+      shouldShowWelcomeMessage: false,
       fontNo: 3,
     };
 
-    jest.clearAllMocks();
-    jest
-      .spyOn(browser.storage.sync, 'get')
-      .mockImplementation(() => Promise.resolve(legacySyncData));
-    jest
-      .spyOn(browser.storage.local, 'get')
-      .mockImplementation(() =>
-        Promise.resolve(Promise.resolve(legacyLocalData)),
-      );
-    jest
-      .spyOn(browser.storage.local, 'set')
-      .mockImplementation(() => Promise.resolve());
-
-    await updateAllLegacyData();
-
-    expect(browser.storage.local.set).toHaveBeenCalledWith(expected);
+    expect(convertV1ToV2OptionsData(legacySyncData, legacyLocalData)).toEqual(
+      expected,
+    );
   });
 
-  test('구버전 데이터가 복구가 불가능할 정도로 손상되어 있다면, 복구 불가능한 데이터 그룹은 초기화 후 저장을 진행해야 한다.', async () => {
+  test('1버전 데이터의 일부 키값이 복구가 불가능할 정도로 손상되어 있다면, 해당 키 값들에 대해서는 2버전의 초기 데이터를 반환해야 한다.', async () => {
     const legacySyncData = {
       query: {
         2: {
@@ -466,9 +699,9 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
       queryLog: undefined,
     };
 
-    const expected = {
+    const expected: V2.OptionsData = {
       checkedAlgorithmIds: DEFAULT_CHECKED_ALGORITHM_IDS,
-      dataVersion: 'v1.2',
+      dataVersion: 2,
       hiderOptions: {
         algorithmHiderUsage: 'click',
         problemTagLockDuration: { hours: 1, minutes: 30 },
@@ -483,91 +716,157 @@ describe('Test #2 - 잘못된 구버전 데이터에 대응하기', () => {
       timers: DEFAULT_TIMERS,
       totamjungTheme: 'totamjung',
       fontNo: DEFAULT_FONT_NO,
+      shouldShowWelcomeMessage: false,
     };
 
-    jest.clearAllMocks();
-    jest
-      .spyOn(browser.storage.sync, 'get')
-      .mockImplementation(() => Promise.resolve(legacySyncData));
-    jest
-      .spyOn(browser.storage.local, 'get')
-      .mockImplementation(() =>
-        Promise.resolve(Promise.resolve(legacyLocalData)),
-      );
-    jest
-      .spyOn(browser.storage.local, 'set')
-      .mockImplementation(() => Promise.resolve());
-
-    await updateAllLegacyData();
-
-    expect(browser.storage.local.set).toHaveBeenCalledWith(expected);
+    expect(convertV1ToV2OptionsData(legacySyncData, legacyLocalData)).toEqual(
+      expected,
+    );
   });
 
-  test('구버전 데이터가 빈 오브젝트여도 런타임 에러 없이 기본 데이터로 저장을 진행해야 한다.', async () => {
-    jest.clearAllMocks();
-    jest
-      .spyOn(browser.storage.sync, 'get')
-      .mockImplementation(() => Promise.resolve({}));
-    jest
-      .spyOn(browser.storage.local, 'get')
-      .mockImplementation(() => Promise.resolve({}));
-    jest
-      .spyOn(browser.storage.local, 'set')
-      .mockImplementation(() => Promise.resolve());
+  test('손상된 2버전 데이터를 3버전 데이터로 변환할 경우 복구 가능한 범위 내에서 복구한 데이터를 반환해야 한다.', async () => {
+    const legacyData = {
+      checkedAlgorithmIds: ['', -2.3, -5, 'foo', 1, 2, 3, undefined, null],
+      dataVersion: 2,
+      hiderOptions: {
+        algorithmHiderUsage: 'click',
+        problemTagLockDuration: { hours: 0, minutes: 20 },
+        problemTagLockUsage: 'auto',
+        shouldHideTier: true,
+        shouldWarnHighTier: true,
+        warnTier: 16,
+      },
+      quickSlots: {
+        hotkey: 'F2',
+        selectedSlotNo: 0,
+        slots: {
+          1: 'asdf',
+          2: {},
+          3: 100,
+          4: {
+            isEmpty: false,
+            query: 'tier:0..0 solvable:true ',
+            title: '추첨 4',
+          },
+          '5': {
+            isEmpty: false,
+            query: 'tier:s1..g4 ratable:true solvable:true 수열',
+            title: '직접 만든 쿼리',
+          },
+          6: { empty: true },
+          7: 'not an object',
+          8: { isEmpty: true },
+          9: { isEmpty: true },
+          0: { isEmpty: true },
+        },
+      },
+      randomDefenseHistory: [
+        {
+          createdAt: '2024-06-30T13:34:10.000Z',
+          problemId: 1036,
+          tier: 15,
+          title: '36진수',
+        },
+        {
+          createdAt: '2024-06-28T11:33:36.000Z',
+          problemId: 29063,
+          tier: 0,
+          title: 'Телепорты',
+        },
+        null,
+        {
+          date: '2024-06-12 21:49:04',
+          no: 23912,
+          tier: 18,
+          title: 'Locked Doors',
+        },
+      ],
+      timers: [
+        {
+          problemId: 12340,
+          expiresAt: '2034-10-09T15:35:32.677Z',
+        },
+        { foo: 1 },
+        {
+          problemId: 30291,
+          expiresAt: '2034-10-19T15:35:32.677Z',
+        },
+      ],
+      totamjungTheme: 'totamjung',
+      fontNo: 5,
+      shouldShowWelcomeMessage: true,
+    };
 
-    await updateAllLegacyData();
+    const expected: OptionsData = {
+      checkedAlgorithmIds: [1, 2, 3],
+      quickSlots: {
+        hotkey: 'F2',
+        selectedSlotNo: 0,
+        slots: {
+          1: { isEmpty: true },
+          2: { isEmpty: true },
+          3: { isEmpty: true },
+          4: {
+            isEmpty: false,
+            query: 'tier:0..0 solvable:true ',
+            title: '추첨 4',
+          },
+          '5': {
+            isEmpty: false,
+            query: 'tier:s1..g4 ratable:true solvable:true 수열',
+            title: '직접 만든 쿼리',
+          },
+          6: { isEmpty: true },
+          7: { isEmpty: true },
+          8: { isEmpty: true },
+          9: { isEmpty: true },
+          0: { isEmpty: true },
+        },
+      },
+      hiderOptions: {
+        algorithmHiderUsage: 'click',
+        problemTagLockDuration: { hours: 0, minutes: 20 },
+        problemTagLockUsage: 'auto',
+        shouldHideTier: true,
+        shouldWarnHighTier: true,
+        shouldRevealTierOnHover: false,
+        warnTier: 16,
+      },
+      randomDefenseHistory: [
+        {
+          createdAt: '2024-06-30T13:34:10.000Z',
+          problemId: 1036,
+          tier: 15,
+          title: '36진수',
+        },
+        {
+          createdAt: '2024-06-28T11:33:36.000Z',
+          problemId: 29063,
+          tier: 0,
+          title: 'Телепорты',
+        },
+      ],
+      timers: [
+        {
+          problemId: 12340,
+          expiresAt: '2034-10-09T15:35:32.677Z',
+        },
+        {
+          problemId: 30291,
+          expiresAt: '2034-10-19T15:35:32.677Z',
+        },
+      ],
+      gachaOptions: {
+        isTierHidden: false,
+        isAudioMuted: true,
+      },
+      totamjungTheme: 'totamjung',
+      fontNo: 5,
+      shouldShowWelcomeMessage: true,
+      dataVersion: 3,
+      isTierHidden: false,
+    };
 
-    expect(browser.storage.local.get).not.toThrow();
-    expect(browser.storage.local.set).toHaveBeenCalledWith({
-      [STORAGE_KEY.CHECKED_ALGORITHM_IDS]: DEFAULT_CHECKED_ALGORITHM_IDS,
-      [STORAGE_KEY.QUICK_SLOTS]: DEFAULT_QUICK_SLOTS,
-      [STORAGE_KEY.TOTAMJUNG_THEME]: DEFAULT_TOTAMJUNG_THEME,
-      [STORAGE_KEY.HIDER_OPTIONS]: DEFAULT_HIDER_OPTIONS,
-      [STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: DEFAULT_RANDOM_DEFENSE_HISTORY,
-      [STORAGE_KEY.TIMERS]: DEFAULT_TIMERS,
-      [STORAGE_KEY.IS_TIER_HIDDEN]: DEFAULT_IS_TIER_HIDDEN,
-      [STORAGE_KEY.FONT_NO]: DEFAULT_FONT_NO,
-      [STORAGE_KEY.DATA_VERSION]: 'v1.2',
-    });
-  });
-});
-
-describe('Test #3 - 구버전 데이터가 아닌 경우(변환을 하면 안 되는 경우)에 대응하기', () => {
-  test('데이터에 버전 정보가 들어있고, 그 버전이 "v1.2"인 경우 구버전 데이터로 보지 않아야 하고, 변환을 진행하지 않아야 한다.', async () => {
-    jest.clearAllMocks();
-    jest
-      .spyOn(browser.storage.sync, 'get')
-      .mockImplementation(() => Promise.resolve({}));
-    jest
-      .spyOn(browser.storage.local, 'get')
-      .mockImplementation(() =>
-        Promise.resolve(Promise.resolve({ dataVersion: 'v1.2' })),
-      );
-    jest
-      .spyOn(browser.storage.local, 'set')
-      .mockImplementation(() => Promise.resolve());
-
-    await updateAllLegacyData();
-
-    expect(browser.storage.local.set).not.toHaveBeenCalled();
-  });
-
-  test('데이터에 버전 정보가 들어있더라도, 그 버전이 정해둔 최신 버전과 일치하지 않는 경우 구버전 데이터로 보고 변환을 진행해야 한다.', async () => {
-    jest.clearAllMocks();
-    jest
-      .spyOn(browser.storage.sync, 'get')
-      .mockImplementation(() => Promise.resolve({}));
-    jest
-      .spyOn(browser.storage.local, 'get')
-      .mockImplementation(() =>
-        Promise.resolve({ dataVersion: 'some old version' }),
-      );
-    jest
-      .spyOn(browser.storage.local, 'set')
-      .mockImplementation(() => Promise.resolve());
-
-    await updateAllLegacyData();
-
-    expect(browser.storage.local.set).toHaveBeenCalled();
+    expect(convertV2ToLatestOptionsData(legacyData)).toEqual(expected);
   });
 });

--- a/domains/dataHandlers/legacyDataUpdater.ts
+++ b/domains/dataHandlers/legacyDataUpdater.ts
@@ -1,164 +1,44 @@
 import {
-  V1_SYNC_STORAGE_KEY,
-  V1_LOCAL_STORAGE_KEY,
-  V2_STORAGE_KEY,
-  STORAGE_KEY,
-} from '@/constants/commands';
-import { sanitizeCheckedAlgorithmIds } from './sanitizers/checkedAlgorithmIdsSanitizer';
-import {
-  sanitizeV1QuickSlots,
-  sanitizeQuickSlots,
-} from './sanitizers/quickSlotsSanitizer';
-import {
-  sanitizeV1RandomDefenseHistory,
-  sanitizeRandomDefenseHistory,
-} from './sanitizers/randomDefenseHistorySanitizer';
-import { sanitizeIsTierHidden } from './sanitizers/isTierHiddenSanitizer';
-import { sanitizeFontNo } from './sanitizers/fontNoSanitizer';
-import { sanitizeTimers } from './sanitizers/timersSanitizer';
-import { sanitizeV2HiderOptions } from './sanitizers/hiderOptionsSanitizer';
-import { convertV1ToLatestQuickSlots } from './converters/legacyToLatestQuickSlotsConverter';
-import { convertV1ToLatestRandomDefenseHistory } from './converters/legacyToLatestRandomDefenseHistory';
-import {
-  convertV1ToV2HiderOptions,
-  convertV2ToLatestHiderOptions,
-} from './converters/legacyToLatestHiderOptionsConverter';
-import { convertV1ToLatestTotamjungThemeBySettings } from './converters/legacyToLatestTotamjungThemeConverter';
-import { convertV1ToLatestFontNoBySettings } from './converters/legacyToLatestFontNo';
-import { convertV1ToLatestTimers } from './converters/legacyToLatestTimers';
-import { sanitizeTotamjungTheme } from './sanitizers/totamjungThemeSanitizer';
-import { DEFAULT_GACHA_OPTIONS } from '@/constants/defaultValues';
-import { deleteOptionsData } from './optionsDataHandler';
+  convertV1ToV2OptionsData,
+  convertV2ToLatestOptionsData,
+} from '@/domains/dataHandlers/converters/legacyToLatestOptionsDataConverter';
 
-const validVersions = [2, 'v1.2', 3] as const;
+const getDataVersion = (data: Record<string, unknown>) => {
+  const { dataVersion } = data;
 
-export const updateV1ToV2Data = async () => {
-  const { dataVersion } = await browser.storage.local.get(
-    STORAGE_KEY.DATA_VERSION,
-  );
-
-  if (dataVersion === 'v1.2') {
-    return;
+  if (dataVersion === 2 || dataVersion === 'v1.2') {
+    return 2;
   }
 
-  if (typeof dataVersion === 'number' && dataVersion !== 1) {
-    return;
+  if (dataVersion === 3) {
+    return 3;
   }
 
-  const [legacySyncData, legacyLocalData] = await Promise.all([
-    browser.storage.sync.get(Object.values(V1_SYNC_STORAGE_KEY)),
-    browser.storage.local.get(Object.values(V1_LOCAL_STORAGE_KEY)),
-  ]);
-
-  const legacyQuickSlots = sanitizeV1QuickSlots(
-    legacySyncData[V1_SYNC_STORAGE_KEY.QUICK_SLOTS],
-  );
-  const legacyRandomDefenseHistory = sanitizeV1RandomDefenseHistory(
-    legacyLocalData[V1_LOCAL_STORAGE_KEY.RANDOM_DEFENSE_HISTORY],
-  );
-  const checkedAlgorithmIds = sanitizeCheckedAlgorithmIds(
-    legacySyncData[V1_SYNC_STORAGE_KEY.CHECKED_ALGORITHM_IDS],
-  );
-  const isTierHidden = sanitizeIsTierHidden(
-    legacySyncData[STORAGE_KEY.IS_TIER_HIDDEN],
-  );
-
-  const totamjungTheme = convertV1ToLatestTotamjungThemeBySettings(
-    legacySyncData[V1_SYNC_STORAGE_KEY.SETTINGS],
-  );
-  const hiderOptions = convertV1ToV2HiderOptions(
-    legacySyncData[V1_SYNC_STORAGE_KEY.TIMER],
-    legacySyncData[V1_SYNC_STORAGE_KEY.SETTINGS],
-  );
-  const quickSlots = convertV1ToLatestQuickSlots(legacyQuickSlots);
-  const randomDefenseHistory = convertV1ToLatestRandomDefenseHistory(
-    legacyRandomDefenseHistory,
-  );
-  const fontNo = convertV1ToLatestFontNoBySettings(
-    legacySyncData[V1_SYNC_STORAGE_KEY.SETTINGS],
-  );
-  const timers = convertV1ToLatestTimers(
-    legacySyncData[V1_SYNC_STORAGE_KEY.TIMER],
-  );
-
-  browser.storage.local.set({
-    [V2_STORAGE_KEY.CHECKED_ALGORITHM_IDS]: checkedAlgorithmIds,
-    [V2_STORAGE_KEY.QUICK_SLOTS]: quickSlots,
-    [V2_STORAGE_KEY.TOTAMJUNG_THEME]: totamjungTheme,
-    [V2_STORAGE_KEY.HIDER_OPTIONS]: hiderOptions,
-    [V2_STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: randomDefenseHistory,
-    [V2_STORAGE_KEY.IS_TIER_HIDDEN]: isTierHidden,
-    [V2_STORAGE_KEY.FONT_NO]: fontNo,
-    [V2_STORAGE_KEY.TIMERS]: timers,
-    [V2_STORAGE_KEY.DATA_VERSION]: 2,
-  });
-};
-
-export const updateV2ToLatestData = async () => {
-  const { dataVersion } = await browser.storage.local.get(
-    STORAGE_KEY.DATA_VERSION,
-  );
-
-  if (!['v1.2', 2].includes(dataVersion)) {
-    return;
-  }
-
-  const legacyData = await browser.storage.local.get(
-    Object.values(V2_STORAGE_KEY),
-  );
-
-  const legacyHiderOptions = sanitizeV2HiderOptions(
-    legacyData[V2_STORAGE_KEY.HIDER_OPTIONS],
-  );
-
-  const checkedAlgorithmIds = sanitizeCheckedAlgorithmIds(
-    legacyData[V2_STORAGE_KEY.CHECKED_ALGORITHM_IDS],
-  );
-  const quickSlots = sanitizeQuickSlots(legacyData[V2_STORAGE_KEY.QUICK_SLOTS]);
-  const totamjungTheme = sanitizeTotamjungTheme(
-    legacyData[V2_STORAGE_KEY.TOTAMJUNG_THEME],
-  );
-  const hiderOptions = convertV2ToLatestHiderOptions(legacyHiderOptions);
-  const randomDefenseHistory = sanitizeRandomDefenseHistory(
-    legacyData[V2_STORAGE_KEY.RANDOM_DEFENSE_HISTORY],
-  );
-  const isTierHidden = sanitizeIsTierHidden(
-    legacyData[STORAGE_KEY.IS_TIER_HIDDEN],
-  );
-  const fontNo = sanitizeFontNo(legacyData[V2_STORAGE_KEY.FONT_NO]);
-  const timers = sanitizeTimers(legacyData[V2_STORAGE_KEY.TIMERS]);
-
-  browser.storage.local.set({
-    [STORAGE_KEY.CHECKED_ALGORITHM_IDS]: checkedAlgorithmIds,
-    [STORAGE_KEY.QUICK_SLOTS]: quickSlots,
-    [STORAGE_KEY.TOTAMJUNG_THEME]: totamjungTheme,
-    [STORAGE_KEY.HIDER_OPTIONS]: hiderOptions,
-    [STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: randomDefenseHistory,
-    [STORAGE_KEY.IS_TIER_HIDDEN]: isTierHidden,
-    [STORAGE_KEY.FONT_NO]: fontNo,
-    [STORAGE_KEY.TIMERS]: timers,
-    [STORAGE_KEY.GACHA_OPTIONS]: DEFAULT_GACHA_OPTIONS,
-    [STORAGE_KEY.DATA_VERSION]: 3,
-  });
+  return 1;
 };
 
 export const updateAllLegacyData = async () => {
-  const { dataVersion } = await browser.storage.local.get(
-    STORAGE_KEY.DATA_VERSION,
+  const [syncStorageData, localStorageData] = await Promise.all([
+    browser.storage.sync.get(),
+    browser.storage.local.get(),
+  ]);
+
+  const dataVersion = getDataVersion(localStorageData);
+
+  if (dataVersion === 3) {
+    return;
+  }
+
+  if (dataVersion === 1) {
+    browser.storage.local.set(
+      convertV2ToLatestOptionsData(
+        convertV1ToV2OptionsData(syncStorageData, localStorageData),
+      ),
+    );
+    return;
+  }
+
+  await browser.storage.local.set(
+    convertV2ToLatestOptionsData(localStorageData),
   );
-
-  if (!validVersions.includes(dataVersion) && typeof dataVersion === 'number') {
-    await deleteOptionsData();
-    return;
-  }
-
-  if (!dataVersion) {
-    await updateV1ToV2Data();
-    await updateV2ToLatestData();
-    return;
-  }
-
-  if (dataVersion === 'v1.2' || dataVersion < 3) {
-    await updateV2ToLatestData();
-  }
 };

--- a/domains/dataHandlers/legacyDataUpdater.ts
+++ b/domains/dataHandlers/legacyDataUpdater.ts
@@ -1,20 +1,38 @@
 import {
-  LEGACY_SYNC_STORAGE_KEY,
-  LEGACY_LOCAL_STORAGE_KEY,
+  V1_SYNC_STORAGE_KEY,
+  V1_LOCAL_STORAGE_KEY,
+  V2_STORAGE_KEY,
   STORAGE_KEY,
 } from '@/constants/commands';
 import { sanitizeCheckedAlgorithmIds } from './sanitizers/checkedAlgorithmIdsSanitizer';
-import { sanitizeLegacyQuickSlots } from './sanitizers/quickSlotsSanitizer';
-import { sanitizeLegacyRandomDefenseHistory } from './sanitizers/randomDefenseHistorySanitizer';
+import {
+  sanitizeV1QuickSlots,
+  sanitizeQuickSlots,
+} from './sanitizers/quickSlotsSanitizer';
+import {
+  sanitizeV1RandomDefenseHistory,
+  sanitizeRandomDefenseHistory,
+} from './sanitizers/randomDefenseHistorySanitizer';
 import { sanitizeIsTierHidden } from './sanitizers/isTierHiddenSanitizer';
-import { convertLegacyToLatestQuickSlots } from './converters/legacyToLatestQuickSlotsConverter';
-import { convertLegacyToLatestRandomDefenseHistory } from './converters/legacyToLatestRandomDefenseHistory';
-import { convertLegacyToLatestHiderOptions } from './converters/legacyToLatestHiderOptionsConverter';
-import { convertLegacyToLatestTotamjungThemeBySettings } from './converters/legacyToLatestTotamjungThemeConverter';
-import { convertLegacyToLatestFontNoBySettings } from './converters/legacyToLatestFontNo';
-import { convertLegacyToLatestTimers } from './converters/legacyToLatestTimers';
+import { sanitizeFontNo } from './sanitizers/fontNoSanitizer';
+import { sanitizeTimers } from './sanitizers/timersSanitizer';
+import { sanitizeV2HiderOptions } from './sanitizers/hiderOptionsSanitizer';
+import { convertV1ToLatestQuickSlots } from './converters/legacyToLatestQuickSlotsConverter';
+import { convertV1ToLatestRandomDefenseHistory } from './converters/legacyToLatestRandomDefenseHistory';
+import {
+  convertV1ToV2HiderOptions,
+  convertV2ToLatestHiderOptions,
+} from './converters/legacyToLatestHiderOptionsConverter';
+import { convertV1ToLatestTotamjungThemeBySettings } from './converters/legacyToLatestTotamjungThemeConverter';
+import { convertV1ToLatestFontNoBySettings } from './converters/legacyToLatestFontNo';
+import { convertV1ToLatestTimers } from './converters/legacyToLatestTimers';
+import { sanitizeTotamjungTheme } from './sanitizers/totamjungThemeSanitizer';
+import { DEFAULT_GACHA_OPTIONS } from '@/constants/defaultValues';
+import { deleteOptionsData } from './optionsDataHandler';
 
-export const updateAllLegacyData = async () => {
+const validVersions = [2, 'v1.2', 3] as const;
+
+export const updateV1ToV2Data = async () => {
   const { dataVersion } = await browser.storage.local.get(
     STORAGE_KEY.DATA_VERSION,
   );
@@ -23,41 +41,92 @@ export const updateAllLegacyData = async () => {
     return;
   }
 
+  if (typeof dataVersion === 'number' && dataVersion !== 1) {
+    return;
+  }
+
   const [legacySyncData, legacyLocalData] = await Promise.all([
-    browser.storage.sync.get(Object.values(LEGACY_SYNC_STORAGE_KEY)),
-    browser.storage.local.get(Object.values(LEGACY_LOCAL_STORAGE_KEY)),
+    browser.storage.sync.get(Object.values(V1_SYNC_STORAGE_KEY)),
+    browser.storage.local.get(Object.values(V1_LOCAL_STORAGE_KEY)),
   ]);
 
-  const legacyQuickSlots = sanitizeLegacyQuickSlots(
-    legacySyncData[LEGACY_SYNC_STORAGE_KEY.QUICK_SLOTS],
+  const legacyQuickSlots = sanitizeV1QuickSlots(
+    legacySyncData[V1_SYNC_STORAGE_KEY.QUICK_SLOTS],
   );
-  const legacyRandomDefenseHistory = sanitizeLegacyRandomDefenseHistory(
-    legacyLocalData[LEGACY_LOCAL_STORAGE_KEY.RANDOM_DEFENSE_HISTORY],
+  const legacyRandomDefenseHistory = sanitizeV1RandomDefenseHistory(
+    legacyLocalData[V1_LOCAL_STORAGE_KEY.RANDOM_DEFENSE_HISTORY],
   );
   const checkedAlgorithmIds = sanitizeCheckedAlgorithmIds(
-    legacySyncData[LEGACY_SYNC_STORAGE_KEY.CHECKED_ALGORITHM_IDS],
+    legacySyncData[V1_SYNC_STORAGE_KEY.CHECKED_ALGORITHM_IDS],
   );
   const isTierHidden = sanitizeIsTierHidden(
     legacySyncData[STORAGE_KEY.IS_TIER_HIDDEN],
   );
 
-  const totamjungTheme = convertLegacyToLatestTotamjungThemeBySettings(
-    legacySyncData[LEGACY_SYNC_STORAGE_KEY.SETTINGS],
+  const totamjungTheme = convertV1ToLatestTotamjungThemeBySettings(
+    legacySyncData[V1_SYNC_STORAGE_KEY.SETTINGS],
   );
-  const hiderOptions = convertLegacyToLatestHiderOptions(
-    legacySyncData[LEGACY_SYNC_STORAGE_KEY.TIMER],
-    legacySyncData[LEGACY_SYNC_STORAGE_KEY.SETTINGS],
+  const hiderOptions = convertV1ToV2HiderOptions(
+    legacySyncData[V1_SYNC_STORAGE_KEY.TIMER],
+    legacySyncData[V1_SYNC_STORAGE_KEY.SETTINGS],
   );
-  const quickSlots = convertLegacyToLatestQuickSlots(legacyQuickSlots);
-  const randomDefenseHistory = convertLegacyToLatestRandomDefenseHistory(
+  const quickSlots = convertV1ToLatestQuickSlots(legacyQuickSlots);
+  const randomDefenseHistory = convertV1ToLatestRandomDefenseHistory(
     legacyRandomDefenseHistory,
   );
-  const fontNo = convertLegacyToLatestFontNoBySettings(
-    legacySyncData[LEGACY_SYNC_STORAGE_KEY.SETTINGS],
+  const fontNo = convertV1ToLatestFontNoBySettings(
+    legacySyncData[V1_SYNC_STORAGE_KEY.SETTINGS],
   );
-  const timers = convertLegacyToLatestTimers(
-    legacySyncData[LEGACY_SYNC_STORAGE_KEY.TIMER],
+  const timers = convertV1ToLatestTimers(
+    legacySyncData[V1_SYNC_STORAGE_KEY.TIMER],
   );
+
+  browser.storage.local.set({
+    [V2_STORAGE_KEY.CHECKED_ALGORITHM_IDS]: checkedAlgorithmIds,
+    [V2_STORAGE_KEY.QUICK_SLOTS]: quickSlots,
+    [V2_STORAGE_KEY.TOTAMJUNG_THEME]: totamjungTheme,
+    [V2_STORAGE_KEY.HIDER_OPTIONS]: hiderOptions,
+    [V2_STORAGE_KEY.RANDOM_DEFENSE_HISTORY]: randomDefenseHistory,
+    [V2_STORAGE_KEY.IS_TIER_HIDDEN]: isTierHidden,
+    [V2_STORAGE_KEY.FONT_NO]: fontNo,
+    [V2_STORAGE_KEY.TIMERS]: timers,
+    [V2_STORAGE_KEY.DATA_VERSION]: 2,
+  });
+};
+
+export const updateV2ToLatestData = async () => {
+  const { dataVersion } = await browser.storage.local.get(
+    STORAGE_KEY.DATA_VERSION,
+  );
+
+  if (!['v1.2', 2].includes(dataVersion)) {
+    return;
+  }
+
+  const legacyData = await browser.storage.local.get(
+    Object.values(V2_STORAGE_KEY),
+  );
+
+  const legacyHiderOptions = sanitizeV2HiderOptions(
+    legacyData[V2_STORAGE_KEY.HIDER_OPTIONS],
+  );
+
+  const checkedAlgorithmIds = sanitizeCheckedAlgorithmIds(
+    legacyData[V2_STORAGE_KEY.CHECKED_ALGORITHM_IDS],
+  );
+  const quickSlots = sanitizeQuickSlots(legacyData[V2_STORAGE_KEY.QUICK_SLOTS]);
+  const totamjungTheme = sanitizeTotamjungTheme(
+    legacyData[V2_STORAGE_KEY.TOTAMJUNG_THEME],
+  );
+  const hiderOptions = convertV2ToLatestHiderOptions(legacyHiderOptions);
+  const randomDefenseHistory = sanitizeRandomDefenseHistory(
+    legacyData[V2_STORAGE_KEY.RANDOM_DEFENSE_HISTORY],
+  );
+  const isTierHidden = sanitizeIsTierHidden(
+    legacyData[STORAGE_KEY.IS_TIER_HIDDEN],
+  );
+  const fontNo = sanitizeFontNo(legacyData[V2_STORAGE_KEY.FONT_NO]);
+  const timers = sanitizeTimers(legacyData[V2_STORAGE_KEY.TIMERS]);
 
   browser.storage.local.set({
     [STORAGE_KEY.CHECKED_ALGORITHM_IDS]: checkedAlgorithmIds,
@@ -68,6 +137,28 @@ export const updateAllLegacyData = async () => {
     [STORAGE_KEY.IS_TIER_HIDDEN]: isTierHidden,
     [STORAGE_KEY.FONT_NO]: fontNo,
     [STORAGE_KEY.TIMERS]: timers,
-    [STORAGE_KEY.DATA_VERSION]: 'v1.2',
+    [STORAGE_KEY.GACHA_OPTIONS]: DEFAULT_GACHA_OPTIONS,
+    [STORAGE_KEY.DATA_VERSION]: 3,
   });
+};
+
+export const updateAllLegacyData = async () => {
+  const { dataVersion } = await browser.storage.local.get(
+    STORAGE_KEY.DATA_VERSION,
+  );
+
+  if (!validVersions.includes(dataVersion) && typeof dataVersion === 'number') {
+    await deleteOptionsData();
+    return;
+  }
+
+  if (!dataVersion) {
+    await updateV1ToV2Data();
+    await updateV2ToLatestData();
+    return;
+  }
+
+  if (dataVersion === 'v1.2' || dataVersion < 3) {
+    await updateV2ToLatestData();
+  }
 };

--- a/domains/dataHandlers/quickSlotsDataHandler.test.ts
+++ b/domains/dataHandlers/quickSlotsDataHandler.test.ts
@@ -7,7 +7,7 @@ import {
   fetchQuickSlots,
   saveQuickSlots,
 } from '../dataHandlers/quickSlotsDataHandler';
-import { DEFAULT_QUICK_SLOTS_RESPONSE } from '@/constants/defaultValues';
+import { DEFAULT_QUICK_SLOTS } from '@/constants/defaultValues';
 import type { QuickSlots } from '@/types/randomDefense';
 
 const validQuickSlots: QuickSlots = {
@@ -260,7 +260,7 @@ describe('Test #2 - 유효하지 않은 퀵슬롯 정보를 불러올 경우 대
       }),
     );
 
-    expect(await fetchQuickSlots()).toEqual(DEFAULT_QUICK_SLOTS_RESPONSE);
+    expect(await fetchQuickSlots()).toEqual(DEFAULT_QUICK_SLOTS);
   });
 
   test('slots 프로퍼티를 찾을 수 없는 경우, 복구가 불가능한 것으로 판정하고, 초기 데이터를 반환해야 한다.', async () => {
@@ -275,7 +275,7 @@ describe('Test #2 - 유효하지 않은 퀵슬롯 정보를 불러올 경우 대
       }),
     );
 
-    expect(await fetchQuickSlots()).toEqual(DEFAULT_QUICK_SLOTS_RESPONSE);
+    expect(await fetchQuickSlots()).toEqual(DEFAULT_QUICK_SLOTS);
   });
 
   test('데이터가 오브젝트 형태가 아닌 경우, 복구가 불가능한 것으로 판정하고, 초기 데이터를 반환해야 한다.', async () => {
@@ -287,7 +287,7 @@ describe('Test #2 - 유효하지 않은 퀵슬롯 정보를 불러올 경우 대
       }),
     );
 
-    expect(await fetchQuickSlots()).toEqual(DEFAULT_QUICK_SLOTS_RESPONSE);
+    expect(await fetchQuickSlots()).toEqual(DEFAULT_QUICK_SLOTS);
   });
 });
 

--- a/domains/dataHandlers/sanitizers/hiderOptionsSanitizer.ts
+++ b/domains/dataHandlers/sanitizers/hiderOptionsSanitizer.ts
@@ -1,6 +1,18 @@
-import { DEFAULT_HIDER_OPTIONS } from '@/constants/defaultValues';
-import { isHiderOptions } from '../validators/hiderOptionsValidator';
+import {
+  DEFAULT_HIDER_OPTIONS,
+  DEFAULT_V2_HIDER_OPTIONS,
+} from '@/constants/defaultValues';
+import {
+  isHiderOptions,
+  isV2HiderOptions,
+} from '../validators/hiderOptionsValidator';
 
-export const hiderOptionsSanitizer = (hiderOptions: unknown) => {
+export const sanitizeV2HiderOptions = (legacyHiderOptions: unknown) => {
+  return isV2HiderOptions(legacyHiderOptions)
+    ? legacyHiderOptions
+    : DEFAULT_V2_HIDER_OPTIONS;
+};
+
+export const sanitizeHiderOptions = (hiderOptions: unknown) => {
   return isHiderOptions(hiderOptions) ? hiderOptions : DEFAULT_HIDER_OPTIONS;
 };

--- a/domains/dataHandlers/sanitizers/quickSlotsSanitizer.ts
+++ b/domains/dataHandlers/sanitizers/quickSlotsSanitizer.ts
@@ -1,26 +1,22 @@
 import {
   isSlot,
   isHotkey,
+  isV1RepairableQuickSlots,
   isRepairableQuickSlots,
-  isRepairableLegacyQuickSlots,
+  isV1QuickSlots,
   isQuickSlots,
   isSlotNo,
-  isLegacyQuickSlots,
 } from '../validators/quickSlotsValidator';
 import {
-  DEFAULT_QUICK_SLOTS_RESPONSE,
-  DEFAULT_LEGACY_QUICK_SLOTS_RESPONSE,
+  DEFAULT_QUICK_SLOTS,
+  DEFAULT_V1_QUICK_SLOTS,
 } from '@/constants/defaultValues';
 import {
   MAX_CUSTOM_QUERY_LENGTH,
   TITLE_MAX_LENGTH,
 } from '@/constants/randomDefense';
-import type {
-  QuickSlots,
-  LegacyQuickSlots,
-  SlotNo,
-  Slot,
-} from '@/types/randomDefense';
+import type { QuickSlots, SlotNo, Slot } from '@/types/randomDefense';
+import { V1 } from '@/types/legacyData';
 
 const SLOT_NOS: SlotNo[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
 
@@ -50,7 +46,7 @@ const sanitizeSlot = (slot: unknown, slotNo: SlotNo): Slot => {
 
 export const sanitizeQuickSlots = (quickSlots: unknown): QuickSlots => {
   if (!isRepairableQuickSlots(quickSlots)) {
-    return DEFAULT_QUICK_SLOTS_RESPONSE;
+    return DEFAULT_QUICK_SLOTS;
   }
 
   const hotkey =
@@ -75,14 +71,14 @@ export const sanitizeQuickSlots = (quickSlots: unknown): QuickSlots => {
 
   return isQuickSlots(sanitizedQuickSlots)
     ? sanitizedQuickSlots
-    : DEFAULT_QUICK_SLOTS_RESPONSE;
+    : DEFAULT_QUICK_SLOTS;
 };
 
-export const sanitizeLegacyQuickSlots = (
+export const sanitizeV1QuickSlots = (
   legacyQuickSlots: unknown,
-): LegacyQuickSlots => {
-  if (!isRepairableLegacyQuickSlots(legacyQuickSlots)) {
-    return DEFAULT_LEGACY_QUICK_SLOTS_RESPONSE;
+): V1.QuickSlots => {
+  if (!isV1RepairableQuickSlots(legacyQuickSlots)) {
+    return DEFAULT_V1_QUICK_SLOTS;
   }
 
   const { selectedNo, ...slots } = legacyQuickSlots;
@@ -101,7 +97,7 @@ export const sanitizeLegacyQuickSlots = (
     sanitizedLegacyQuickSlots[slotNo] = sanitizeSlot(slot, slotNo);
   });
 
-  return isLegacyQuickSlots(sanitizedLegacyQuickSlots)
+  return isV1QuickSlots(sanitizedLegacyQuickSlots)
     ? sanitizedLegacyQuickSlots
-    : DEFAULT_LEGACY_QUICK_SLOTS_RESPONSE;
+    : DEFAULT_V1_QUICK_SLOTS;
 };

--- a/domains/dataHandlers/sanitizers/randomDefenseHistorySanitizer.ts
+++ b/domains/dataHandlers/sanitizers/randomDefenseHistorySanitizer.ts
@@ -45,6 +45,14 @@ const isValidV1RandomDefenseHistoryInfo = (item: unknown) => {
   );
 };
 
+const getSortedV1RandomDefenseHistory = (
+  randomDefenseHistory: V1.RandomDefenseHistoryInfo[],
+) => {
+  return [...randomDefenseHistory].sort((a, b) =>
+    new Date(a.date).getTime() > new Date(b.date).getTime() ? -1 : 1,
+  );
+};
+
 const getSortedRandomDefenseHistory = (
   randomDefenseHistory: RandomDefenseHistoryInfo[],
 ) => {
@@ -95,5 +103,7 @@ export const sanitizeV1RandomDefenseHistory = (
     }
   });
 
-  return sanitizedLegacyRandomDefenseHistory.slice(0, MAX_HISTORY_LIMIT);
+  return getSortedV1RandomDefenseHistory(
+    sanitizedLegacyRandomDefenseHistory,
+  ).slice(0, MAX_HISTORY_LIMIT);
 };

--- a/domains/dataHandlers/sanitizers/randomDefenseHistorySanitizer.ts
+++ b/domains/dataHandlers/sanitizers/randomDefenseHistorySanitizer.ts
@@ -8,16 +8,14 @@ import {
   MAX_TIER,
 } from '@/constants/randomDefense';
 import {
-  isLegacyRandomDefenseHistoryInfo,
   isRandomDefenseHistoryInfo,
+  isV1RandomDefenseHistoryInfo,
 } from '@/domains/dataHandlers/validators/randomDefenseHistoryValidator';
-import {
-  LegacyRandomDefenseHistoryInfo,
-  RandomDefenseHistoryInfo,
-} from '@/types/randomDefense';
+import { RandomDefenseHistoryInfo } from '@/types/randomDefense';
 import { isValidIsoString } from '@/utils/isValidIsoString';
 import { isValidDate } from '@/utils/isValidDate';
 import { DEFAULT_RANDOM_DEFENSE_HISTORY } from '@/constants/defaultValues';
+import type { V1 } from '@/types/legacyData';
 
 const isValidRandomDefenseHistoryInfo = (item: unknown) => {
   return (
@@ -33,9 +31,9 @@ const isValidRandomDefenseHistoryInfo = (item: unknown) => {
   );
 };
 
-const isValidLegacyRandomDefenseHistoryInfo = (item: unknown) => {
+const isValidV1RandomDefenseHistoryInfo = (item: unknown) => {
   return (
-    isLegacyRandomDefenseHistoryInfo(item) &&
+    isV1RandomDefenseHistoryInfo(item) &&
     item.no % 1 === 0 &&
     item.no >= MIN_PROBLEM_ID &&
     item.no <= MAX_PROBLEM_ID &&
@@ -79,20 +77,19 @@ export const sanitizeRandomDefenseHistory = (
   );
 };
 
-export const sanitizeLegacyRandomDefenseHistory = (
+export const sanitizeV1RandomDefenseHistory = (
   legacyRandomDefenseHistory: unknown,
-): LegacyRandomDefenseHistoryInfo[] => {
+): V1.RandomDefenseHistoryInfo[] => {
   if (!Array.isArray(legacyRandomDefenseHistory)) {
     return DEFAULT_RANDOM_DEFENSE_HISTORY;
   }
 
-  const sanitizedLegacyRandomDefenseHistory: LegacyRandomDefenseHistoryInfo[] =
-    [];
+  const sanitizedLegacyRandomDefenseHistory: V1.RandomDefenseHistoryInfo[] = [];
 
   legacyRandomDefenseHistory.forEach((item) => {
     if (
-      isLegacyRandomDefenseHistoryInfo(item) &&
-      isValidLegacyRandomDefenseHistoryInfo(item)
+      isV1RandomDefenseHistoryInfo(item) &&
+      isValidV1RandomDefenseHistoryInfo(item)
     ) {
       sanitizedLegacyRandomDefenseHistory.push(item);
     }

--- a/domains/dataHandlers/validators/fontNoValidator.ts
+++ b/domains/dataHandlers/validators/fontNoValidator.ts
@@ -1,11 +1,12 @@
-import { FontNo, LegacyFontNo } from '@/types/font';
+import type { FontNo } from '@/types/font';
+import type { V1 } from '@/types/legacyData';
 
-const LEGACY_FONT_REGEX = /^(none|font-\d{1,2})$/;
+const V1_FONT_REGEX = /^(none|font-\d{1,2})$/;
+
+export const isV1FontNo = (data: unknown): data is V1.FontNo => {
+  return typeof data === 'string' && V1_FONT_REGEX.test(data);
+};
 
 export const isFontNo = (data: unknown): data is FontNo => {
   return typeof data === 'number' && !isNaN(data) && data % 1 === 0;
-};
-
-export const isLegacyFontNo = (data: unknown): data is LegacyFontNo => {
-  return typeof data === 'string' && LEGACY_FONT_REGEX.test(data);
 };

--- a/domains/dataHandlers/validators/hiderOptionsValidator.ts
+++ b/domains/dataHandlers/validators/hiderOptionsValidator.ts
@@ -1,15 +1,12 @@
 import { isObject, isRatedTier } from '@/types/typeGuards';
-import type {
-  HiderOptions,
-  LegacySettings,
-  LegacyTimer,
-} from '@/types/algorithm';
+import type { HiderOptions } from '@/types/algorithm';
+import type { V1, V2 } from '@/types/legacyData';
 import {
   isNumericString,
   isNumericStringAllowsLeadingZeroes,
 } from '@/utils/numericStringChecker';
 
-export const isHiderOptions = (data: unknown): data is HiderOptions => {
+export const isV2HiderOptions = (data: unknown): data is V2.HiderOptions => {
   if (
     !(
       isObject(data) &&
@@ -17,7 +14,6 @@ export const isHiderOptions = (data: unknown): data is HiderOptions => {
       'shouldHideTier' in data &&
       'shouldWarnHighTier' in data &&
       'warnTier' in data &&
-      'shouldRevealTierOnHover' in data &&
       'algorithmHiderUsage' in data &&
       'problemTagLockUsage' in data &&
       isObject(data.problemTagLockDuration) &&
@@ -27,7 +23,6 @@ export const isHiderOptions = (data: unknown): data is HiderOptions => {
       typeof data.problemTagLockDuration.minutes === 'number' &&
       typeof data.shouldHideTier === 'boolean' &&
       typeof data.shouldWarnHighTier === 'boolean' &&
-      typeof data.shouldRevealTierOnHover === 'boolean' &&
       isRatedTier(data.warnTier) &&
       typeof data.algorithmHiderUsage === 'string' &&
       ['click', 'always'].includes(data.algorithmHiderUsage) &&
@@ -50,7 +45,15 @@ export const isHiderOptions = (data: unknown): data is HiderOptions => {
   );
 };
 
-export const isLegacyTimer = (data: unknown): data is LegacyTimer => {
+export const isHiderOptions = (data: unknown): data is HiderOptions => {
+  return (
+    isV2HiderOptions(data) &&
+    'shouldRevealTierOnHover' in data &&
+    typeof data.shouldRevealTierOnHover === 'boolean'
+  );
+};
+
+export const isV1Timer = (data: unknown): data is V1.Timer => {
   return (
     isObject(data) &&
     'expire' in data &&
@@ -71,7 +74,7 @@ export const isLegacyTimer = (data: unknown): data is LegacyTimer => {
   );
 };
 
-export const isLegacySettings = (data: unknown): data is LegacySettings => {
+export const isV1Settings = (data: unknown): data is V1.Settings => {
   if (
     !(
       isObject(data) &&

--- a/domains/dataHandlers/validators/optionsDataValidator.ts
+++ b/domains/dataHandlers/validators/optionsDataValidator.ts
@@ -1,13 +1,48 @@
 import { isValidCheckedAlgorithmIds } from './checkedAlgorithmIdsValidator';
 import { isQuickSlots } from './quickSlotsValidator';
 import { isTotamjungTheme } from './totamjungThemeValidator';
-import { isHiderOptions } from './hiderOptionsValidator';
+import { isHiderOptions, isV2HiderOptions } from './hiderOptionsValidator';
 import { isRandomDefenseHistoryInfos } from './randomDefenseHistoryValidator';
 import { isFontNo } from './fontNoValidator';
 import { isTimers } from './isTimersValidator';
-import { STORAGE_KEY } from '@/constants/commands';
+import { STORAGE_KEY, V2_STORAGE_KEY } from '@/constants/commands';
 import { isObject } from '@/types/typeGuards';
 import type { OptionsData } from '@/types/options';
+import type { V2 } from '@/types/legacyData';
+import { isGachaOptions } from './gachaOptionsValidator';
+import { isShouldShowWelcomeMessage } from './isShouldShowWelcomeMessageDataValidator';
+
+export const isV2OptionsData = (data: unknown): data is V2.OptionsData => {
+  if (
+    !(
+      isObject(data) &&
+      V2_STORAGE_KEY.DATA_VERSION in data &&
+      V2_STORAGE_KEY.CHECKED_ALGORITHM_IDS in data &&
+      V2_STORAGE_KEY.QUICK_SLOTS in data &&
+      V2_STORAGE_KEY.TOTAMJUNG_THEME in data &&
+      V2_STORAGE_KEY.HIDER_OPTIONS in data &&
+      V2_STORAGE_KEY.RANDOM_DEFENSE_HISTORY in data &&
+      V2_STORAGE_KEY.IS_TIER_HIDDEN in data &&
+      V2_STORAGE_KEY.FONT_NO in data &&
+      V2_STORAGE_KEY.TIMERS in data
+    )
+  ) {
+    return false;
+  }
+
+  return (
+    (data[STORAGE_KEY.DATA_VERSION] === 'v1.2' ||
+      data[STORAGE_KEY.DATA_VERSION] === 2) &&
+    isValidCheckedAlgorithmIds(data[STORAGE_KEY.CHECKED_ALGORITHM_IDS]) &&
+    isQuickSlots(data[STORAGE_KEY.QUICK_SLOTS]) &&
+    isTotamjungTheme(data[STORAGE_KEY.TOTAMJUNG_THEME]) &&
+    isV2HiderOptions(data[STORAGE_KEY.HIDER_OPTIONS]) &&
+    isRandomDefenseHistoryInfos(data[STORAGE_KEY.RANDOM_DEFENSE_HISTORY]) &&
+    typeof data[STORAGE_KEY.IS_TIER_HIDDEN] === 'boolean' &&
+    isFontNo(data[STORAGE_KEY.FONT_NO]) &&
+    isTimers(data[STORAGE_KEY.TIMERS])
+  );
+};
 
 export const isOptionsData = (data: unknown): data is OptionsData => {
   if (
@@ -21,14 +56,16 @@ export const isOptionsData = (data: unknown): data is OptionsData => {
       STORAGE_KEY.RANDOM_DEFENSE_HISTORY in data &&
       STORAGE_KEY.IS_TIER_HIDDEN in data &&
       STORAGE_KEY.FONT_NO in data &&
-      STORAGE_KEY.TIMERS in data
+      STORAGE_KEY.TIMERS in data &&
+      STORAGE_KEY.GACHA_OPTIONS in data &&
+      STORAGE_KEY.SHOULD_SHOW_WELCOME_MESSAGE in data
     )
   ) {
     return false;
   }
 
   return (
-    data[STORAGE_KEY.DATA_VERSION] === 'v1.2' &&
+    data[STORAGE_KEY.DATA_VERSION] === 3 &&
     isValidCheckedAlgorithmIds(data[STORAGE_KEY.CHECKED_ALGORITHM_IDS]) &&
     isQuickSlots(data[STORAGE_KEY.QUICK_SLOTS]) &&
     isTotamjungTheme(data[STORAGE_KEY.TOTAMJUNG_THEME]) &&
@@ -36,6 +73,8 @@ export const isOptionsData = (data: unknown): data is OptionsData => {
     isRandomDefenseHistoryInfos(data[STORAGE_KEY.RANDOM_DEFENSE_HISTORY]) &&
     typeof data[STORAGE_KEY.IS_TIER_HIDDEN] === 'boolean' &&
     isFontNo(data[STORAGE_KEY.FONT_NO]) &&
-    isTimers(data[STORAGE_KEY.TIMERS])
+    isTimers(data[STORAGE_KEY.TIMERS]) &&
+    isGachaOptions(data[STORAGE_KEY.GACHA_OPTIONS]) &&
+    isShouldShowWelcomeMessage(data[STORAGE_KEY.SHOULD_SHOW_WELCOME_MESSAGE])
   );
 };

--- a/domains/dataHandlers/validators/quickSlotsValidator.ts
+++ b/domains/dataHandlers/validators/quickSlotsValidator.ts
@@ -1,13 +1,12 @@
 import { isNumericObject, isObject } from '@/types/typeGuards';
 import type {
   Hotkey,
-  LegacyQuickSlots,
   QuickSlots,
-  RepairableLegacyQuickSlots,
   RepairableQuickSlots,
   Slot,
   SlotNo,
 } from '@/types/randomDefense';
+import type { V1 } from '@/types/legacyData';
 
 export const isHotkey = (data: unknown): data is Hotkey => {
   return data === 'Alt' || data === 'F2';
@@ -42,6 +41,32 @@ export const isSlotNo = (data: unknown): data is SlotNo => {
   return [1, 2, 3, 4, 5, 6, 7, 8, 9, 0].includes(data);
 };
 
+export const isV1QuickSlots = (data: unknown): data is V1.QuickSlots => {
+  if (
+    !(
+      isObject(data) &&
+      'selectedNo' in data &&
+      typeof data.selectedNo === 'number'
+    )
+  ) {
+    return false;
+  }
+
+  const { selectedNo, ...slots } = data;
+
+  if (!(selectedNo % 1 === 0 && selectedNo >= 0 && selectedNo <= 9)) {
+    return false;
+  }
+
+  if (!isNumericObject(slots)) {
+    return false;
+  }
+
+  return Array.from({ length: 10 }).every(
+    (_, key) => key in slots && isSlot(slots[key]),
+  );
+};
+
 export const isQuickSlots = (data: unknown): data is QuickSlots => {
   if (
     !(
@@ -68,35 +93,9 @@ export const isQuickSlots = (data: unknown): data is QuickSlots => {
   );
 };
 
-export const isLegacyQuickSlots = (data: unknown): data is LegacyQuickSlots => {
-  if (
-    !(
-      isObject(data) &&
-      'selectedNo' in data &&
-      typeof data.selectedNo === 'number'
-    )
-  ) {
-    return false;
-  }
-
-  const { selectedNo, ...slots } = data;
-
-  if (!(selectedNo % 1 === 0 && selectedNo >= 0 && selectedNo <= 9)) {
-    return false;
-  }
-
-  if (!isNumericObject(slots)) {
-    return false;
-  }
-
-  return Array.from({ length: 10 }).every(
-    (_, key) => key in slots && isSlot(slots[key]),
-  );
-};
-
-export const isRepairableLegacyQuickSlots = (
+export const isV1RepairableQuickSlots = (
   data: unknown,
-): data is RepairableLegacyQuickSlots => {
+): data is V1.RepairableQuickSlots => {
   return (
     isObject(data) && Array.from({ length: 10 }).every((_, key) => key in data)
   );

--- a/domains/dataHandlers/validators/randomDefenseHistoryValidator.ts
+++ b/domains/dataHandlers/validators/randomDefenseHistoryValidator.ts
@@ -1,10 +1,27 @@
 import { solvedAcNumericTierIcons } from '@/assets/svg/tier';
 import type {
-  LegacyRandomDefenseHistoryInfo,
   RandomDefenseHistoryInfo,
   RandomDefenseHistoryResponse,
 } from '@/types/randomDefense';
+import type { V1 } from '@/types/legacyData';
 import { isIsoString, isObject } from '@/types/typeGuards';
+
+export const isV1RandomDefenseHistoryInfo = (
+  data: unknown,
+): data is V1.RandomDefenseHistoryInfo => {
+  return (
+    isObject(data) &&
+    'no' in data &&
+    'title' in data &&
+    'tier' in data &&
+    'date' in data &&
+    typeof data.no === 'number' &&
+    typeof data.title === 'string' &&
+    typeof data.tier === 'number' &&
+    typeof data.date === 'string' &&
+    data.tier in solvedAcNumericTierIcons
+  );
+};
 
 export const isRandomDefenseHistoryInfo = (
   data: unknown,
@@ -20,23 +37,6 @@ export const isRandomDefenseHistoryInfo = (
     typeof data.tier === 'number' &&
     data.tier in solvedAcNumericTierIcons &&
     isIsoString(data.createdAt)
-  );
-};
-
-export const isLegacyRandomDefenseHistoryInfo = (
-  data: unknown,
-): data is LegacyRandomDefenseHistoryInfo => {
-  return (
-    isObject(data) &&
-    'no' in data &&
-    'title' in data &&
-    'tier' in data &&
-    'date' in data &&
-    typeof data.no === 'number' &&
-    typeof data.title === 'string' &&
-    typeof data.tier === 'number' &&
-    typeof data.date === 'string' &&
-    data.tier in solvedAcNumericTierIcons
   );
 };
 

--- a/hooks/widget/useRandomDefense.ts
+++ b/hooks/widget/useRandomDefense.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { COMMANDS } from '@/constants/commands';
-import { DEFAULT_QUICK_SLOTS_RESPONSE } from '@/constants/defaultValues';
+import { DEFAULT_QUICK_SLOTS } from '@/constants/defaultValues';
 import { isQuickSlots } from '@/domains/dataHandlers/validators/quickSlotsValidator';
 import { isRandomDefenseResult } from '@/domains/dataHandlers/validators/RandomDefenseResultValidator';
 import useHotKeyLongPress from '../useHotkeyLongPress';
@@ -18,7 +18,7 @@ const useRandomDefense = (params: UseRandomDefenseParams) => {
   const [isRandomDefenseAvailable, setIsRandomDefenseAvailable] =
     useState(false);
   const isRandomDefenseAvailableRef = useRef(isRandomDefenseAvailable);
-  const quickSlotsRef = useRef<QuickSlots>(DEFAULT_QUICK_SLOTS_RESPONSE);
+  const quickSlotsRef = useRef<QuickSlots>(DEFAULT_QUICK_SLOTS);
   useHotKeyLongPress({
     baseKey: quickSlotsRef.current.hotkey,
     requiredLongPressTimeInMilliseconds: 1000,

--- a/types/algorithm.ts
+++ b/types/algorithm.ts
@@ -27,20 +27,6 @@ export interface HiderOptions {
   problemTagLockUsage: 'click' | 'auto';
 }
 
-export interface LegacyTimer {
-  expire: number;
-  hour: string;
-  minute: string;
-  problem: number;
-}
-
-export interface LegacySettings {
-  font: `font-${number}` | 'none';
-  lock: 'click' | 'always';
-  predict: 'click' | 'always';
-  theme: 'yes' | 'no';
-}
-
 export type CheckedAlgorithmIds = number[];
 
 export interface Timer {

--- a/types/font.ts
+++ b/types/font.ts
@@ -1,3 +1,1 @@
 export type FontNo = number;
-
-export type LegacyFontNo = 'none' | `font-${number}`;

--- a/types/legacyData.ts
+++ b/types/legacyData.ts
@@ -1,0 +1,72 @@
+import { solvedAcNumericTierIcons } from '@/assets/svg/tier';
+import type { SlotNo, Slots } from '@/types/randomDefense';
+import type { HiderOptions as LatestHiderOptions } from './algorithm';
+import type { OptionsData as LatestOptionsData } from './options';
+import { STORAGE_KEY } from '@/constants/commands';
+
+/**
+ * v1.2 이전 버전에서의 데이터 타입입니다.
+ * 데이터 버전은 1입니다.
+ */
+export namespace V1 {
+  export type DataVersion = 1;
+
+  export interface Timer {
+    expire: number;
+    hour: string;
+    minute: string;
+    problem: number;
+  }
+
+  export interface Settings {
+    font: `font-${number}` | 'none';
+    lock: 'click' | 'always';
+    predict: 'click' | 'always';
+    theme: 'yes' | 'no';
+  }
+
+  export type FontNo = 'none' | `font-${number}`;
+
+  export interface RandomDefenseHistoryInfo {
+    no: number;
+    title: string;
+    tier: keyof typeof solvedAcNumericTierIcons;
+    date: string;
+  }
+
+  export interface RepairableQuickSlots {
+    1: unknown;
+    2: unknown;
+    3: unknown;
+    4: unknown;
+    5: unknown;
+    6: unknown;
+    7: unknown;
+    8: unknown;
+    9: unknown;
+    0: unknown;
+    selectedNo?: unknown;
+  }
+
+  export type QuickSlots = {
+    selectedNo: SlotNo;
+  } & Slots;
+}
+
+/**
+ * v1.2.* 버전에서의 데이터 타입입니다.
+ * 데이터 버전은 2지만, 실제 배포 시에는 "v1.2"로 사용했습니다.
+ */
+export namespace V2 {
+  export type DataVersion = 2 | 'v1.2';
+
+  export type OptionsData = Omit<
+    LatestOptionsData,
+    typeof STORAGE_KEY.GACHA_OPTIONS | typeof STORAGE_KEY.HIDER_OPTIONS
+  > & { hiderOptions: V2.HiderOptions };
+
+  export type HiderOptions = Omit<
+    LatestHiderOptions,
+    'shouldRevealTierOnHover'
+  >;
+}

--- a/types/legacyData.ts
+++ b/types/legacyData.ts
@@ -62,8 +62,13 @@ export namespace V2 {
 
   export type OptionsData = Omit<
     LatestOptionsData,
-    typeof STORAGE_KEY.GACHA_OPTIONS | typeof STORAGE_KEY.HIDER_OPTIONS
-  > & { hiderOptions: V2.HiderOptions };
+    | typeof STORAGE_KEY.GACHA_OPTIONS
+    | typeof STORAGE_KEY.HIDER_OPTIONS
+    | typeof STORAGE_KEY.SHOULD_SHOW_WELCOME_MESSAGE
+    | typeof STORAGE_KEY.DATA_VERSION
+  > & { hiderOptions: V2.HiderOptions } & {
+    shouldShowWelcomeMessage?: boolean;
+  } & { dataVersion: V2.DataVersion };
 
   export type HiderOptions = Omit<
     LatestHiderOptions,

--- a/types/options.ts
+++ b/types/options.ts
@@ -6,6 +6,7 @@ import type { HiderOptions } from '@/types/algorithm';
 import type { RandomDefenseHistoryResponse } from '@/types/randomDefense';
 import type { FontNo } from '@/types/font';
 import type { Timer } from '@/types/algorithm';
+import type { GachaOptions } from '@/types/gacha';
 
 export interface OptionsData {
   [STORAGE_KEY.CHECKED_ALGORITHM_IDS]: CheckedAlgorithmIds;
@@ -16,7 +17,8 @@ export interface OptionsData {
   [STORAGE_KEY.IS_TIER_HIDDEN]: RandomDefenseHistoryResponse['isHidden'];
   [STORAGE_KEY.FONT_NO]: FontNo;
   [STORAGE_KEY.TIMERS]: Timer[];
-  [STORAGE_KEY.DATA_VERSION]: 'v1.2';
+  [STORAGE_KEY.GACHA_OPTIONS]: GachaOptions;
+  [STORAGE_KEY.DATA_VERSION]: 3;
 }
 
 export interface OptionsSectionProps {

--- a/types/options.ts
+++ b/types/options.ts
@@ -18,6 +18,7 @@ export interface OptionsData {
   [STORAGE_KEY.FONT_NO]: FontNo;
   [STORAGE_KEY.TIMERS]: Timer[];
   [STORAGE_KEY.GACHA_OPTIONS]: GachaOptions;
+  [STORAGE_KEY.SHOULD_SHOW_WELCOME_MESSAGE]: boolean;
   [STORAGE_KEY.DATA_VERSION]: 3;
 }
 

--- a/types/randomDefense.ts
+++ b/types/randomDefense.ts
@@ -8,13 +8,6 @@ export interface RandomDefenseHistoryInfo {
   createdAt: IsoString;
 }
 
-export interface LegacyRandomDefenseHistoryInfo {
-  no: number;
-  title: string;
-  tier: keyof typeof solvedAcNumericTierIcons;
-  date: string;
-}
-
 export interface RandomDefenseHistoryResponse {
   randomDefenseHistory: RandomDefenseHistoryInfo[];
   isHidden: boolean;
@@ -67,10 +60,6 @@ export interface QuickSlots {
   selectedSlotNo: SlotNo;
   slots: Slots;
 }
-
-export type LegacyQuickSlots = {
-  selectedNo: SlotNo;
-} & Slots;
 
 interface SlotValidVerdict {
   isValid: true;


### PR DESCRIPTION
## PR 설명
본 PR에서는 아래의 작업들을 수행했습니다.

### 1️⃣ 데이터 버전을 3으로 마이그레이션하는 기능을 구현

- 즉석 추첨 설정까지의 데이터를 포함하는 데이터 버전 3을 새롭게 만들었습니다. 이 데이터 버전은 추후 업데이트할 버전인 `v1.3`에 대응됩니다.
- 데이터 버전 1(`~v1.1.*`), 데이터 버전 2(`~v1.2.*`)의 데이터 타입들은 별도의 namespace로 보관하여 네이밍에 용이하도록 관리했습니다.
- 데이터 버전을 $1 \rightarrow 2$, $2 \rightarrow 3$으로 마이그레이션을 할 수 있도록 데이터 검증 함수, 마이그레이션 함수, 데이터 복구 함수를 구현했습니다.
- 최종적으로, `v1.2.*` 이전의 구버전에서 이번 버전으로 업데이트할 경우 데이터 초기화 없이 자동으로 마이그레이션이 진행되도록 구현했으며, 세이브 파일을 올리는 경우에도 2버전(`~v1.2.*`)이 호환 가능하도록 구현했습니다.
- 
### 2️⃣  eslint에 규칙 추가
- `@typescript-eslint/no-namespace` 규칙을 `"off"`로 설정
- `@typescript-eslint/no-unused-vars` 규칙을 `"warn"`로 설정
