### PR TITLE
[FEAT] solved.ac 지원 및 외부 서비스의 테마에 대응

### DIFF
--- a/components/GachaProblemCountInputModal/GachaProblemCountInputModal.stories.tsx
+++ b/components/GachaProblemCountInputModal/GachaProblemCountInputModal.stories.tsx
@@ -139,3 +139,138 @@ export const PlainTheme: Story = {
     onSubmitProblemCount: () => {},
   },
 };
+
+export const SolvedAcLightTheme: Story = {
+  ...PlainTheme,
+  render: (_, { args }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <IconButton
+          type="button"
+          name="모달 열기"
+          size="large"
+          color="#d1b072"
+          disabled={false}
+          ariaLabel="모달 열기"
+          onClick={() => setIsOpen(true)}
+        />
+        <GachaProblemCountInputModal
+          {...args}
+          theme="solvedAcLight"
+          open={isOpen}
+          onClose={() => setIsOpen(false)}
+          onSubmitProblemCount={() => setIsOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const SolvedAcDarkTheme: Story = {
+  ...PlainTheme,
+  render: (_, { args }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <IconButton
+          type="button"
+          name="모달 열기"
+          size="large"
+          color="#d1b072"
+          disabled={false}
+          ariaLabel="모달 열기"
+          onClick={() => setIsOpen(true)}
+        />
+        <GachaProblemCountInputModal
+          {...args}
+          theme="solvedAcDark"
+          open={isOpen}
+          onClose={() => setIsOpen(false)}
+          onSubmitProblemCount={() => setIsOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const SolvedAcBlackTheme: Story = {
+  ...PlainTheme,
+  render: (_, { args }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <IconButton
+          type="button"
+          name="모달 열기"
+          size="large"
+          color="#d1b072"
+          disabled={false}
+          ariaLabel="모달 열기"
+          onClick={() => setIsOpen(true)}
+        />
+        <GachaProblemCountInputModal
+          {...args}
+          theme="solvedAcBlack"
+          open={isOpen}
+          onClose={() => setIsOpen(false)}
+          onSubmitProblemCount={() => setIsOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const BojExtendedDarkTheme: Story = {
+  ...PlainTheme,
+  render: (_, { args }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <IconButton
+          type="button"
+          name="모달 열기"
+          size="large"
+          color="#d1b072"
+          disabled={false}
+          ariaLabel="모달 열기"
+          onClick={() => setIsOpen(true)}
+        />
+        <GachaProblemCountInputModal
+          {...args}
+          theme="bojExtendedDark"
+          open={isOpen}
+          onClose={() => setIsOpen(false)}
+          onSubmitProblemCount={() => setIsOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const BojExtendedRigelTheme: Story = {
+  ...PlainTheme,
+  render: (_, { args }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <IconButton
+          type="button"
+          name="모달 열기"
+          size="large"
+          color="#d1b072"
+          disabled={false}
+          ariaLabel="모달 열기"
+          onClick={() => setIsOpen(true)}
+        />
+        <GachaProblemCountInputModal
+          {...args}
+          theme="bojExtendedRigel"
+          open={isOpen}
+          onClose={() => setIsOpen(false)}
+          onSubmitProblemCount={() => setIsOpen(false)}
+        />
+      </>
+    );
+  },
+};

--- a/components/GachaProblemCountInputModal/GachaProblemCountInputModal.styled.ts
+++ b/components/GachaProblemCountInputModal/GachaProblemCountInputModal.styled.ts
@@ -1,4 +1,33 @@
 import { styled } from 'styled-components';
+import { MainTheme } from '@/types/mainTheme';
+import { getTransparentHexColor } from '@/utils/getTransparentHexColor';
+import { lightThemes } from './GachaProblemCountInputModal';
+import { theme } from '@/styles/theme';
+
+const inputBorderColors: Record<MainTheme, string> = {
+  none: theme.color.LIGHT_GRAY,
+  totamjung: theme.color.LIGHTER_BROWN,
+  bojExtendedDark: theme.bojExtendedColor.LIGHT_GRAY,
+  bojExtendedRigel: theme.bojExtendedColor.SKY_BLUE,
+  solvedAcLight: theme.color.LIGHT_GRAY,
+  solvedAcDark: theme.color.LIGHT_GRAY,
+  solvedAcBlack: theme.color.LIGHT_GRAY,
+};
+
+const inputFocusedBorderColors: Record<MainTheme, string> = {
+  ...inputBorderColors,
+  totamjung: theme.color.LEMON,
+};
+
+const inputBackgroundColors: Record<MainTheme, string> = {
+  none: theme.color.WHITE,
+  totamjung: theme.color.DARK_BROWN,
+  bojExtendedDark: theme.bojExtendedColor.DARKEST_GRAY,
+  bojExtendedRigel: theme.bojExtendedColor.DARK_INDIGO,
+  solvedAcLight: theme.color.WHITE,
+  solvedAcDark: theme.solvedAcColor.DARK_INDIGO,
+  solvedAcBlack: theme.color.BLACK,
+};
 
 export const ContentContainer = styled.div`
   display: flex;
@@ -9,32 +38,51 @@ export const ContentContainer = styled.div`
   max-width: 100%;
 `;
 
-export const ProblemCountInput = styled.input<{ $theme: 'none' | 'totamjung' }>`
+export const ProblemCountInput = styled.input<{
+  $totamjungTheme: MainTheme;
+}>`
   width: 100%;
   height: 40px;
   padding: 0 8px;
 
   border: 2px solid
-    ${({ theme, $theme }) =>
-      $theme === 'totamjung'
-        ? theme.color.LIGHTER_BROWN
-        : theme.color.LIGHT_GRAY};
+    ${({ $totamjungTheme }) => inputBorderColors[$totamjungTheme]};
   border-radius: 5.666px;
-  background-color: ${({ theme, $theme }) =>
-    $theme === 'totamjung' ? theme.color.DARK_BROWN : theme.color.WHITE};
+  background-color: ${({ $totamjungTheme }) =>
+    inputBackgroundColors[$totamjungTheme]};
 
-  color: ${({ theme, $theme }) =>
-    $theme === 'totamjung' ? theme.color.WHITE : theme.color.BLACK};
+  color: ${({ theme, $totamjungTheme }) =>
+    lightThemes.includes($totamjungTheme)
+      ? theme.color.BLACK
+      : theme.color.WHITE};
   font-size: 18px;
 
   &:focus,
   &:active {
-    border-color: ${({ theme, $theme }) =>
-      $theme === 'totamjung' ? theme.color.LEMON : theme.color.LIGHT_GRAY};
+    border-color: ${({ $totamjungTheme }) =>
+      inputFocusedBorderColors[$totamjungTheme]};
     outline: 3px solid
-      ${({ theme, $theme }) =>
-        $theme === 'totamjung' ? theme.color.LEMON : theme.color.LIGHT_GRAY}70;
+      ${({ $totamjungTheme }) =>
+        getTransparentHexColor(inputFocusedBorderColors[$totamjungTheme], 0.5)};
   }
 
   transition: outline 0.05s;
+`;
+
+export const Text = styled.p<{
+  $totamjungTheme: MainTheme;
+  $fontSize: string;
+  $textAlign: 'left' | 'right';
+  $isTransparent?: boolean;
+}>`
+  font-family: Pretendard;
+  font-size: ${({ $fontSize }) => $fontSize};
+  text-align: ${({ $textAlign }) => $textAlign};
+  color: ${({ theme, $totamjungTheme, $isTransparent }) => {
+    const opacity = $isTransparent ? 0.6 : 1;
+
+    return lightThemes.includes($totamjungTheme)
+      ? getTransparentHexColor(theme.color.BLACK, opacity)
+      : getTransparentHexColor(theme.color.WHITE, opacity);
+  }};
 `;

--- a/components/GachaProblemCountInputModal/GachaProblemCountInputModal.tsx
+++ b/components/GachaProblemCountInputModal/GachaProblemCountInputModal.tsx
@@ -1,15 +1,17 @@
 import Modal, { ModalActionButtonsContainer } from '@/components/common/Modal';
 import IconButton from '@/components/common/IconButton';
-import Text from '@/components/common/Text';
 import * as S from './GachaProblemCountInputModal.styled';
 import { CheckCircleIcon } from '@/assets/svg';
-import { theme } from '@/styles/theme';
 import useGachaProblemCount from '@/hooks/useGachaProblemCount';
 import { MAX_PROBLEM_COUNT_PER_RANDOM_DEFENSE } from '@/constants/randomDefense';
+import type { MainTheme } from '@/types/mainTheme';
+import { theme as styledTheme } from '@/styles/theme';
+
+export const lightThemes: readonly MainTheme[] = ['none', 'solvedAcLight'];
 
 interface GachaProblemCountInputModalProps {
   open: boolean;
-  theme?: 'none' | 'totamjung';
+  theme?: MainTheme;
   portalTarget?: HTMLElement | null;
   shouldShowHotkeyMessage: boolean;
   onClose: () => void;
@@ -21,7 +23,7 @@ const GachaProblemCountInputModal = (
 ) => {
   const {
     open,
-    theme: modalTheme = 'totamjung',
+    theme = 'totamjung',
     portalTarget,
     shouldShowHotkeyMessage,
     onClose,
@@ -33,55 +35,49 @@ const GachaProblemCountInputModal = (
   return (
     <Modal
       title="즉석 추첨"
-      theme={modalTheme}
+      theme={theme}
       portalTarget={portalTarget}
       open={open}
       onClose={onClose}
     >
       <S.ContentContainer>
-        <Text
-          type={modalTheme === 'totamjung' ? 'normal' : 'darkGray'}
-          fontSize="16px"
-        >
+        <S.Text $totamjungTheme={theme} $fontSize="16px" $textAlign="left">
           추첨을 진행할 문제 수를 입력해 주세요.
-        </Text>
+        </S.Text>
         <S.ProblemCountInput
           type="number"
           min={1}
           max={MAX_PROBLEM_COUNT_PER_RANDOM_DEFENSE}
           value={inputValue}
-          $theme={modalTheme}
+          $totamjungTheme={theme}
           onChange={updateInputValue}
           autoFocus
         />
-        <Text
-          type={modalTheme === 'totamjung' ? 'normal' : 'darkGray'}
-          textAlign="right"
-          fontSize="14px"
-        >
+        <S.Text $totamjungTheme={theme} $fontSize="14px" $textAlign="right">
           {`1문제 이상, ${MAX_PROBLEM_COUNT_PER_RANDOM_DEFENSE}문제 이하`}
-        </Text>
+        </S.Text>
         {shouldShowHotkeyMessage && (
-          <Text
-            type={modalTheme === 'totamjung' ? 'gray' : 'darkGray'}
-            textAlign="left"
-            fontSize="16px"
+          <S.Text
+            $totamjungTheme={theme}
+            $fontSize="16px"
+            $textAlign="left"
+            $isTransparent={true}
           >
             TIP: 즉석 추첨은 백준 사이트 내에서 슬롯 번호에 대응하는 단축키를
             길게 누르는 것으로도 진행할 수 있습니다.
-          </Text>
+          </S.Text>
         )}
       </S.ContentContainer>
-      <ModalActionButtonsContainer theme={modalTheme}>
+      <ModalActionButtonsContainer theme={theme}>
         <IconButton
           type="button"
           name="확인"
           size="medium"
           iconSrc={<CheckCircleIcon />}
           color={
-            modalTheme === 'totamjung'
-              ? theme.color.GOLD
-              : theme.color.DARK_GRAY
+            lightThemes.includes(theme)
+              ? styledTheme.color.DARK_GRAY
+              : styledTheme.color.GOLD
           }
           disabled={!isInputValueValid}
           ariaLabel="확인"

--- a/components/InspectResultIcon/InspectResultIcon.stories.tsx
+++ b/components/InspectResultIcon/InspectResultIcon.stories.tsx
@@ -51,3 +51,31 @@ export const TotamjungQuestionIcon: Story = {
     icon: 'question',
   },
 };
+
+export const BojExtendedDarkCheckIcon: Story = {
+  args: {
+    theme: 'bojExtendedDark',
+    icon: 'check',
+  },
+};
+
+export const BojExtendedDarkQuestionIcon: Story = {
+  args: {
+    theme: 'bojExtendedDark',
+    icon: 'question',
+  },
+};
+
+export const BojExtendedRigelCheckIcon: Story = {
+  args: {
+    theme: 'bojExtendedRigel',
+    icon: 'check',
+  },
+};
+
+export const BojExtendedRigelQuestionIcon: Story = {
+  args: {
+    theme: 'bojExtendedRigel',
+    icon: 'question',
+  },
+};

--- a/components/InspectResultIcon/InspectResultIcon.tsx
+++ b/components/InspectResultIcon/InspectResultIcon.tsx
@@ -20,7 +20,7 @@ const descriptions = {
 const filters: Record<TotamjungTheme | BojExtendedTheme, string> = {
   none: styledTheme.filter.BOJ_BLUE_FILTER,
   totamjung: styledTheme.filter.LIGHT_BROWN_FILTER,
-  bojExtendedRigel: styledTheme.bojExtendedFilter.DARK_SKY_BLUE,
+  bojExtendedRigel: styledTheme.bojExtendedFilter.SKY_BLUE,
   bojExtendedDark: styledTheme.bojExtendedFilter.DARK_GRAY,
 };
 

--- a/components/InspectResultIcon/InspectResultIcon.tsx
+++ b/components/InspectResultIcon/InspectResultIcon.tsx
@@ -1,10 +1,28 @@
 import { theme as styledTheme } from '@/styles/theme';
-import type { TotamjungTheme } from '@/types/totamjungTheme';
+import type { BojExtendedTheme, TotamjungTheme } from '@/types/mainTheme';
 
 interface InspectResultIconProps {
-  theme: TotamjungTheme;
+  theme: TotamjungTheme | BojExtendedTheme;
   icon: 'check' | 'question';
 }
+
+const iconSources = {
+  check: browser.runtime.getURL('/inspect-result-check.png'),
+  question: browser.runtime.getURL('/inspect-result-question.png'),
+};
+
+const descriptions = {
+  check: '이 문제는 알고 있는 알고리즘만으로 풀 수 있는 문제입니다.',
+  question:
+    '이 문제를 풀기 위해서는 모르는 알고리즘을 사용해야 할 수 있습니다.',
+};
+
+const filters: Record<TotamjungTheme | BojExtendedTheme, string> = {
+  none: styledTheme.filter.BOJ_BLUE_FILTER,
+  totamjung: styledTheme.filter.LIGHT_BROWN_FILTER,
+  bojExtendedRigel: styledTheme.bojExtendedFilter.DARK_SKY_BLUE,
+  bojExtendedDark: styledTheme.bojExtendedFilter.DARK_GRAY,
+};
 
 /**
  * content script의 컴포넌트의 구성 요소이나, Shadow DOM 외부로 렌더링되는 컴포넌트이기 때문에,
@@ -12,27 +30,23 @@ interface InspectResultIconProps {
  */
 const InspectResultIcon = (props: InspectResultIconProps) => {
   const { theme, icon } = props;
-  const iconSrc =
-    icon === 'check'
-      ? browser.runtime.getURL('/inspect-result-check.png')
-      : browser.runtime.getURL('/inspect-result-question.png');
-  const alt =
-    icon === 'check'
-      ? '이 문제는 알고 있는 알고리즘만으로 풀 수 있는 문제입니다.'
-      : '이 문제를 풀기 위해서는 모르는 알고리즘을 사용해야 할 수 있습니다.';
+
   const styles = {
     width: '26px',
     height: '26px',
     margin: '1px 0px 5px 7px',
-    filter:
-      theme === 'totamjung'
-        ? styledTheme.filter.LIGHT_BROWN_FILTER
-        : styledTheme.filter.BOJ_BLUE_FILTER,
+    filter: filters[theme],
     userSelect: 'none',
   } as const;
 
   return (
-    <img src={iconSrc} style={styles} alt={alt} title={alt} draggable="false" />
+    <img
+      src={iconSources[icon]}
+      style={styles}
+      alt={descriptions[icon]}
+      title={descriptions[icon]}
+      draggable="false"
+    />
   );
 };
 

--- a/components/LeftSlideToast/LeftSlideToast.stories.tsx
+++ b/components/LeftSlideToast/LeftSlideToast.stories.tsx
@@ -87,46 +87,6 @@ export const SvgIcon: Story = {
   },
 };
 
-export const TotamjungTheme: Story = {
-  decorators: [
-    (Story) => (
-      <div style={{ height: '160px' }}>
-        <Story />
-      </div>
-    ),
-  ],
-  args: {
-    mainIconSrc: browser.runtime.getURL('/dice.png'),
-    theme: 'totamjung',
-    progress: 65,
-    title: '테스트 제목입니다.',
-    descriptions:
-      '그리고 여기에는 지금 무슨 일이 일어났는지에 대한 설명이 있을 거에요.',
-    open: true,
-    onClose: fn(),
-  },
-};
-
-export const TotamjungThemeWithSvgIcon: Story = {
-  decorators: [
-    (Story) => (
-      <div style={{ height: '160px' }}>
-        <Story />
-      </div>
-    ),
-  ],
-  args: {
-    mainIconSrc: <CopyIcon />,
-    theme: 'totamjung',
-    progress: 65,
-    title: '테스트 제목입니다.',
-    descriptions:
-      '그리고 여기에는 지금 무슨 일이 일어났는지에 대한 설명이 있을 거에요.',
-    open: true,
-    onClose: fn(),
-  },
-};
-
 export const MultipleDescriptions: Story = {
   decorators: [
     (Story) => (
@@ -187,5 +147,53 @@ export const VeryLongDescription: Story = {
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum vestibulum. Cras venenatis euismod malesuada. Nulla facilisi. Curabitur facilisis, libero a pretium auctor, sapien erat tincidunt nulla, vitae vestibulum elit leo at odio. Donec vehicula mauris ut nisi hendrerit, ac dictum libero consequat. Integer euismod neque eu magna facilisis, in suscipit sem sagittis.',
     open: true,
     onClose: fn(),
+  },
+};
+
+export const TotamjungTheme: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    theme: 'totamjung',
+  },
+};
+
+export const SolvedAcLightTheme: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    theme: 'solvedAcLight',
+  },
+};
+
+export const SolvedAcDarkTheme: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    theme: 'solvedAcDark',
+  },
+};
+
+export const SolvedAcBlackTheme: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    theme: 'solvedAcBlack',
+  },
+};
+
+export const BojExtendedDarkTheme: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    theme: 'bojExtendedDark',
+  },
+};
+
+export const BojExtendedRigelTheme: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    theme: 'bojExtendedRigel',
   },
 };

--- a/components/LeftSlideToast/LeftSlideToast.styled.ts
+++ b/components/LeftSlideToast/LeftSlideToast.styled.ts
@@ -18,8 +18,8 @@ const toastBorderColors: Record<MainTheme, string> = {
   bojExtendedDark: theme.bojExtendedColor.DARK_GRAY,
   bojExtendedRigel: theme.bojExtendedColor.DARK_SKY_BLUE,
   solvedAcLight: theme.solvedAcColor.LIGHT_GRAY,
-  solvedAcDark: theme.solvedAcColor.LIGHT_GRAY,
-  solvedAcBlack: theme.solvedAcColor.LIGHT_GRAY,
+  solvedAcDark: theme.solvedAcColor.GRAY,
+  solvedAcBlack: theme.solvedAcColor.GRAY,
 };
 
 const toastBoxShadowColors: Record<MainTheme, string> = {

--- a/components/LeftSlideToast/LeftSlideToast.styled.ts
+++ b/components/LeftSlideToast/LeftSlideToast.styled.ts
@@ -1,9 +1,86 @@
-import { styled, css } from 'styled-components';
-import type { TotamjungTheme } from '@/types/totamjungTheme';
+import { styled } from 'styled-components';
+import { theme } from '@/styles/theme';
+import type { MainTheme } from '@/types/mainTheme';
+
+const toastBackgroundColors: Record<MainTheme, string> = {
+  none: theme.color.BOJ_BLUE,
+  totamjung: theme.color.DARK_BROWN,
+  bojExtendedDark: theme.bojExtendedColor.DARKEST_GRAY,
+  bojExtendedRigel: theme.bojExtendedColor.SKY_BLUE,
+  solvedAcLight: theme.solvedAcColor.OFF_WHITE,
+  solvedAcDark: theme.solvedAcColor.INDIGO,
+  solvedAcBlack: theme.solvedAcColor.DARK_INDIGO,
+};
+
+const toastBorderColors: Record<MainTheme, string> = {
+  none: theme.color.BOJ_BLUE,
+  totamjung: theme.color.LIGHTER_BROWN,
+  bojExtendedDark: theme.bojExtendedColor.DARK_GRAY,
+  bojExtendedRigel: theme.bojExtendedColor.DARK_SKY_BLUE,
+  solvedAcLight: theme.solvedAcColor.LIGHT_GRAY,
+  solvedAcDark: theme.solvedAcColor.LIGHT_GRAY,
+  solvedAcBlack: theme.solvedAcColor.LIGHT_GRAY,
+};
+
+const toastBoxShadowColors: Record<MainTheme, string> = {
+  none: 'transparent',
+  totamjung: theme.color.LIGHTER_BROWN,
+  bojExtendedDark: theme.bojExtendedColor.DARKER_GRAY,
+  bojExtendedRigel: 'transparent',
+  solvedAcLight: theme.solvedAcColor.OFF_WHITE,
+  solvedAcDark: theme.solvedAcColor.DARK_INDIGO,
+  solvedAcBlack: theme.color.BLACK,
+};
+
+const toastTitleColors: Record<MainTheme, string> = {
+  none: theme.color.WHITE,
+  totamjung: theme.color.BEIGE,
+  bojExtendedDark: theme.bojExtendedColor.LIGHT_GRAY,
+  bojExtendedRigel: theme.color.WHITE,
+  solvedAcLight: theme.color.BLACK,
+  solvedAcDark: theme.solvedAcColor.OFF_WHITE,
+  solvedAcBlack: theme.solvedAcColor.OFF_WHITE,
+};
+
+const toastDescriptionColors: Record<MainTheme, string> = {
+  ...toastTitleColors,
+  totamjung: theme.color.WHITE,
+  bojExtendedDark: theme.color.WHITE,
+};
+
+const toastIconColors: Record<MainTheme, string> = {
+  none: theme.color.WHITE,
+  totamjung: theme.color.LIGHTEST_BROWN,
+  bojExtendedDark: theme.bojExtendedColor.LIGHT_GRAY,
+  bojExtendedRigel: theme.color.WHITE,
+  solvedAcLight: theme.solvedAcColor.GRAY,
+  solvedAcDark: theme.solvedAcColor.LIGHT_GRAY,
+  solvedAcBlack: theme.solvedAcColor.LIGHT_GRAY,
+};
+
+const toastIconFilters: Record<MainTheme, string> = {
+  none: theme.filter.WHITE_FILTER,
+  totamjung: theme.filter.LIGHT_BROWN_FILTER,
+  bojExtendedDark: theme.bojExtendedFilter.LIGHT_GRAY,
+  bojExtendedRigel: theme.filter.WHITE_FILTER,
+  solvedAcLight: theme.solvedAcFilter.LIGHT_GRAY,
+  solvedAcDark: theme.solvedAcFilter.LIGHT_GRAY,
+  solvedAcBlack: theme.solvedAcFilter.LIGHT_GRAY,
+};
+
+export const circleProgressBarColors: Record<MainTheme, string> = {
+  none: theme.color.WHITE,
+  totamjung: theme.color.LIGHTEST_BROWN,
+  bojExtendedDark: theme.bojExtendedColor.LIGHT_GRAY,
+  bojExtendedRigel: theme.color.WHITE,
+  solvedAcLight: theme.solvedAcColor.GRAY,
+  solvedAcDark: theme.solvedAcColor.LIGHT_GRAY,
+  solvedAcBlack: theme.solvedAcColor.LIGHT_GRAY,
+};
 
 export const Container = styled.div<{
   $open: boolean;
-  $totamjungTheme: TotamjungTheme;
+  $totamjungTheme: MainTheme;
 }>`
   display: flex;
   column-gap: 10px;
@@ -16,18 +93,12 @@ export const Container = styled.div<{
   padding: 10px;
 
   border-radius: 10px;
-
-  ${({ theme, $totamjungTheme }) =>
-    $totamjungTheme === 'totamjung'
-      ? css`
-          border: 2px solid ${theme.color.LIGHTER_BROWN};
-          background-color: ${theme.color.DARK_BROWN};
-          box-shadow: 0 0 20px ${theme.color.LIGHTER_BROWN};
-        `
-      : css`
-          border: 2px solid ${theme.color.BOJ_BLUE};
-          background-color: ${theme.color.BOJ_BLUE};
-        `}
+  border: 2px solid
+    ${({ $totamjungTheme }) => toastBorderColors[$totamjungTheme]};
+  background-color: ${({ $totamjungTheme }) =>
+    toastBackgroundColors[$totamjungTheme]};
+  box-shadow: 0 0 20px
+    ${({ $totamjungTheme }) => toastBoxShadowColors[$totamjungTheme]};
 
   transform: ${({ $open }) => ($open ? 'translateX(0)' : 'translateX(-450px)')};
   transition: transform cubic-bezier(0.25, 0.46, 0.45, 0.94) 0.3s;
@@ -41,26 +112,20 @@ export const LeftIconWrapper = styled.div`
   width: 66px;
 `;
 
-export const IconImage = styled.img<{ $totamjungTheme: TotamjungTheme }>`
+export const IconImage = styled.img<{ $totamjungTheme: MainTheme }>`
   width: 40px;
 
-  filter: ${({ theme, $totamjungTheme }) =>
-    $totamjungTheme === 'totamjung'
-      ? theme.filter.LIGHTEST_BROWN_FILTER
-      : theme.filter.WHITE_FILTER};
+  filter: ${({ $totamjungTheme }) => toastIconFilters[$totamjungTheme]};
   user-select: none;
 `;
 
-export const IconWrapper = styled.div<{ $totamjungTheme: TotamjungTheme }>`
+export const IconWrapper = styled.div<{ $totamjungTheme: MainTheme }>`
   &,
   & > svg {
     width: 48px;
     height: 48px;
 
-    color: ${({ theme, $totamjungTheme }) =>
-      $totamjungTheme === 'totamjung'
-        ? theme.color.LIGHTEST_BROWN
-        : theme.color.WHITE};
+    color: ${({ $totamjungTheme }) => toastIconColors[$totamjungTheme]};
   }
 `;
 
@@ -72,12 +137,12 @@ export const ContentContainer = styled.div`
   width: 264px;
 `;
 
-export const Title = styled.p<{ $totamjungTheme: TotamjungTheme }>`
+export const Title = styled.p<{ $totamjungTheme: MainTheme }>`
   font-size: 16px;
   font-weight: 700;
+  font-family: Pretendard;
   word-break: break-all;
-  color: ${({ theme, $totamjungTheme }) =>
-    $totamjungTheme === 'totamjung' ? theme.color.BEIGE : theme.color.WHITE};
+  color: ${({ $totamjungTheme }) => toastTitleColors[$totamjungTheme]};
 `;
 
 export const DescriptionList = styled.ul`
@@ -86,8 +151,13 @@ export const DescriptionList = styled.ul`
   row-gap: 4px;
 `;
 
+export const Description = styled.p`
+  font-size: 14px;
+  word-break: break-all;
+`;
+
 export const DescriptionContainer = styled.li<{
-  $totamjungTheme: TotamjungTheme;
+  $totamjungTheme: MainTheme;
 }>`
   display: flex;
   column-gap: 3px;
@@ -96,22 +166,17 @@ export const DescriptionContainer = styled.li<{
 
   line-height: 17px;
 
+  & > ${Description} {
+    color: ${({ $totamjungTheme }) => toastDescriptionColors[$totamjungTheme]};
+  }
+
   & > svg {
     flex-shrink: 0;
 
     width: 17px;
     height: 17px;
-    color: ${({ theme, $totamjungTheme }) =>
-      $totamjungTheme === 'totamjung'
-        ? theme.color.LIGHTEST_BROWN
-        : theme.color.WHITE};
+    color: ${({ $totamjungTheme }) => toastIconColors[$totamjungTheme]};
   }
-`;
-
-export const Description = styled.p`
-  font-size: 14px;
-  word-break: break-all;
-  color: ${({ theme }) => theme.color.WHITE};
 `;
 
 export const RightControlPanel = styled.div`
@@ -123,7 +188,7 @@ export const RightControlPanel = styled.div`
   width: 32px;
 `;
 
-export const CloseButton = styled.button<{ $totamjungTheme: TotamjungTheme }>`
+export const CloseButton = styled.button<{ $totamjungTheme: MainTheme }>`
   width: 30px;
   height: 30px;
 
@@ -132,9 +197,6 @@ export const CloseButton = styled.button<{ $totamjungTheme: TotamjungTheme }>`
   & > svg {
     width: 30px;
     height: 30px;
-    color: ${({ theme, $totamjungTheme }) =>
-      $totamjungTheme === 'totamjung'
-        ? theme.color.LIGHTEST_BROWN
-        : theme.color.WHITE};
+    color: ${({ $totamjungTheme }) => toastIconColors[$totamjungTheme]};
   }
 `;

--- a/components/LeftSlideToast/LeftSlideToast.tsx
+++ b/components/LeftSlideToast/LeftSlideToast.tsx
@@ -1,25 +1,20 @@
 import * as S from './LeftSlideToast.styled';
+import { circleProgressBarColors } from './LeftSlideToast.styled';
+import { getTransparentHexColor } from '@/utils/getTransparentHexColor';
 import { CheckIcon, CloseIcon } from '@/assets/svg';
 import type { SVGProps, ReactElement } from 'react';
-import { TotamjungTheme } from '@/types/totamjungTheme';
+import type { MainTheme } from '@/types/mainTheme';
 import CircleProgressBar from '@/components/common/CircleProgressBar';
 
 interface LeftSlideToastProps {
   mainIconSrc: string | ReactElement<SVGProps<SVGSVGElement>>;
-  theme: TotamjungTheme;
+  theme: MainTheme;
   progress: number;
   title: string;
   descriptions?: string | string[];
   open: boolean;
   onClose: () => void;
 }
-
-const COLORS = {
-  WHITE: 'white',
-  SKY_BLUE: '#1c8cd1',
-  BROWN: '#331911',
-  LIGHT_BROWN: '#a17362',
-};
 
 const LeftSlideToast = (props: LeftSlideToastProps) => {
   const { mainIconSrc, theme, progress, title, descriptions, open, onClose } =
@@ -65,8 +60,11 @@ const LeftSlideToast = (props: LeftSlideToastProps) => {
         <CircleProgressBar
           size={32}
           progress={progress}
-          color={theme === 'totamjung' ? COLORS.LIGHT_BROWN : COLORS.WHITE}
-          trackColor={theme === 'totamjung' ? COLORS.BROWN : COLORS.SKY_BLUE}
+          color={circleProgressBarColors[theme]}
+          trackColor={getTransparentHexColor(
+            circleProgressBarColors[theme],
+            0.3,
+          )}
         />
       </S.RightControlPanel>
     </S.Container>

--- a/components/RandomDefenseGachaModal/RandomDefenseGachaModal.tsx
+++ b/components/RandomDefenseGachaModal/RandomDefenseGachaModal.tsx
@@ -20,10 +20,11 @@ import CardBox from '@/components/CardBox';
 import ProblemCardGrid from '@/components/ProblemCardGrid';
 import useRandomDefenseGachaModal from '@/hooks/gacha/useRandomDefenseGachaModal';
 import GachaModalNotification from '../GachaModalNotification/GachaModalNotification';
+import type { MainTheme } from '@/types/mainTheme';
 
 interface RandomDefenseGachaModalProps {
   open: boolean;
-  theme?: 'none' | 'totamjung';
+  theme?: MainTheme;
   slot: FilledSlot;
   problemCount: number;
   portalTarget?: HTMLElement | null;

--- a/components/Widget/Widget.stories.tsx
+++ b/components/Widget/Widget.stories.tsx
@@ -40,3 +40,99 @@ export const Default: Story = {
     onToast: fn(),
   },
 };
+
+export const Totamjung: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: '100%', height: '240px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    rootElement: document.body,
+    theme: 'totamjung',
+    onChangeTheme: fn(),
+    onToast: fn(),
+  },
+};
+
+export const BojExtendedDark: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: '100%', height: '240px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    rootElement: document.body,
+    theme: 'bojExtendedDark',
+    onChangeTheme: fn(),
+    onToast: fn(),
+  },
+};
+
+export const BojExtendedRigel: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: '100%', height: '240px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    rootElement: document.body,
+    theme: 'bojExtendedRigel',
+    onChangeTheme: fn(),
+    onToast: fn(),
+  },
+};
+
+export const SolvedAcLight: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: '100%', height: '240px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    rootElement: document.body,
+    theme: 'solvedAcLight',
+    onChangeTheme: fn(),
+    onToast: fn(),
+  },
+};
+
+export const SolvedAcDark: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: '100%', height: '240px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    rootElement: document.body,
+    theme: 'solvedAcDark',
+    onChangeTheme: fn(),
+    onToast: fn(),
+  },
+};
+
+export const SolvedAcBlack: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: '100%', height: '240px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    rootElement: document.body,
+    theme: 'solvedAcBlack',
+    onChangeTheme: fn(),
+    onToast: fn(),
+  },
+};

