### PR TITLE
[FIX] 즉석 추첨으로 여러 문제를 추첨 기록에 저장 시 반대 순서로 저장되는 문제를 해결

### DIFF
--- a/hooks/gacha/useRandomDefenseGachaModal.ts
+++ b/hooks/gacha/useRandomDefenseGachaModal.ts
@@ -170,10 +170,12 @@ const useRandomDefenseGachaModal = (
 
   const saveGachaResultToStorage = () => {
     const currentIsoString = new Date().toISOString();
-    const randomDefenseHistoryInfos = problemInfos.map((problemInfo) => ({
-      ...problemInfo,
-      createdAt: currentIsoString,
-    }));
+    const randomDefenseHistoryInfos = problemInfos
+      .map((problemInfo) => ({
+        ...problemInfo,
+        createdAt: currentIsoString,
+      }))
+      .reverse();
 
     browser.runtime.sendMessage({
       command: COMMANDS.ADD_RANDOM_DEFENSE_HISTORY_INFOS,


### PR DESCRIPTION
## PR 설명
본 PR에서는 즉석 추첨으로 여러 문제를 추첨 기록에 저장 시 반대 순서로 저장되는 문제를 해결했습니다.