--- a/components/Widget/Widget.styled.ts
+++ b/components/Widget/Widget.styled.ts
@@ -1,4 +1,57 @@
+import type { MainTheme } from '@/types/mainTheme';
+import { theme } from '@/styles/theme';
 import { styled, keyframes, css } from 'styled-components';
+import { getTransparentHexColor } from '@/utils/getTransparentHexColor';
+
+const topButtonBackgroundColors: Record<MainTheme, string> = {
+  none: theme.color.BOJ_BLUE,
+  totamjung: theme.color.LIGHTEST_BROWN,
+  solvedAcLight: theme.solvedAcColor.LIME,
+  solvedAcDark: theme.solvedAcColor.LIME,
+  solvedAcBlack: theme.solvedAcColor.LIME,
+  bojExtendedDark: theme.bojExtendedColor.DARK_GRAY,
+  bojExtendedRigel: theme.bojExtendedColor.DARK_SKY_BLUE,
+} as const;
+
+const topButtonArrowBackgroundColors: Record<MainTheme, string> = {
+  none: theme.color.PURE_WHITE,
+  totamjung: theme.color.BROWN,
+  solvedAcLight: theme.color.PURE_WHITE,
+  solvedAcDark: theme.color.PURE_WHITE,
+  solvedAcBlack: theme.color.PURE_WHITE,
+  bojExtendedDark: theme.bojExtendedColor.LIGHT_GRAY,
+  bojExtendedRigel: theme.color.WHITE,
+} as const;
+
+const dropdownIconsFilters: Record<MainTheme, string> = {
+  none: theme.filter.BOJ_BLUE_FILTER,
+  totamjung: theme.filter.LIGHTEST_BROWN_FILTER,
+  solvedAcLight: theme.solvedAcFilter.LIME,
+  solvedAcDark: theme.solvedAcFilter.LIME,
+  solvedAcBlack: theme.solvedAcFilter.LIME,
+  bojExtendedDark: theme.bojExtendedFilter.DARK_GRAY,
+  bojExtendedRigel: theme.bojExtendedFilter.DARK_SKY_BLUE,
+} as const;
+
+const dropdownBackgroundColors: Record<MainTheme, string> = {
+  none: 'transparent',
+  totamjung: theme.color.BLACK_TRANSPARENT,
+  solvedAcLight: 'transparent',
+  solvedAcDark: theme.color.BLACK_TRANSPARENT,
+  solvedAcBlack: theme.color.BLACK_TRANSPARENT,
+  bojExtendedDark: theme.color.BLACK_TRANSPARENT,
+  bojExtendedRigel: theme.color.BLACK_TRANSPARENT,
+} as const;
+
+const speechBubbleTextColors: Record<MainTheme, string> = {
+  none: theme.color.WHITE,
+  totamjung: theme.color.WHITE,
+  solvedAcLight: theme.color.BLACK,
+  solvedAcDark: theme.color.WHITE,
+  solvedAcBlack: theme.color.WHITE,
+  bojExtendedDark: theme.color.WHITE,
+  bojExtendedRigel: theme.color.WHITE,
+} as const;
 
 export const Container = styled.div`
   padding-top: 10px;
@@ -39,7 +92,7 @@ const bounceTop = keyframes`
 `;
 
 export const TopButton = styled.button<{
-  $widgetTheme: 'none' | 'totamjung';
+  $widgetTheme: MainTheme;
 }>`
   display: flex;
   justify-content: center;
@@ -51,19 +104,14 @@ export const TopButton = styled.button<{
 
   border-radius: 20px !important;
   background-color: ${({ theme, $widgetTheme }) =>
-    $widgetTheme === 'none'
-      ? theme.color.BOJ_BLUE
-      : theme.color.LIGHTEST_BROWN};
+    topButtonBackgroundColors[$widgetTheme] ?? theme.color.BOJ_BLUE};
 
   transition:
     0.3s transform,
     0.1s outline;
   z-index: 1;
   outline: 0px solid
-    ${({ theme, $widgetTheme }) =>
-      $widgetTheme === 'totamjung'
-        ? theme.color.LIGHTEST_BROWN_TRANSPARENT
-        : theme.color.BOJ_BLUE_TRANSPARENT} !important;
+    ${({ $widgetTheme }) => topButtonBackgroundColors[$widgetTheme]} !important;
 
   &:active {
     transform: scale(0.93);
@@ -72,15 +120,17 @@ export const TopButton = styled.button<{
   &:hover,
   &:active {
     outline: 4px solid
-      ${({ theme, $widgetTheme }) =>
-        $widgetTheme === 'totamjung'
-          ? theme.color.LIGHTEST_BROWN_TRANSPARENT
-          : theme.color.BOJ_BLUE_TRANSPARENT} !important;
+      ${({ $widgetTheme }) => {
+        return getTransparentHexColor(
+          topButtonBackgroundColors[$widgetTheme],
+          0.4,
+        );
+      }} !important;
   }
 
   & span {
-    background-color: ${({ theme, $widgetTheme }) =>
-      $widgetTheme === 'none' ? theme.color.PURE_WHITE : theme.color.BROWN};
+    background-color: ${({ $widgetTheme }) =>
+      topButtonArrowBackgroundColors[$widgetTheme]};
   }
 `;
 
@@ -112,7 +162,7 @@ export const TopIconFrag = styled.span<{ $direction: 'left' | 'right' }>`
 `;
 
 export const DropdownMenu = styled.ul<{
-  $widgetTheme: 'none' | 'totamjung';
+  $widgetTheme: MainTheme;
   $isExpanded: boolean;
 }>`
   display: flex;
@@ -125,13 +175,10 @@ export const DropdownMenu = styled.ul<{
   padding: 8px 0 0 0;
 
   border: 2px solid
-    ${({ theme, $widgetTheme }) =>
-      $widgetTheme === 'none'
-        ? theme.color.BOJ_BLUE
-        : theme.color.LIGHTEST_BROWN};
+    ${({ $widgetTheme }) => topButtonBackgroundColors[$widgetTheme]};
   border-radius: 20px !important;
-  background-color: ${({ theme, $widgetTheme }) =>
-    $widgetTheme === 'none' ? 'transparent' : theme.color.BLACK_TRANSPARENT};
+  background-color: ${({ $widgetTheme }) =>
+    dropdownBackgroundColors[$widgetTheme]};
 
   backdrop-filter: blur(5px);
   transform-origin: center bottom;
@@ -183,16 +230,12 @@ export const DropdownButtonIcon = styled.img.attrs({ draggable: false })`
 `;
 
 export const DropdownMenuButton = styled.button<{
-  $widgetTheme: 'none' | 'totamjung';
+  $widgetTheme: MainTheme;
 }>`
   ${dropdownMenuButtonStyles}
 
   & > ${DropdownButtonIcon} {
-    filter: ${({ theme, $widgetTheme }) => {
-      return $widgetTheme === 'none'
-        ? theme.filter.BOJ_BLUE_FILTER
-        : theme.filter.LIGHT_BROWN_FILTER;
-    }};
+    filter: ${({ $widgetTheme }) => dropdownIconsFilters[$widgetTheme]};
   }
 `;
 
@@ -207,16 +250,12 @@ const maskFillUp = keyframes`
 `;
 
 export const RandomDefenseButton = styled.button<{
-  $widgetTheme: 'none' | 'totamjung';
+  $widgetTheme: MainTheme;
 }>`
   ${dropdownMenuButtonStyles}
 
   & > ${DropdownButtonIcon} {
-    filter: ${({ theme, $widgetTheme }) => {
-      return $widgetTheme === 'none'
-        ? theme.filter.BOJ_BLUE_FILTER
-        : theme.filter.LIGHT_BROWN_FILTER;
-    }};
+    filter: ${({ $widgetTheme }) => dropdownIconsFilters[$widgetTheme]};
   }
 
   &.pressing:after {
@@ -249,8 +288,20 @@ export const SpeechBubbleWrapper = styled.div`
   height: 65px;
 `;
 
-export const SpeechBubbleContentContainer = styled.div`
+export const SpeechBubbleText = styled.span`
+  font-size: 14px;
+  line-height: 14px;
+  font-family: Pretendard;
+`;
+
+export const SpeechBubbleContentContainer = styled.div<{
+  $totamjungTheme: MainTheme;
+}>`
   display: flex;
   flex-direction: column;
   row-gap: 4px;
+
+  & > ${SpeechBubbleText} {
+    color: ${({ $totamjungTheme }) => speechBubbleTextColors[$totamjungTheme]};
+  }
 `;

--- a/components/Widget/Widget.styled.ts
+++ b/components/Widget/Widget.styled.ts
@@ -10,7 +10,7 @@ const topButtonBackgroundColors: Record<MainTheme, string> = {
   solvedAcDark: theme.solvedAcColor.LIME,
   solvedAcBlack: theme.solvedAcColor.LIME,
   bojExtendedDark: theme.bojExtendedColor.DARK_GRAY,
-  bojExtendedRigel: theme.bojExtendedColor.DARK_SKY_BLUE,
+  bojExtendedRigel: theme.bojExtendedColor.SKY_BLUE,
 } as const;
 
 const topButtonArrowBackgroundColors: Record<MainTheme, string> = {
@@ -30,7 +30,7 @@ const dropdownIconsFilters: Record<MainTheme, string> = {
   solvedAcDark: theme.solvedAcFilter.LIME,
   solvedAcBlack: theme.solvedAcFilter.LIME,
   bojExtendedDark: theme.bojExtendedFilter.DARK_GRAY,
-  bojExtendedRigel: theme.bojExtendedFilter.DARK_SKY_BLUE,
+  bojExtendedRigel: theme.bojExtendedFilter.SKY_BLUE,
 } as const;
 
 const dropdownBackgroundColors: Record<MainTheme, string> = {

--- a/components/Widget/Widget.tsx
+++ b/components/Widget/Widget.tsx
@@ -7,6 +7,7 @@ import { createPortal } from 'react-dom';
 import { $ } from '@/utils/querySelector';
 import GachaProblemCountInputModal from '@/components/GachaProblemCountInputModal';
 import RandomDefenseGachaModal from '../RandomDefenseGachaModal';
+import { isSolvedAcTheme } from '@/domains/dataHandlers/validators/solvedAcThemeValidadtor';
 import type { MainTheme, TotamjungTheme } from '@/types/mainTheme';
 
 interface WidgetProps {
@@ -140,6 +141,7 @@ const Widget = (props: WidgetProps) => {
           </S.DropdownMenu>
           {problemTitleElement &&
             shouldShowInspectIcon &&
+            !isSolvedAcTheme(theme) &&
             createPortal(
               <InspectResultIcon
                 theme={theme}

--- a/components/Widget/Widget.tsx
+++ b/components/Widget/Widget.tsx
@@ -1,17 +1,16 @@
 import useWidget from '@/hooks/widget/useWidget';
 import InspectResultIcon from '@/components/InspectResultIcon/InspectResultIcon';
 import SpeechBubble from '@/components/common/SpeechBubble';
-import Text from '@/components/common/Text';
 import * as S from './Widget.styled';
-import type { TotamjungTheme } from '@/types/totamjungTheme';
 import type { ToastInfo } from '@/types/toast';
 import { createPortal } from 'react-dom';
 import { $ } from '@/utils/querySelector';
 import GachaProblemCountInputModal from '@/components/GachaProblemCountInputModal';
 import RandomDefenseGachaModal from '../RandomDefenseGachaModal';
+import type { MainTheme, TotamjungTheme } from '@/types/mainTheme';
 
 interface WidgetProps {
-  theme: TotamjungTheme;
+  theme: MainTheme;
   rootElement: HTMLElement;
   onChangeTheme: (theme: TotamjungTheme) => void;
   onToast: (toastInfo: ToastInfo, duration: number) => void;
@@ -47,6 +46,7 @@ const Widget = (props: WidgetProps) => {
   } = useWidget(props);
 
   const problemTitleElement = $('#problem_title');
+  const isExternalThemeEnabled = theme !== 'none' && theme !== 'totamjung';
 
   return (
     <S.Container>
@@ -85,6 +85,7 @@ const Widget = (props: WidgetProps) => {
                 aria-label={
                   theme === 'none' ? '토탐정 테마 켜기' : '토탐정 테마 끄기'
                 }
+                disabled={isExternalThemeEnabled}
                 onClick={toggleTotamjungTheme}
               >
                 <S.DropdownButtonIcon
@@ -152,17 +153,17 @@ const Widget = (props: WidgetProps) => {
                 open={true}
                 maxWidth="400px"
                 content={
-                  <S.SpeechBubbleContentContainer>
-                    <Text type="normal" fontSize="14px">
+                  <S.SpeechBubbleContentContainer $totamjungTheme={theme}>
+                    <S.SpeechBubbleText>
                       토탐정을 설치해 주셔서 감사합니다!
-                    </Text>
-                    <Text type="normal" fontSize="14px">
+                    </S.SpeechBubbleText>
+                    <S.SpeechBubbleText>
                       <strong>위젯을 우클릭</strong>하여 토탐정의 여러 기능들을
                       활용해 보세요.
-                    </Text>
+                    </S.SpeechBubbleText>
                   </S.SpeechBubbleContentContainer>
                 }
-                totamjungTheme={theme}
+                theme={theme}
                 direction="left"
                 hasCloseButton={true}
                 onClose={closeWelcomeMessage}

--- a/components/common/Modal/Modal.stories.tsx
+++ b/components/common/Modal/Modal.stories.tsx
@@ -248,6 +248,72 @@ export const TextWithControlButtons: Story = {
 };
 
 /**
+ * 제목이 매우 길어 화면에 표시할 수 없는 경우 뒷 내용은 생략(...)되어 표시됩니다.
+ *
+ * 모달의 가로 길이는 사용자의 웹 브라우저에 따라 축소/확대될 수도 있으므로, **콘텐츠의 크기는 이를 고려하여 고정값인 `width`보다는 유동적인 대응이 가능한 `min-width`, `max-width` 등을 더 추천합니다.**
+ */
+export const VeryLongTitle: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <div>
+        <Modal
+          open={isOpen}
+          title="이 제목은 너무 길어서 도저히 한 화면에 표시할 수 없을 정도입니다. 여러분의 모니터에서 테스트할 때는 어느 정도일지 모르겠지만 아무튼 이 제목도 굉장히 길기 때문에 감당이 힘들 것이라고 생각합니다."
+          onClose={() => {
+            setIsOpen(false);
+          }}
+        >
+          <div style={{ maxWidth: '100%' }}>
+            <Text type="normal" fontSize="16px">
+              기본적으로 콘텐츠가 차지하는 크기가 작더라도, 제목의 길이가 길면,
+              모달의 길이는 제목의 길이를 한 줄에 표시할 수 있도록 늘어나요.
+              그렇지만, 모달을 띄운 창의 크기가 작다면 이마저도 한계가 있을
+              거에요.
+            </Text>
+            <Text type="primary" fontSize="16px">
+              그 때에는, 줄임표(...)를 사용해 제목을 생략시켜서 표시하도록
+              작동해요.
+            </Text>
+          </div>
+          <ModalActionButtonsContainer>
+            <IconButton
+              type="button"
+              name="그렇군요"
+              size="medium"
+              color="#a3a3a3"
+              iconSrc={<CheckCircleIcon />}
+              disabled={false}
+              ariaLabel="전혀 안 궁금하지만 이해했다고 대충 대답하기"
+              onClick={() => {
+                setIsOpen(false);
+              }}
+            />
+          </ModalActionButtonsContainer>
+        </Modal>
+        <IconButton
+          type="button"
+          name="모달 열기"
+          size="large"
+          color="#a15eff"
+          disabled={false}
+          ariaLabel="모달 열기"
+          onClick={() => {
+            setIsOpen(true);
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    open: false,
+    title: '테스트용 알림창',
+    onClose: () => {},
+  },
+};
+
+/**
  * 대부분의 상황에서는 토탐정 테마 모달을 사용하지만, 백준 내에서 어울리는 UI를 보여주어야 할 경우 다른 테마를 사용할 수도 있습니다.
  */
 export const PlainThemeWithControlButtons: Story = {
@@ -305,12 +371,7 @@ export const PlainThemeWithControlButtons: Story = {
   },
 };
 
-/**
- * 제목이 매우 길어 화면에 표시할 수 없는 경우 뒷 내용은 생략(...)되어 표시됩니다.
- *
- * 모달의 가로 길이는 사용자의 웹 브라우저에 따라 축소/확대될 수도 있으므로, **콘텐츠의 크기는 이를 고려하여 고정값인 `width`보다는 유동적인 대응이 가능한 `min-width`, `max-width` 등을 더 추천합니다.**
- */
-export const VeryLongTitle: Story = {
+export const SolvedAcLightWithControlButtons: Story = {
   render: () => {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -318,32 +379,246 @@ export const VeryLongTitle: Story = {
       <div>
         <Modal
           open={isOpen}
-          title="이 제목은 너무 길어서 도저히 한 화면에 표시할 수 없을 정도입니다. 여러분의 모니터에서 테스트할 때는 어느 정도일지 모르겠지만 아무튼 이 제목도 굉장히 길기 때문에 감당이 힘들 것이라고 생각합니다."
+          title="테스트 모달"
+          theme="solvedAcLight"
           onClose={() => {
             setIsOpen(false);
           }}
         >
-          <div style={{ maxWidth: '100%' }}>
-            <Text type="normal" fontSize="16px">
-              기본적으로 콘텐츠가 차지하는 크기가 작더라도, 제목의 길이가 길면,
-              모달의 길이는 제목의 길이를 한 줄에 표시할 수 있도록 늘어나요.
-              그렇지만, 모달을 띄운 창의 크기가 작다면 이마저도 한계가 있을
-              거에요.
-            </Text>
-            <Text type="primary" fontSize="16px">
-              그 때에는, 줄임표(...)를 사용해 제목을 생략시켜서 표시하도록
-              작동해요.
+          <div style={{ width: '300px' }}>
+            <Text type="darkGray" fontSize="16px">
+              토탐정 테마가 적용되지 않은 모달입니다.
             </Text>
           </div>
-          <ModalActionButtonsContainer>
+          <ModalActionButtonsContainer theme="solvedAcLight">
             <IconButton
               type="button"
-              name="그렇군요"
+              name="확인"
               size="medium"
-              color="#a3a3a3"
+              color="#333333"
               iconSrc={<CheckCircleIcon />}
               disabled={false}
-              ariaLabel="전혀 안 궁금하지만 이해했다고 대충 대답하기"
+              ariaLabel="확인"
+              onClick={() => {
+                setIsOpen(false);
+              }}
+            />
+          </ModalActionButtonsContainer>
+        </Modal>
+        <IconButton
+          type="button"
+          name="모달 열기"
+          size="large"
+          color="#a15eff"
+          disabled={false}
+          ariaLabel="모달 열기"
+          onClick={() => {
+            setIsOpen(true);
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    open: false,
+    title: '테스트용 알림창',
+    onClose: () => {},
+  },
+};
+
+export const SolvedAcDarkWithControlButtons: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <div>
+        <Modal
+          open={isOpen}
+          title="테스트 모달"
+          theme="solvedAcDark"
+          onClose={() => {
+            setIsOpen(false);
+          }}
+        >
+          <div style={{ width: '300px' }}>
+            <Text type="normal" fontSize="16px">
+              solved.ac의 다크 테마가 적용된 모달입니다.
+            </Text>
+          </div>
+          <ModalActionButtonsContainer theme="solvedAcDark">
+            <IconButton
+              type="button"
+              name="확인"
+              size="medium"
+              color="#eeeeee"
+              iconSrc={<CheckCircleIcon />}
+              disabled={false}
+              ariaLabel="확인"
+              onClick={() => {
+                setIsOpen(false);
+              }}
+            />
+          </ModalActionButtonsContainer>
+        </Modal>
+        <IconButton
+          type="button"
+          name="모달 열기"
+          size="large"
+          color="#a15eff"
+          disabled={false}
+          ariaLabel="모달 열기"
+          onClick={() => {
+            setIsOpen(true);
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    open: false,
+    title: '테스트용 알림창',
+    onClose: () => {},
+  },
+};
+
+export const SolvedAcBlackWithControlButtons: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <div>
+        <Modal
+          open={isOpen}
+          title="테스트 모달"
+          theme="solvedAcBlack"
+          onClose={() => {
+            setIsOpen(false);
+          }}
+        >
+          <div style={{ width: '300px' }}>
+            <Text type="normal" fontSize="16px">
+              solved.ac의 암전 테마가 적용된 모달입니다.
+            </Text>
+          </div>
+          <ModalActionButtonsContainer theme="solvedAcBlack">
+            <IconButton
+              type="button"
+              name="확인"
+              size="medium"
+              color="#eeeeee"
+              iconSrc={<CheckCircleIcon />}
+              disabled={false}
+              ariaLabel="확인"
+              onClick={() => {
+                setIsOpen(false);
+              }}
+            />
+          </ModalActionButtonsContainer>
+        </Modal>
+        <IconButton
+          type="button"
+          name="모달 열기"
+          size="large"
+          color="#a15eff"
+          disabled={false}
+          ariaLabel="모달 열기"
+          onClick={() => {
+            setIsOpen(true);
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    open: false,
+    title: '테스트용 알림창',
+    onClose: () => {},
+  },
+};
+
+export const BojExtendedDarkWithControlButtons: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <div>
+        <Modal
+          open={isOpen}
+          title="테스트 모달"
+          theme="bojExtendedDark"
+          onClose={() => {
+            setIsOpen(false);
+          }}
+        >
+          <div style={{ width: '300px' }}>
+            <Text type="normal" fontSize="16px">
+              BOJ Extended의 Dark 테마가 적용된 모달입니다.
+            </Text>
+          </div>
+          <ModalActionButtonsContainer theme="bojExtendedDark">
+            <IconButton
+              type="button"
+              name="확인"
+              size="medium"
+              color="#555555"
+              iconSrc={<CheckCircleIcon />}
+              disabled={false}
+              ariaLabel="확인"
+              onClick={() => {
+                setIsOpen(false);
+              }}
+            />
+          </ModalActionButtonsContainer>
+        </Modal>
+        <IconButton
+          type="button"
+          name="모달 열기"
+          size="large"
+          color="#a15eff"
+          disabled={false}
+          ariaLabel="모달 열기"
+          onClick={() => {
+            setIsOpen(true);
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    open: false,
+    title: '테스트용 알림창',
+    onClose: () => {},
+  },
+};
+
+export const BojExtendedRigelWithControlButtons: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <div>
+        <Modal
+          open={isOpen}
+          title="테스트 모달"
+          theme="bojExtendedRigel"
+          onClose={() => {
+            setIsOpen(false);
+          }}
+        >
+          <div style={{ width: '300px' }}>
+            <Text type="normal" fontSize="16px">
+              BOJ Extended의 Rigel 테마가 적용된 모달입니다.
+            </Text>
+          </div>
+          <ModalActionButtonsContainer theme="bojExtendedRigel">
+            <IconButton
+              type="button"
+              name="확인"
+              size="medium"
+              color="#eeeeee"
+              iconSrc={<CheckCircleIcon />}
+              disabled={false}
+              ariaLabel="확인"
               onClick={() => {
                 setIsOpen(false);
               }}

--- a/components/common/Modal/Modal.styled.ts
+++ b/components/common/Modal/Modal.styled.ts
@@ -1,4 +1,46 @@
+import { theme } from '@/styles/theme';
+import type { MainTheme } from '@/types/mainTheme';
 import { css, styled } from 'styled-components';
+
+const modalHeaderBackgroundColors: Record<MainTheme, string> = {
+  none: theme.color.WHITE,
+  totamjung: theme.color.DARK_BROWN,
+  bojExtendedDark: theme.bojExtendedColor.DARKEST_GRAY,
+  bojExtendedRigel: theme.bojExtendedColor.DARK_INDIGO,
+  solvedAcLight: theme.color.WHITE,
+  solvedAcDark: theme.solvedAcColor.DARK_INDIGO,
+  solvedAcBlack: theme.color.BLACK,
+};
+
+const modalTitleColors: Record<MainTheme, string> = {
+  none: theme.color.BLACK,
+  totamjung: theme.color.GOLD,
+  bojExtendedDark: theme.bojExtendedColor.LIGHT_GRAY,
+  bojExtendedRigel: theme.color.WHITE,
+  solvedAcLight: theme.color.BLACK,
+  solvedAcDark: theme.color.WHITE,
+  solvedAcBlack: theme.color.WHITE,
+};
+
+const modalBodyBackgroundColors: Record<MainTheme, string> = {
+  none: theme.color.PURE_WHITE,
+  totamjung: theme.color.BROWN,
+  bojExtendedDark: theme.bojExtendedColor.DARKER_GRAY,
+  bojExtendedRigel: theme.bojExtendedColor.DARK_SKY_BLUE,
+  solvedAcLight: theme.color.PURE_WHITE,
+  solvedAcDark: theme.solvedAcColor.INDIGO,
+  solvedAcBlack: theme.solvedAcColor.DARK_INDIGO,
+};
+
+const modalBoxShadowColors: Record<MainTheme, string> = {
+  none: theme.color.WHITE,
+  totamjung: theme.color.GOLD,
+  bojExtendedDark: theme.bojExtendedColor.DARKEST_GRAY,
+  bojExtendedRigel: theme.bojExtendedColor.DARK_INDIGO,
+  solvedAcLight: theme.color.WHITE,
+  solvedAcDark: theme.solvedAcColor.DARK_INDIGO,
+  solvedAcBlack: theme.color.BLACK,
+};
 
 export const Container = styled.div`
   display: flex;
@@ -42,16 +84,12 @@ export const Header = styled.div`
 
   height: 56px;
   padding: 16px 16px 0 16px;
-  border-bottom: 16px solid ${({ theme }) => theme.color.DARK_BROWN};
-
-  background-color: ${({ theme }) => theme.color.DARK_BROWN};
 `;
 
 export const Title = styled.p`
   overflow: hidden;
   flex-grow: 1;
 
-  color: ${({ theme }) => theme.color.GOLD};
   font-size: 24px;
   font-family: 'Do Hyeon', Pretendard;
   text-overflow: ellipsis;
@@ -69,7 +107,6 @@ export const CloseButton = styled.button`
   & > svg {
     width: 100%;
     height: 100%;
-    color: ${({ theme }) => theme.color.GOLD};
   }
 `;
 
@@ -78,14 +115,11 @@ export const Body = styled.div<{
 }>`
   padding: ${({ $padding }) => $padding};
 
-  background-color: ${({ theme }) => theme.color.BROWN};
-
-  color: ${({ theme }) => theme.color.WHITE};
   font-size: 16px;
 `;
 
 export const ModalActionButtonsContainer = styled.div<{
-  $theme: 'none' | 'totamjung';
+  $totamjungTheme: MainTheme;
 }>`
   display: flex;
   justify-content: flex-end;
@@ -96,11 +130,11 @@ export const ModalActionButtonsContainer = styled.div<{
   padding: 16px;
   margin: 16px -16px -16px -16px;
 
-  background-color: ${({ theme, $theme }) =>
-    $theme === 'totamjung' ? theme.color.DARK_BROWN : theme.color.WHITE};
+  background-color: ${({ $totamjungTheme }) =>
+    modalHeaderBackgroundColors[$totamjungTheme]};
 `;
 
-export const Modal = styled.div<{ $theme: 'none' | 'totamjung' }>`
+export const Modal = styled.div<{ $totamjungTheme: MainTheme }>`
   position: relative;
   display: flex;
   flex-direction: column;
@@ -109,10 +143,9 @@ export const Modal = styled.div<{ $theme: 'none' | 'totamjung' }>`
   max-height: 100%;
 
   box-shadow: 0 0 30px
-    ${({ theme, $theme }) =>
-      $theme === 'totamjung' ? theme.color.GOLD : theme.color.LIGHT_GRAY};
-  background-color: ${({ theme, $theme }) =>
-    $theme === 'totamjung' ? theme.color.DARK_BROWN : theme.color.WHITE};
+    ${({ $totamjungTheme }) => modalBoxShadowColors[$totamjungTheme]};
+  background-color: ${({ $totamjungTheme }) =>
+    modalHeaderBackgroundColors[$totamjungTheme]};
 
   animation: zoomIn 0.2s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
 
@@ -125,23 +158,21 @@ export const Modal = styled.div<{ $theme: 'none' | 'totamjung' }>`
     }
   }
 
-  ${({ $theme }) =>
-    $theme === 'none' &&
-    css`
-      & ${Header} {
-        border-bottom: 16px solid ${({ theme }) => theme.color.WHITE};
+  ${({ $totamjungTheme }) => css`
+    & ${Header} {
+      border-bottom: 16px solid ${modalHeaderBackgroundColors[$totamjungTheme]};
 
-        background-color: ${({ theme }) => theme.color.WHITE};
-      }
+      background-color: ${modalHeaderBackgroundColors[$totamjungTheme]};
+    }
 
-      & ${Title}, & ${CloseButton} > svg {
-        color: ${({ theme }) => theme.color.DARK_GRAY};
-      }
+    & ${Title}, & ${CloseButton} > svg {
+      color: ${modalTitleColors[$totamjungTheme]};
+    }
 
-      & ${Body} {
-        background-color: ${({ theme }) => theme.color.PURE_WHITE};
+    & ${Body} {
+      background-color: ${modalBodyBackgroundColors[$totamjungTheme]};
 
-        color: ${({ theme }) => theme.color.DARK_GRAY};
-      }
-    `};
+      color: ${({ theme }) => theme.color.DARK_GRAY};
+    }
+  `};
 `;

--- a/components/common/Modal/Modal.styled.ts
+++ b/components/common/Modal/Modal.styled.ts
@@ -22,8 +22,14 @@ const modalTitleColors: Record<MainTheme, string> = {
   solvedAcBlack: theme.color.WHITE,
 };
 
+const modalCloseButtonIconColors: Record<MainTheme, string> = {
+  ...modalTitleColors,
+  solvedAcDark: theme.solvedAcColor.LIGHT_GRAY,
+  solvedAcBlack: theme.solvedAcColor.LIGHT_GRAY,
+};
+
 const modalBodyBackgroundColors: Record<MainTheme, string> = {
-  none: theme.color.PURE_WHITE,
+  none: theme.color.WHITE,
   totamjung: theme.color.BROWN,
   bojExtendedDark: theme.bojExtendedColor.DARKER_GRAY,
   bojExtendedRigel: theme.bojExtendedColor.DARK_SKY_BLUE,
@@ -33,7 +39,7 @@ const modalBodyBackgroundColors: Record<MainTheme, string> = {
 };
 
 const modalBoxShadowColors: Record<MainTheme, string> = {
-  none: theme.color.WHITE,
+  none: theme.color.LIGHT_GRAY,
   totamjung: theme.color.GOLD,
   bojExtendedDark: theme.bojExtendedColor.DARKEST_GRAY,
   bojExtendedRigel: theme.bojExtendedColor.DARK_INDIGO,
@@ -165,8 +171,12 @@ export const Modal = styled.div<{ $totamjungTheme: MainTheme }>`
       background-color: ${modalHeaderBackgroundColors[$totamjungTheme]};
     }
 
-    & ${Title}, & ${CloseButton} > svg {
+    & ${Title} {
       color: ${modalTitleColors[$totamjungTheme]};
+    }
+
+    & ${CloseButton} > svg {
+      color: ${modalCloseButtonIconColors[$totamjungTheme]};
     }
 
     & ${Body} {

--- a/components/common/Modal/Modal.styled.ts
+++ b/components/common/Modal/Modal.styled.ts
@@ -24,12 +24,14 @@ const modalTitleColors: Record<MainTheme, string> = {
 
 const modalCloseButtonIconColors: Record<MainTheme, string> = {
   ...modalTitleColors,
+  none: theme.solvedAcColor.GRAY,
+  solvedAcLight: theme.solvedAcColor.GRAY,
   solvedAcDark: theme.solvedAcColor.LIGHT_GRAY,
   solvedAcBlack: theme.solvedAcColor.LIGHT_GRAY,
 };
 
 const modalBodyBackgroundColors: Record<MainTheme, string> = {
-  none: theme.color.WHITE,
+  none: theme.color.PURE_WHITE,
   totamjung: theme.color.BROWN,
   bojExtendedDark: theme.bojExtendedColor.DARKER_GRAY,
   bojExtendedRigel: theme.bojExtendedColor.DARK_SKY_BLUE,

--- a/components/common/Modal/Modal.tsx
+++ b/components/common/Modal/Modal.tsx
@@ -3,19 +3,20 @@ import useEscKey from '@/hooks/useEscKey';
 import { CloseIcon } from '@/assets/svg';
 import { createPortal } from 'react-dom';
 import type { PropsWithChildren, ReactNode } from 'react';
+import type { MainTheme } from '@/types/mainTheme';
 
 interface ModalProps {
   title: string;
   open: boolean;
   padding?: string;
   closeOnBackdropClick?: boolean;
-  theme?: 'none' | 'totamjung';
+  theme?: MainTheme;
   portalTarget?: HTMLElement | null;
   onClose: () => void;
 }
 
 interface ModalActionButtonsContainerProps {
-  theme?: 'none' | 'totamjung';
+  theme?: MainTheme;
   children: ReactNode;
 }
 
@@ -43,7 +44,7 @@ const Modal = (props: PropsWithChildren<ModalProps>) => {
             }
           }}
         />
-        <S.Modal role="dialog" $theme={theme}>
+        <S.Modal role="dialog" $totamjungTheme={theme}>
           <S.Header>
             <S.Title>{title}</S.Title>
             <S.CloseButton onClick={onClose} aria-label="모달 닫기">
@@ -69,7 +70,7 @@ export const ModalActionButtonsContainer = (
   const { children, theme = 'totamjung' } = props;
 
   return (
-    <S.ModalActionButtonsContainer $theme={theme}>
+    <S.ModalActionButtonsContainer $totamjungTheme={theme}>
       {children}
     </S.ModalActionButtonsContainer>
   );

--- a/components/common/SimpleModal/SimpleModal.stories.tsx
+++ b/components/common/SimpleModal/SimpleModal.stories.tsx
@@ -355,3 +355,123 @@ export const PlainYesNo: Story = {
     onNoSelect: () => {},
   },
 };
+
+export const SolvedAcLightConfirm: Story = {
+  ...PlainConfirm,
+  args: {
+    ...PlainConfirm.args,
+    theme: 'solvedAcLight',
+  },
+};
+
+export const SolvedAcLightCancelConfirm: Story = {
+  ...PlainCancelConfirm,
+  args: {
+    ...PlainCancelConfirm.args,
+    theme: 'solvedAcLight',
+  },
+};
+
+export const SolvedAcLightYesNo: Story = {
+  ...PlainYesNo,
+  args: {
+    ...PlainYesNo.args,
+    theme: 'solvedAcLight',
+  },
+};
+
+export const SolvedAcDarkConfirm: Story = {
+  ...PlainConfirm,
+  args: {
+    ...PlainConfirm.args,
+    theme: 'solvedAcDark',
+  },
+};
+
+export const SolvedAcDarkCancelConfirm: Story = {
+  ...PlainCancelConfirm,
+  args: {
+    ...PlainCancelConfirm.args,
+    theme: 'solvedAcDark',
+  },
+};
+
+export const SolvedAcDarkYesNo: Story = {
+  ...PlainYesNo,
+  args: {
+    ...PlainYesNo.args,
+    theme: 'solvedAcDark',
+  },
+};
+
+export const SolvedAcBlackConfirm: Story = {
+  ...PlainConfirm,
+  args: {
+    ...PlainConfirm.args,
+    theme: 'solvedAcBlack',
+  },
+};
+
+export const SolvedAcBlackCancelConfirm: Story = {
+  ...PlainCancelConfirm,
+  args: {
+    ...PlainCancelConfirm.args,
+    theme: 'solvedAcBlack',
+  },
+};
+
+export const SolvedAcBlackYesNo: Story = {
+  ...PlainYesNo,
+  args: {
+    ...PlainYesNo.args,
+    theme: 'solvedAcBlack',
+  },
+};
+
+export const BojExtendedDarkConfirm: Story = {
+  ...PlainConfirm,
+  args: {
+    ...PlainConfirm.args,
+    theme: 'bojExtendedDark',
+  },
+};
+
+export const BojExtendedDarkCancelConfirm: Story = {
+  ...PlainCancelConfirm,
+  args: {
+    ...PlainCancelConfirm.args,
+    theme: 'bojExtendedDark',
+  },
+};
+
+export const BojExtendedDarkYesNo: Story = {
+  ...PlainYesNo,
+  args: {
+    ...PlainYesNo.args,
+    theme: 'bojExtendedDark',
+  },
+};
+
+export const BojExtendedRigelConfirm: Story = {
+  ...PlainConfirm,
+  args: {
+    ...PlainConfirm.args,
+    theme: 'bojExtendedRigel',
+  },
+};
+
+export const BojExtendedRigelCancelConfirm: Story = {
+  ...PlainCancelConfirm,
+  args: {
+    ...PlainCancelConfirm.args,
+    theme: 'bojExtendedRigel',
+  },
+};
+
+export const BojExtendedRigelYesNo: Story = {
+  ...PlainYesNo,
+  args: {
+    ...PlainYesNo.args,
+    theme: 'bojExtendedRigel',
+  },
+};

--- a/components/common/SimpleModal/SimpleModal.styled.ts
+++ b/components/common/SimpleModal/SimpleModal.styled.ts
@@ -1,7 +1,17 @@
 import { styled } from 'styled-components';
+import { MainTheme } from '@/types/mainTheme';
+import { lightThemes } from './SimpleModal';
 
 export const ContentContainer = styled.div<{ $width: string; $height: string }>`
   width: ${({ $width }) => $width};
   max-width: 100%;
   min-height: ${({ $height }) => $height};
+`;
+
+export const Text = styled.p<{ $totamjungTheme: MainTheme }>`
+  font-size: 16px;
+  color: ${({ theme, $totamjungTheme }) =>
+    lightThemes.includes($totamjungTheme)
+      ? theme.color.BLACK
+      : theme.color.WHITE};
 `;

--- a/components/common/SimpleModal/SimpleModal.tsx
+++ b/components/common/SimpleModal/SimpleModal.tsx
@@ -1,9 +1,9 @@
 import Modal, { ModalActionButtonsContainer } from '@/components/common/Modal';
 import IconButton from '@/components/common/IconButton';
-import Text from '@/components/common/Text';
-import { theme } from '@/styles/theme';
+import { theme as styledTheme } from '@/styles/theme';
 import { CheckCircleIcon, CloseCircleIcon } from '@/assets/svg';
 import * as S from './SimpleModal.styled';
+import type { MainTheme } from '@/types/mainTheme';
 
 type SimpleModalProps = {
   title: string;
@@ -17,23 +17,25 @@ type SimpleModalProps = {
 
 interface ConfirmModalProps {
   actionType: 'confirm';
-  theme?: 'none' | 'totamjung';
+  theme?: MainTheme;
   onClose: () => void;
 }
 
 interface CancelConfirmModalProps {
   actionType: 'cancelConfirm';
-  theme?: 'none' | 'totamjung';
+  theme?: MainTheme;
   onClose: () => void;
   onConfirm: () => void;
 }
 
 interface YesNoModalProps {
   actionType: 'yesNo';
-  theme?: 'none' | 'totamjung';
+  theme?: MainTheme;
   onYesSelect: () => void;
   onNoSelect: () => void;
 }
+
+export const lightThemes: readonly MainTheme[] = ['none', 'solvedAcLight'];
 
 const SimpleModal = (props: SimpleModalProps) => {
   const {
@@ -60,12 +62,7 @@ const SimpleModal = (props: SimpleModalProps) => {
       }}
     >
       <S.ContentContainer $width={width} $height={height}>
-        <Text
-          type={theme === 'totamjung' ? 'normal' : 'darkGray'}
-          fontSize="16px"
-        >
-          {message}
-        </Text>
+        <S.Text $totamjungTheme={theme}>{message}</S.Text>
       </S.ContentContainer>
       <ModalActionButtonsContainer theme={theme}>
         {actionType === 'confirm' ? (
@@ -89,7 +86,7 @@ const SimpleModal = (props: SimpleModalProps) => {
 };
 
 const ConfirmButton = (props: Omit<ConfirmModalProps, 'actionType'>) => {
-  const { theme: modalTheme, onClose } = props;
+  const { theme = 'totamjung', onClose } = props;
 
   return (
     <IconButton
@@ -98,7 +95,9 @@ const ConfirmButton = (props: Omit<ConfirmModalProps, 'actionType'>) => {
       size="medium"
       iconSrc={<CheckCircleIcon />}
       color={
-        modalTheme === 'totamjung' ? theme.color.GOLD : theme.color.DARK_GRAY
+        lightThemes.includes(theme)
+          ? styledTheme.color.DARK_GRAY
+          : styledTheme.color.GOLD
       }
       disabled={false}
       ariaLabel="확인"
@@ -111,7 +110,7 @@ const ConfirmButton = (props: Omit<ConfirmModalProps, 'actionType'>) => {
 const CancelConfirmButtons = (
   props: Omit<CancelConfirmModalProps, 'actionType'>,
 ) => {
-  const { theme: modalTheme, onClose, onConfirm } = props;
+  const { theme = 'totamjung', onClose, onConfirm } = props;
 
   return (
     <>
@@ -121,9 +120,9 @@ const CancelConfirmButtons = (
         size="medium"
         iconSrc={<CloseCircleIcon />}
         color={
-          modalTheme === 'totamjung'
-            ? theme.color.LIGHT_GRAY
-            : theme.color.DARK_GRAY
+          lightThemes.includes(theme)
+            ? styledTheme.color.DARK_GRAY
+            : styledTheme.color.LIGHT_GRAY
         }
         disabled={false}
         ariaLabel="취소"
@@ -135,7 +134,9 @@ const CancelConfirmButtons = (
         size="medium"
         iconSrc={<CheckCircleIcon />}
         color={
-          modalTheme === 'totamjung' ? theme.color.GOLD : theme.color.DARK_GRAY
+          lightThemes.includes(theme)
+            ? styledTheme.color.DARK_GRAY
+            : styledTheme.color.GOLD
         }
         disabled={false}
         ariaLabel="확인"
@@ -146,7 +147,7 @@ const CancelConfirmButtons = (
 };
 
 const YesNoButtons = (props: Omit<YesNoModalProps, 'actionType'>) => {
-  const { theme: modalTheme, onYesSelect, onNoSelect } = props;
+  const { theme = 'totamjung', onYesSelect, onNoSelect } = props;
 
   return (
     <>
@@ -157,7 +158,9 @@ const YesNoButtons = (props: Omit<YesNoModalProps, 'actionType'>) => {
         width="80px"
         iconSrc={<CheckCircleIcon />}
         color={
-          modalTheme === 'totamjung' ? theme.color.LIME : theme.color.GREEN
+          lightThemes.includes(theme)
+            ? styledTheme.color.GREEN
+            : styledTheme.color.LIME
         }
         disabled={false}
         ariaLabel="예"
@@ -168,7 +171,7 @@ const YesNoButtons = (props: Omit<YesNoModalProps, 'actionType'>) => {
         name="아니요"
         size="medium"
         iconSrc={<CloseCircleIcon />}
-        color={theme.color.RED}
+        color={styledTheme.color.RED}
         disabled={false}
         ariaLabel="아니요"
         onClick={onNoSelect}

--- a/components/common/SpeechBubble/SpeechBubble.stories.tsx
+++ b/components/common/SpeechBubble/SpeechBubble.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
     content: {
       description: '말풍선에 담을 내용입니다.',
     },
-    totamjungTheme: {
+    theme: {
       description: '말풍선에 적용할 테마입니다.',
     },
     direction: {
@@ -44,7 +44,7 @@ export const DirectionLeft: Story = {
   args: {
     open: true,
     content: '테스트 메시지입니다.',
-    totamjungTheme: 'none',
+    theme: 'none',
     direction: 'left',
   },
 };
@@ -53,7 +53,7 @@ export const DirectionUp: Story = {
   args: {
     open: true,
     content: '테스트 메시지입니다.',
-    totamjungTheme: 'none',
+    theme: 'none',
     direction: 'up',
   },
 };
@@ -62,7 +62,7 @@ export const DirectionRight: Story = {
   args: {
     open: true,
     content: '테스트 메시지입니다.',
-    totamjungTheme: 'none',
+    theme: 'none',
     direction: 'right',
   },
 };
@@ -71,17 +71,8 @@ export const DirectionDown: Story = {
   args: {
     open: true,
     content: '테스트 메시지입니다.',
-    totamjungTheme: 'none',
+    theme: 'none',
     direction: 'down',
-  },
-};
-
-export const TotamjungTheme: Story = {
-  args: {
-    open: true,
-    content: '테스트 메시지입니다.',
-    totamjungTheme: 'totamjung',
-    direction: 'left',
   },
 };
 
@@ -90,7 +81,7 @@ export const TooManyContent: Story = {
     open: true,
     content:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-    totamjungTheme: 'none',
+    theme: 'none',
     direction: 'left',
   },
 };
@@ -100,7 +91,7 @@ export const TooManyContentWithLimitedWidth: Story = {
     open: true,
     content:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-    totamjungTheme: 'none',
+    theme: 'none',
     direction: 'left',
     maxWidth: '300px',
   },
@@ -110,7 +101,7 @@ export const HasCloseButton: Story = {
   args: {
     open: true,
     content: '테스트 메시지입니다.',
-    totamjungTheme: 'none',
+    theme: 'none',
     direction: 'left',
     hasCloseButton: true,
     onClose: fn(),
@@ -122,7 +113,7 @@ export const CloseButtonWithManyContent: Story = {
     open: true,
     content:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-    totamjungTheme: 'none',
+    theme: 'none',
     direction: 'left',
     hasCloseButton: true,
     onClose: fn(),
@@ -143,9 +134,63 @@ export const UsingReactComponentAsChild: Story = {
         </Text>
       </div>
     ),
-    totamjungTheme: 'none',
+    theme: 'none',
     direction: 'left',
     hasCloseButton: true,
     onClose: fn(),
+  },
+};
+
+export const Totamjung: Story = {
+  args: {
+    open: true,
+    content: '테스트 메시지입니다.',
+    theme: 'totamjung',
+    direction: 'left',
+  },
+};
+
+export const SolvedAcLight: Story = {
+  args: {
+    open: true,
+    content: '테스트 메시지입니다.',
+    theme: 'solvedAcLight',
+    direction: 'left',
+  },
+};
+
+export const SolvedAcDark: Story = {
+  args: {
+    open: true,
+    content: '테스트 메시지입니다.',
+    theme: 'solvedAcDark',
+    direction: 'left',
+  },
+};
+
+export const SolvedAcBlack: Story = {
+  args: {
+    open: true,
+    content: '테스트 메시지입니다.',
+    theme: 'solvedAcBlack',
+    direction: 'left',
+  },
+};
+
+export const BojExtendedRigel: Story = {
+  args: {
+    open: true,
+    content: '테스트 메시지입니다.',
+    theme: 'bojExtendedRigel',
+    direction: 'left',
+  },
+};
+
+export const BojExtendedDark: Story = {
+  args: {
+    open: true,
+    content: '테스트 메시지입니다.',
+    theme: 'bojExtendedDark',
+    direction: 'left',
   },
 };

--- a/components/common/SpeechBubble/SpeechBubble.styled.ts
+++ b/components/common/SpeechBubble/SpeechBubble.styled.ts
@@ -34,7 +34,7 @@ const closeButtonColors: Record<MainTheme, string> = {
   solvedAcDark: theme.color.WHITE,
   solvedAcBlack: theme.color.WHITE,
   bojExtendedDark: theme.bojExtendedColor.LIGHT_GRAY,
-  bojExtendedRigel: theme.bojExtendedColor.DARK_SKY_BLUE,
+  bojExtendedRigel: theme.bojExtendedColor.SKY_BLUE,
 } as const;
 
 export const Container = styled.div<{

--- a/components/common/SpeechBubble/SpeechBubble.styled.ts
+++ b/components/common/SpeechBubble/SpeechBubble.styled.ts
@@ -31,8 +31,8 @@ const closeButtonColors: Record<MainTheme, string> = {
   none: theme.color.WHITE,
   totamjung: theme.color.LIGHTEST_BROWN,
   solvedAcLight: theme.color.GRAY,
-  solvedAcDark: theme.color.WHITE,
-  solvedAcBlack: theme.color.WHITE,
+  solvedAcDark: theme.solvedAcColor.GRAY,
+  solvedAcBlack: theme.solvedAcColor.GRAY,
   bojExtendedDark: theme.bojExtendedColor.LIGHT_GRAY,
   bojExtendedRigel: theme.bojExtendedColor.SKY_BLUE,
 } as const;

--- a/components/common/SpeechBubble/SpeechBubble.styled.ts
+++ b/components/common/SpeechBubble/SpeechBubble.styled.ts
@@ -14,7 +14,7 @@ const bubbleBackgroundColors: Record<MainTheme, string> = {
 
 const bubbleArrowColors: Record<MainTheme, string> = {
   ...bubbleBackgroundColors,
-  solvedAcLight: theme.solvedAcColor.LIGHT_GRAY,
+  solvedAcLight: theme.solvedAcColor.LIGHTER_GRAY,
 } as const;
 
 const bubbleTextColors: Record<MainTheme, string> = {
@@ -30,7 +30,7 @@ const bubbleTextColors: Record<MainTheme, string> = {
 const closeButtonColors: Record<MainTheme, string> = {
   none: theme.color.WHITE,
   totamjung: theme.color.LIGHTEST_BROWN,
-  solvedAcLight: theme.color.BLACK,
+  solvedAcLight: theme.color.GRAY,
   solvedAcDark: theme.color.WHITE,
   solvedAcBlack: theme.color.WHITE,
   bojExtendedDark: theme.bojExtendedColor.LIGHT_GRAY,
@@ -53,7 +53,7 @@ export const Container = styled.div<{
   ${({ theme, $totamjungTheme }) =>
     $totamjungTheme === 'solvedAcLight' &&
     css`
-      border: 1px solid ${theme.solvedAcColor.LIGHT_GRAY};
+      border: 1px solid ${theme.solvedAcColor.LIGHTER_GRAY};
     `};
 
   border-radius: 8px;

--- a/components/common/SpeechBubble/SpeechBubble.styled.ts
+++ b/components/common/SpeechBubble/SpeechBubble.styled.ts
@@ -1,9 +1,45 @@
-import type { TotamjungTheme } from '@/types/totamjungTheme';
+import type { MainTheme } from '@/types/mainTheme';
 import { styled, css } from 'styled-components';
+import { theme } from '@/styles/theme';
+
+const bubbleBackgroundColors: Record<MainTheme, string> = {
+  none: theme.color.BOJ_BLUE,
+  totamjung: theme.color.BLACK_DARKER_TRANSPARENT,
+  solvedAcLight: theme.solvedAcColor.OFF_WHITE,
+  solvedAcDark: theme.solvedAcColor.DARK_INDIGO,
+  solvedAcBlack: theme.solvedAcColor.DARK_INDIGO,
+  bojExtendedDark: theme.color.BLACK_DARKER_TRANSPARENT,
+  bojExtendedRigel: theme.bojExtendedColor.DARK_INDIGO,
+} as const;
+
+const bubbleArrowColors: Record<MainTheme, string> = {
+  ...bubbleBackgroundColors,
+  solvedAcLight: theme.solvedAcColor.LIGHT_GRAY,
+} as const;
+
+const bubbleTextColors: Record<MainTheme, string> = {
+  none: theme.color.WHITE,
+  totamjung: theme.color.WHITE,
+  solvedAcLight: theme.color.BLACK,
+  solvedAcDark: theme.color.WHITE,
+  solvedAcBlack: theme.color.WHITE,
+  bojExtendedDark: theme.color.WHITE,
+  bojExtendedRigel: theme.color.WHITE,
+} as const;
+
+const closeButtonColors: Record<MainTheme, string> = {
+  none: theme.color.WHITE,
+  totamjung: theme.color.LIGHTEST_BROWN,
+  solvedAcLight: theme.color.BLACK,
+  solvedAcDark: theme.color.WHITE,
+  solvedAcBlack: theme.color.WHITE,
+  bojExtendedDark: theme.bojExtendedColor.LIGHT_GRAY,
+  bojExtendedRigel: theme.bojExtendedColor.DARK_SKY_BLUE,
+} as const;
 
 export const Container = styled.div<{
   $open: boolean;
-  $totamjungTheme: TotamjungTheme;
+  $totamjungTheme: MainTheme;
   $direction: 'up' | 'left' | 'right' | 'down';
   $maxWidth?: string;
 }>`
@@ -14,11 +50,15 @@ export const Container = styled.div<{
 
   padding: 14px;
 
+  ${({ theme, $totamjungTheme }) =>
+    $totamjungTheme === 'solvedAcLight' &&
+    css`
+      border: 1px solid ${theme.solvedAcColor.LIGHT_GRAY};
+    `};
+
   border-radius: 8px;
-  background-color: ${({ theme, $totamjungTheme }) =>
-    $totamjungTheme === 'totamjung'
-      ? theme.color.BLACK_DARKER_TRANSPARENT
-      : theme.color.BOJ_BLUE};
+  background-color: ${({ $totamjungTheme }) =>
+    bubbleBackgroundColors[$totamjungTheme]};
 
   word-break: break-all;
 
@@ -43,11 +83,8 @@ export const Container = styled.div<{
 
     border: 9px solid;
 
-    ${({ theme, $totamjungTheme, $direction }) => {
-      const arrowColor =
-        $totamjungTheme === 'totamjung'
-          ? theme.color.BLACK_DARKER_TRANSPARENT
-          : theme.color.BOJ_BLUE;
+    ${({ $totamjungTheme, $direction }) => {
+      const arrowColor = bubbleArrowColors[$totamjungTheme];
 
       if ($direction === 'left') {
         return css`
@@ -103,6 +140,13 @@ export const ContentWrapper = styled.div`
   height: 100%;
 `;
 
+export const Content = styled.span<{ $totamjungTheme: MainTheme }>`
+  font-size: 14px;
+  line-height: 14px;
+  font-family: Pretendard;
+  color: ${({ $totamjungTheme }) => bubbleTextColors[$totamjungTheme]};
+`;
+
 export const CloseButtonWrapper = styled.div`
   display: flex;
 
@@ -112,7 +156,7 @@ export const CloseButtonWrapper = styled.div`
   margin-left: auto;
 `;
 
-export const CloseButton = styled.button<{ $totamjungTheme: TotamjungTheme }>`
+export const CloseButton = styled.button<{ $totamjungTheme: MainTheme }>`
   width: 20px;
   height: 20px;
 
@@ -122,9 +166,6 @@ export const CloseButton = styled.button<{ $totamjungTheme: TotamjungTheme }>`
     width: 100%;
     height: 100%;
 
-    color: ${({ theme, $totamjungTheme }) =>
-      $totamjungTheme === 'totamjung'
-        ? theme.color.LIGHTER_BROWN
-        : theme.color.WHITE};
+    color: ${({ $totamjungTheme }) => closeButtonColors[$totamjungTheme]};
   }
 `;

--- a/components/common/SpeechBubble/SpeechBubble.tsx
+++ b/components/common/SpeechBubble/SpeechBubble.tsx
@@ -1,6 +1,5 @@
-import type { TotamjungTheme } from '@/types/totamjungTheme';
+import type { MainTheme } from '@/types/mainTheme';
 import * as S from './SpeechBubble.styled';
-import Text from '@/components/common/Text';
 import { CloseIcon } from '@/assets/svg';
 import type { ReactNode } from 'react';
 
@@ -9,7 +8,7 @@ type SpeechBubbleProps = PlainSpeechBubbleProps | CloseButtonSpeechBubbleProps;
 interface CloseButtonSpeechBubbleProps {
   open: boolean;
   content: string | ReactNode;
-  totamjungTheme: TotamjungTheme;
+  theme: MainTheme;
   direction: 'up' | 'left' | 'right' | 'down';
   maxWidth?: string;
   hasCloseButton: true;
@@ -19,34 +18,31 @@ interface CloseButtonSpeechBubbleProps {
 interface PlainSpeechBubbleProps {
   open: boolean;
   content: string;
-  totamjungTheme: TotamjungTheme;
+  theme: MainTheme;
   direction: 'up' | 'left' | 'right' | 'down';
   maxWidth?: string;
   hasCloseButton?: false;
 }
 
 const SpeechBubble = (props: SpeechBubbleProps) => {
-  const { open, content, totamjungTheme, direction, maxWidth, hasCloseButton } =
-    props;
+  const { open, content, theme, direction, maxWidth, hasCloseButton } = props;
 
   return (
     <S.Container
       $open={open}
-      $totamjungTheme={totamjungTheme}
+      $totamjungTheme={theme}
       $direction={direction}
       $maxWidth={maxWidth}
     >
       {typeof content === 'string' ? (
-        <Text type="normal" fontSize="14px">
-          {content}
-        </Text>
+        <S.Content $totamjungTheme={theme}>{content}</S.Content>
       ) : (
         <S.ContentWrapper>{content}</S.ContentWrapper>
       )}
       {hasCloseButton && (
         <S.CloseButtonWrapper>
           <S.CloseButton
-            $totamjungTheme={totamjungTheme}
+            $totamjungTheme={theme}
             type="button"
             aria-label="닫기"
             onClick={props.onClose}

--- a/components/core/ContentScript/ContentScript.tsx
+++ b/components/core/ContentScript/ContentScript.tsx
@@ -2,28 +2,28 @@ import Widget from '@/components/Widget';
 import LeftSlideToast from '@/components/LeftSlideToast/LeftSlideToast';
 import useTotamjungThemeState from '@/hooks/useTotamjungThemeState';
 import useToastState from '@/hooks/useToastState';
+import useExternalThemeInfo from '@/hooks/widget/useExternalThemeInfo';
 
 const ContentScript = () => {
   const { totamjungTheme, isLoaded, updateTotamjungTheme } =
     useTotamjungThemeState();
+  const { externalTheme } = useExternalThemeInfo();
   const { toastState, showToast, closeToast } = useToastState();
+
   const totamjungRootRef = useRef<HTMLDivElement>(null);
+  const theme = externalTheme ?? totamjungTheme;
 
   return (
     <div ref={totamjungRootRef} style={{ position: 'relative', zIndex: 10000 }}>
       {isLoaded && totamjungRootRef.current && (
         <>
           <Widget
-            theme={totamjungTheme}
+            theme={theme}
             rootElement={totamjungRootRef.current}
             onChangeTheme={updateTotamjungTheme}
             onToast={showToast}
           />
-          <LeftSlideToast
-            theme={totamjungTheme}
-            onClose={closeToast}
-            {...toastState}
-          />
+          <LeftSlideToast theme={theme} onClose={closeToast} {...toastState} />
         </>
       )}
     </div>

--- a/domains/dataHandlers/converters/legacyToLatestTotamjungThemeConverter.ts
+++ b/domains/dataHandlers/converters/legacyToLatestTotamjungThemeConverter.ts
@@ -1,4 +1,4 @@
-import type { TotamjungTheme } from '@/types/totamjungTheme';
+import type { TotamjungTheme } from '@/types/mainTheme';
 import { isObject } from '@/types/typeGuards';
 
 /**

--- a/domains/dataHandlers/totamjungThemeDataHandler.ts
+++ b/domains/dataHandlers/totamjungThemeDataHandler.ts
@@ -1,7 +1,7 @@
 import { STORAGE_KEY } from '@/constants/commands';
 import { isTotamjungTheme } from '@/domains/dataHandlers/validators/totamjungThemeValidator';
 import { sanitizeTotamjungTheme } from './sanitizers/totamjungThemeSanitizer';
-import type { TotamjungTheme } from '@/types/totamjungTheme';
+import type { TotamjungTheme } from '@/types/mainTheme';
 
 export const fetchTotamjungTheme = async (): Promise<TotamjungTheme> => {
   const data = await browser.storage.local.get(STORAGE_KEY.TOTAMJUNG_THEME);

--- a/domains/dataHandlers/validators/solvedAcThemeValidadtor.ts
+++ b/domains/dataHandlers/validators/solvedAcThemeValidadtor.ts
@@ -1,0 +1,8 @@
+import type { SolvedAcTheme } from '@/types/mainTheme';
+
+export const isSolvedAcTheme = (data: unknown): data is SolvedAcTheme => {
+  return (
+    typeof data === 'string' &&
+    ['solvedAcLight', 'solvedAcDark', 'solvedAcBlack'].includes(data)
+  );
+};

--- a/domains/dataHandlers/validators/totamjungThemeValidator.ts
+++ b/domains/dataHandlers/validators/totamjungThemeValidator.ts
@@ -1,4 +1,4 @@
-import { TotamjungTheme } from '@/types/totamjungTheme';
+import { TotamjungTheme } from '@/types/mainTheme';
 
 export const isTotamjungTheme = (data: unknown): data is TotamjungTheme => {
   return data === 'none' || data === 'totamjung';

--- a/domains/isExternalThemeActive.ts
+++ b/domains/isExternalThemeActive.ts
@@ -1,0 +1,13 @@
+export const isExternalThemeActive = () => {
+  if (location.href.startsWith('https://solved.ac/')) {
+    return true;
+  }
+
+  const bojExtendedTheme = document.documentElement.getAttribute('theme');
+
+  if (bojExtendedTheme && bojExtendedTheme !== 'light') {
+    return true;
+  }
+
+  return false;
+};

--- a/entrypoints/content/index.ts
+++ b/entrypoints/content/index.ts
@@ -1,7 +1,7 @@
 import executeContentScript from './main';
 
 export default defineContentScript({
-  matches: ['https://www.acmicpc.net/*'],
+  matches: ['https://www.acmicpc.net/*', 'https://solved.ac/*'],
   runAt: 'document_idle',
   main() {
     executeContentScript();

--- a/entrypoints/injectionScript.content.ts
+++ b/entrypoints/injectionScript.content.ts
@@ -8,7 +8,7 @@ import '@/assets/css/tierHider.css';
 import '@/assets/css/problemTheme.css';
 
 export default defineContentScript({
-  matches: ['https://www.acmicpc.net/*'],
+  matches: ['https://www.acmicpc.net/*', 'https://solved.ac/*'],
   runAt: 'document_start',
   main() {
     executeInjectionScript();
@@ -29,7 +29,11 @@ const executeInjectionScript = () => {
           return;
         }
 
-        if (totamjungTheme === 'totamjung') {
+        const isBojExtendedThemeEnabled =
+          htmlElement.hasAttribute('theme') &&
+          htmlElement.getAttribute('theme') !== 'light';
+
+        if (totamjungTheme === 'totamjung' && !isBojExtendedThemeEnabled) {
           htmlElement.style.backgroundColor = TOTAMJUNG_THEME_BACKGROUND_COLOR;
           htmlElement.setAttribute('totamjungTheme', 'totamjung');
         } else {

--- a/entrypoints/injectionScript.content.ts
+++ b/entrypoints/injectionScript.content.ts
@@ -2,6 +2,7 @@ import { COMMANDS } from '@/constants/commands';
 import { isFontNo } from '@/domains/dataHandlers/validators/fontNoValidator';
 import { isHiderOptions } from '@/domains/dataHandlers/validators/hiderOptionsValidator';
 import { isTotamjungTheme } from '@/domains/dataHandlers/validators/totamjungThemeValidator';
+import { isExternalThemeActive } from '@/domains/isExternalThemeActive';
 import '@/assets/css/palette.css';
 import '@/assets/css/totamjungTheme.css';
 import '@/assets/css/tierHider.css';
@@ -29,11 +30,7 @@ const executeInjectionScript = () => {
           return;
         }
 
-        const isBojExtendedThemeEnabled =
-          htmlElement.hasAttribute('theme') &&
-          htmlElement.getAttribute('theme') !== 'light';
-
-        if (totamjungTheme === 'totamjung' && !isBojExtendedThemeEnabled) {
+        if (totamjungTheme === 'totamjung' && !isExternalThemeActive()) {
           htmlElement.style.backgroundColor = TOTAMJUNG_THEME_BACKGROUND_COLOR;
           htmlElement.setAttribute('totamjungTheme', 'totamjung');
         } else {

--- a/entrypoints/injectionScript.content.ts
+++ b/entrypoints/injectionScript.content.ts
@@ -173,8 +173,6 @@ const executeInjectionScript = () => {
       ].forEach((element) => {
         headElement.appendChild(element);
       });
-
-      headInjectionObserver.disconnect();
     });
 
     headInjectionObserver.observe(htmlElement, { childList: true });

--- a/hooks/appearance/useAppearanceFieldsetMenu.ts
+++ b/hooks/appearance/useAppearanceFieldsetMenu.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { isTotamjungTheme } from '@/domains/dataHandlers/validators/totamjungThemeValidator';
-import { TotamjungTheme } from '@/types/totamjungTheme';
+import { TotamjungTheme } from '@/types/mainTheme';
 import {
   fetchTotamjungTheme,
   saveTotamjungTheme,

--- a/hooks/useTotamjungThemeState.ts
+++ b/hooks/useTotamjungThemeState.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { COMMANDS } from '@/constants/commands';
 import { isTotamjungTheme } from '@/domains/dataHandlers/validators/totamjungThemeValidator';
-import type { TotamjungTheme } from '@/types/totamjungTheme';
+import type { TotamjungTheme } from '@/types/mainTheme';
 import type { Storage } from 'wxt/browser';
 
 const useTotamjungThemeState = () => {

--- a/hooks/useTotamjungThemeState.ts
+++ b/hooks/useTotamjungThemeState.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { COMMANDS } from '@/constants/commands';
 import { isTotamjungTheme } from '@/domains/dataHandlers/validators/totamjungThemeValidator';
+import { isExternalThemeActive } from '@/domains/isExternalThemeActive';
 import type { TotamjungTheme } from '@/types/mainTheme';
 import type { Storage } from 'wxt/browser';
 
@@ -22,8 +23,10 @@ const useTotamjungThemeState = () => {
       return;
     }
 
-    const html = document.documentElement;
-    html.setAttribute('totamjungTheme', newValue);
+    if (!isExternalThemeActive()) {
+      const html = document.documentElement;
+      html.setAttribute('totamjungTheme', newValue);
+    }
 
     setTotamjungTheme(newValue);
   };

--- a/hooks/widget/useExternalThemeInfo.ts
+++ b/hooks/widget/useExternalThemeInfo.ts
@@ -1,0 +1,111 @@
+import { useState, useEffect } from 'react';
+import type { ExternalTheme } from '@/types/mainTheme';
+
+const isSolvedAcSite = location.href.startsWith('https://solved.ac/');
+
+const getExternalTheme = (): ExternalTheme | null => {
+  if (isSolvedAcSite) {
+    return getSolvedAcTheme();
+  }
+
+  return getBojExtendedTheme();
+};
+
+const getSolvedAcTheme = () => {
+  const solvedAcNavElement = document.getElementsByTagName('nav')[0];
+
+  if (!solvedAcNavElement) {
+    return null;
+  }
+
+  const navBackgroundColor =
+    window.getComputedStyle(solvedAcNavElement).backgroundColor;
+
+  if (navBackgroundColor === 'rgb(21, 32, 43)') {
+    return 'solvedAcDark';
+  }
+
+  if (navBackgroundColor === 'rgb(0, 0, 0)') {
+    return 'solvedAcBlack';
+  }
+
+  return 'solvedAcLight';
+};
+
+const getBojExtendedTheme = () => {
+  const bojExtendedTheme = document.documentElement.getAttribute('theme');
+
+  if (bojExtendedTheme === 'dark') {
+    return 'bojExtendedDark';
+  }
+
+  if (bojExtendedTheme === 'rigel') {
+    return 'bojExtendedRigel';
+  }
+
+  return null;
+};
+
+/**
+ * solved.ac, BOJ Extended 등 외부 요인의 테마를 불러올 수 있습니다. 테마가 적용되어 있지 않은 경우에는 `null`을 반환합니다.
+ */
+const useExternalThemeInfo = () => {
+  const [externalTheme, setExternalTheme] = useState<ExternalTheme | null>(
+    getExternalTheme(),
+  );
+
+  useEffect(() => {
+    if (isSolvedAcSite) {
+      return;
+    }
+
+    const bojExtendedThemeObserver = new MutationObserver(() => {
+      setExternalTheme(getBojExtendedTheme());
+    });
+
+    bojExtendedThemeObserver.observe(document.documentElement, {
+      attributes: true,
+    });
+
+    return () => {
+      bojExtendedThemeObserver.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isSolvedAcSite) {
+      return;
+    }
+
+    const solvedAcThemeObserver = new MutationObserver(() => {
+      setExternalTheme(getSolvedAcTheme());
+    });
+
+    const solvedAcNavObserver = new MutationObserver(() => {
+      const solvedAcNavElement = document.getElementsByTagName('nav')[0];
+
+      if (!solvedAcNavElement) {
+        return;
+      }
+
+      solvedAcNavObserver.disconnect();
+      solvedAcThemeObserver.observe(solvedAcNavElement, { attributes: true });
+    });
+
+    solvedAcNavObserver.observe(document.body, {
+      attributes: true,
+      childList: true,
+    });
+
+    return () => {
+      solvedAcThemeObserver.disconnect();
+      solvedAcNavObserver.disconnect();
+    };
+  }, []);
+
+  return {
+    externalTheme,
+  };
+};
+
+export default useExternalThemeInfo;

--- a/hooks/widget/useWidget.ts
+++ b/hooks/widget/useWidget.ts
@@ -112,6 +112,13 @@ const useWidget = (params: UseWidgetParams) => {
     loadWidgetData();
   }, []);
 
+  useEffect(() => {
+    document.documentElement.setAttribute(
+      'totamjungTheme',
+      theme === 'totamjung' ? 'totamjung' : 'none',
+    );
+  }, [theme]);
+
   const scrollToTop = () => {
     if (isScrollingToTop) {
       return;

--- a/hooks/widget/useWidget.ts
+++ b/hooks/widget/useWidget.ts
@@ -10,12 +10,12 @@ import useMouseLongPress from '@/hooks/useMouseLongPress';
 import { changeNormalToWarnTier } from '@/domains/tierHider/normalToWarnTierChanger';
 import { isShouldShowWelcomeMessage } from '@/domains/dataHandlers/validators/isShouldShowWelcomeMessageDataValidator';
 import type { ToastInfo } from '@/types/toast';
-import type { TotamjungTheme } from '@/types/totamjungTheme';
+import type { MainTheme, TotamjungTheme } from '@/types/mainTheme';
 import type { HiderOptions } from '@/types/algorithm';
 import { FilledSlot } from '@/types/randomDefense';
 
 interface UseWidgetParams {
-  theme: TotamjungTheme;
+  theme: MainTheme;
   onChangeTheme: (theme: TotamjungTheme) => void;
   onToast: (toastInfo: ToastInfo, duration: number) => void;
 }

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -151,7 +151,8 @@ export const theme = {
   solvedAcColor: {
     LIME: '#17ce3a',
     OFF_WHITE: '#f7f8f9',
-    LIGHT_GRAY: '#dddfe0',
+    LIGHT_GRAY: '#b8bcbf',
+    GRAY: '#8a8f95',
     INDIGO: '#15202b',
     DARK_INDIGO: '#0b131b',
   },
@@ -168,6 +169,8 @@ export const theme = {
 
   solvedAcFilter: {
     LIME: 'brightness(0) saturate(100%) invert(60%) sepia(34%) saturate(3800%) hue-rotate(87deg) brightness(105%) contrast(86%)',
+    LIGHT_GRAY:
+      'brightness(0) saturate(100%) invert(79%) sepia(4%) saturate(201%) hue-rotate(163deg) brightness(94%) contrast(93%)',
   },
 
   bojExtendedFilter: {
@@ -175,6 +178,8 @@ export const theme = {
       'brightness(0) saturate(100%) invert(31%) sepia(0%) saturate(1005%) hue-rotate(147deg) brightness(100%) contrast(88%)',
     SKY_BLUE:
       'brightness(0) saturate(100%) invert(31%) sepia(81%) saturate(2692%) hue-rotate(171deg) brightness(96%) contrast(101%)',
+    LIGHT_GRAY:
+      'brightness(0) saturate(100%) invert(76%) sepia(5%) saturate(94%) hue-rotate(155deg) brightness(86%) contrast(88%)',
   },
 };
 

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -156,7 +156,7 @@ export const theme = {
   },
 
   bojExtendedColor: {
-    DARK_SKY_BLUE: '#008db4',
+    SKY_BLUE: '#008db4',
     DARK_INDIGO: '#001a26',
     DARK_GRAY: '#545454',
     LIGHT_GRAY: '#a2a4a5',
@@ -169,7 +169,7 @@ export const theme = {
   bojExtendedFilter: {
     DARK_GRAY:
       'brightness(0) saturate(100%) invert(31%) sepia(0%) saturate(1005%) hue-rotate(147deg) brightness(100%) contrast(88%)',
-    DARK_SKY_BLUE:
+    SKY_BLUE:
       'brightness(0) saturate(100%) invert(31%) sepia(81%) saturate(2692%) hue-rotate(171deg) brightness(96%) contrast(101%)',
   },
 };

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -151,8 +151,9 @@ export const theme = {
   solvedAcColor: {
     LIME: '#17ce3a',
     OFF_WHITE: '#f7f8f9',
-    LIGHT_GRAY: '#b8bcbf',
     GRAY: '#8a8f95',
+    LIGHT_GRAY: '#b8bcbf',
+    LIGHTER_GRAY: '#dddfe0',
     INDIGO: '#15202b',
     DARK_INDIGO: '#0b131b',
   },

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -152,13 +152,17 @@ export const theme = {
     LIME: '#17ce3a',
     OFF_WHITE: '#f7f8f9',
     LIGHT_GRAY: '#dddfe0',
+    INDIGO: '#15202b',
     DARK_INDIGO: '#0b131b',
   },
 
   bojExtendedColor: {
     SKY_BLUE: '#008db4',
+    DARK_SKY_BLUE: '#002635',
     DARK_INDIGO: '#001a26',
     DARK_GRAY: '#545454',
+    DARKER_GRAY: '#202020',
+    DARKEST_GRAY: '#161616',
     LIGHT_GRAY: '#a2a4a5',
   },
 

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -147,6 +147,31 @@ export const theme = {
     LIGHT_GRAY_FILTER:
       'brightness(0) saturate(100%) invert(86%) sepia(0%) saturate(1969%) hue-rotate(175deg) brightness(78%) contrast(96%)',
   },
+
+  solvedAcColor: {
+    LIME: '#17ce3a',
+    OFF_WHITE: '#f7f8f9',
+    LIGHT_GRAY: '#dddfe0',
+    DARK_INDIGO: '#0b131b',
+  },
+
+  bojExtendedColor: {
+    DARK_SKY_BLUE: '#008db4',
+    DARK_INDIGO: '#001a26',
+    DARK_GRAY: '#545454',
+    LIGHT_GRAY: '#a2a4a5',
+  },
+
+  solvedAcFilter: {
+    LIME: 'brightness(0) saturate(100%) invert(60%) sepia(34%) saturate(3800%) hue-rotate(87deg) brightness(105%) contrast(86%)',
+  },
+
+  bojExtendedFilter: {
+    DARK_GRAY:
+      'brightness(0) saturate(100%) invert(31%) sepia(0%) saturate(1005%) hue-rotate(147deg) brightness(100%) contrast(88%)',
+    DARK_SKY_BLUE:
+      'brightness(0) saturate(100%) invert(31%) sepia(81%) saturate(2692%) hue-rotate(171deg) brightness(96%) contrast(101%)',
+  },
 };
 
 export type Theme = typeof theme;

--- a/types/mainTheme.ts
+++ b/types/mainTheme.ts
@@ -1,0 +1,9 @@
+export type TotamjungTheme = 'none' | 'totamjung';
+
+export type BojExtendedTheme = 'bojExtendedDark' | 'bojExtendedRigel';
+
+export type SolvedAcTheme = 'solvedAcLight' | 'solvedAcDark' | 'solvedAcBlack';
+
+export type ExternalTheme = BojExtendedTheme | SolvedAcTheme;
+
+export type MainTheme = TotamjungTheme | ExternalTheme;

--- a/types/options.ts
+++ b/types/options.ts
@@ -1,7 +1,7 @@
 import { STORAGE_KEY } from '@/constants/commands';
 import type { CheckedAlgorithmIds } from '@/types/algorithm';
 import type { QuickSlots } from '@/types/randomDefense';
-import type { TotamjungTheme } from '@/types/totamjungTheme';
+import type { TotamjungTheme } from '@/types/mainTheme';
 import type { HiderOptions } from '@/types/algorithm';
 import type { RandomDefenseHistoryResponse } from '@/types/randomDefense';
 import type { FontNo } from '@/types/font';

--- a/types/totamjungTheme.ts
+++ b/types/totamjungTheme.ts
@@ -1,1 +1,0 @@
-export type TotamjungTheme = 'none' | 'totamjung';

--- a/utils/getTransparentHexColor.test.ts
+++ b/utils/getTransparentHexColor.test.ts
@@ -1,0 +1,45 @@
+import { getTransparentHexColor } from './getTransparentHexColor';
+
+describe('Test #1 - 색상 반환 테스트', () => {
+  test.each([
+    ['#ff0000', 1, '#ff0000ff'],
+    ['#00ff00', 0.5, '#00ff0080'],
+    ['#0000ff', 0, '#0000ff00'],
+    ['#123456', 0.25, '#12345640'],
+    ['#abcdef', 0.75, '#abcdefbf'],
+  ])(
+    '색상 코드가 %s이고 투명도가 %f일 경우 에러 없이 %s를 반환해야 한다.',
+    (hex, opacity, expected) => {
+      expect(getTransparentHexColor(hex, opacity)).toBe(expected);
+    },
+  );
+});
+
+describe('Test #2 - 예외 처리 테스트', () => {
+  describe('잘못된 색상 포맷이 주어졌을 경우', () => {
+    test.each([
+      '#FFF',
+      '#12345',
+      '#1234567',
+      '123456',
+      '#ABCDEF',
+      '#gggggg',
+      'red',
+    ])('색상 코드가 %s라면 관련 에러가 발생해야 한다.', (invalidHex) => {
+      expect(() => getTransparentHexColor(invalidHex, 0.5)).toThrow(
+        '잘못된 색상 코드입니다. 색상 코드는 6자리의 HEX 형식의 코드여야 하며, 숫자 및 영소문자로만 구성되어야 합니다.',
+      );
+    });
+  });
+
+  describe('잘못된 투명도가 주어졌을 경우', () => {
+    test.each([-0.1, 1.1, 2, NaN])(
+      '투명도가 %f라면 관련 에러가 발생해야 한다.',
+      (invalidOpacity) => {
+        expect(() => getTransparentHexColor('#123456', invalidOpacity)).toThrow(
+          '투명도는 반드시 0 이상 1 이하의 수여야 합니다.',
+        );
+      },
+    );
+  });
+});

--- a/utils/getTransparentHexColor.ts
+++ b/utils/getTransparentHexColor.ts
@@ -1,0 +1,26 @@
+const hexRegex = /^#([0-9a-f]{6})$/;
+
+export const getTransparentHexColor = (
+  hexColor: string,
+  opacity: number,
+): string => {
+  if (!hexRegex.test(hexColor)) {
+    throw new Error(
+      '잘못된 색상 코드입니다. 색상 코드는 6자리의 HEX 형식의 코드여야 하며, 숫자 및 영소문자로만 구성되어야 합니다.',
+    );
+  }
+
+  if (isNaN(opacity) || opacity < 0 || opacity > 1) {
+    throw new Error('투명도는 반드시 0 이상 1 이하의 수여야 합니다.');
+  }
+
+  const red = parseInt(hexColor.slice(1, 3), 16);
+  const green = parseInt(hexColor.slice(3, 5), 16);
+  const blue = parseInt(hexColor.slice(5, 7), 16);
+
+  const opacityHex = Math.round(opacity * 255)
+    .toString(16)
+    .padStart(2, '0');
+
+  return `#${[red, green, blue].map((hex) => hex.toString(16).padStart(2, '0')).join('')}${opacityHex}`;
+};

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     web_accessible_resources: [
       {
         resources: ['/*'],
-        matches: ['https://www.acmicpc.net/*'],
+        matches: ['https://www.acmicpc.net/*', 'https://solved.ac/*'],
       },
     ],
   },


### PR DESCRIPTION
## 관련 이슈
- closes https://github.com/wzrabbit/boj-totamjung/issues/155

## PR 설명
본 PR에서는 아래의 작업들을 수행했습니다.

### 1️⃣ solved.ac 지원
- 이제 BOJ 뿐만 아니라 [solved.ac](https://solved.ac/) 에서도 토탐정을 사용할 수 있도록 변경했습니다. 이에 따라 토탐정 위젯이 보이게 됩니다. solved.ac에서는 **랜덤 디펜스 및 즉석 추첨 기능**만을 이용할 수 있습니다.

### 2️⃣ 외부 서비스의 테마에 대응
토탐정 테마는 아무 테마가 적용되어 있지 않은 BOJ 웹사이트에서만 작동하도록 설계되었습니다. 그렇기 때문에 현재 사용자가 머무르고 있는 페이지가 BOJ가 아니거나, 이미 다른 테마가 켜져 있는 상태에서 토탐정 테마가 켜질 경우 UI가 깨지거나 오작동을 할 수 있습니다. 그렇기 때문에 의도를 벗어나는 상황에서 토탐정 테마를 비활성화해야 했습니다. 또한, 활성화된 외부 테마에 맞춰 토탐정의 위젯의 색상을 변경한다면 더 어울릴 것이며 다른 서비스와 병행해서 토탐정을 사용하기에 적합할 것입니다.

- 이제 토탐정 테마는 아래의 상황에서 자동으로 비활성화되며, 테마 변경 메뉴 또한 비활성화됩니다.
  1. BOJ Extended가 설치되어 있고 BOJ Extended의 테마가 적용 중인 경우.
  2. solved.ac 페이지 내에 사용자가 머무르고 있는 경우. 

- 위의 상황으로 토탐정 테마가 비활성화되어 있다면, 토탐정 위젯은 활성화된 테마에 맞게 토탐정 위젯을 포함해 UI의 색상이 변경됩니다. 아래는 영향을 받는 UI들입니다.
  1. 토탐정 위젯
  2. 최초 설치 시 보이는 안내 말풍선
  3. 문제 조사 결과 아이콘
  4. 토스트
  5. 즉석 추첨 문제 수 선택 모달
  6. 즉석 추첨 모달

## 스크린샷 📸 

### 1️⃣ 토탐정 위젯

<img src="https://github.com/user-attachments/assets/1b7d6637-1b14-45fb-b760-4dc7dbbf99f5" width="300px" />

### 2️⃣ 안내 말풍선

![image](https://github.com/user-attachments/assets/47a7c05b-b58e-4d99-be24-67d87029d810)


### 3️⃣ 문제 조사 결과 아이콘 및 토스트

![image](https://github.com/user-attachments/assets/ed419c8b-777d-46c3-89c9-90816152d749)


### 4️⃣ 즉석 추첨 문제 수 선택 모달

![image](https://github.com/user-attachments/assets/6c8f193c-0468-4d40-8e4f-8e6df69e4a21)

### 5️⃣ 즉석 추첨 모달

![image](https://github.com/user-attachments/assets/dd848979-fcea-4585-b47d-11fd5335bdd0)
