### PR TITLE
[FIX] 단축키 사용 시 두 번째 시도부터 랜덤 디펜스/즉석 추첨이 작동하지 않는 문제 해결

### DIFF
--- a/hooks/useHotkeyLongPress.ts
+++ b/hooks/useHotkeyLongPress.ts
@@ -136,6 +136,9 @@ const useHotKeyLongPress = (params: UseHotkeyLongPressParams) => {
    */
   const unlockHotkey = () => {
     setIsHotkeyLocked(false);
+    pressingBaseKeyRef.current = null;
+    pressingNumberKeyRef.current = null;
+    isHotkeyPressingRef.current = false;
   };
 
   useEffect(() => {
@@ -146,6 +149,7 @@ const useHotKeyLongPress = (params: UseHotkeyLongPressParams) => {
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('keyup', handleKeyUp);
+      clearTimeout(keyPressTimerRef.current);
     };
   }, [initBaseKey, isHotkeyLocked]);
 

--- a/hooks/widget/useRandomDefense.ts
+++ b/hooks/widget/useRandomDefense.ts
@@ -19,7 +19,7 @@ const useRandomDefense = (params: UseRandomDefenseParams) => {
     useState(false);
   const isRandomDefenseAvailableRef = useRef(isRandomDefenseAvailable);
   const quickSlotsRef = useRef<QuickSlots>(DEFAULT_QUICK_SLOTS);
-  useHotKeyLongPress({
+  const { unlockHotkey } = useHotKeyLongPress({
     baseKey: quickSlotsRef.current.hotkey,
     requiredLongPressTimeInMilliseconds: 1000,
     onPress: (numberKey) => performRandomDefense(numberKey, 'press'),
@@ -179,6 +179,7 @@ const useRandomDefense = (params: UseRandomDefenseParams) => {
   const enableRandomDefense = () => {
     isRandomDefenseAvailableRef.current = true;
     setIsRandomDefenseAvailable(true);
+    unlockHotkey();
   };
 
   /**


### PR DESCRIPTION
## 관련 이슈
- #76 

## PR 설명
본 PR에서는 아래의 버그를 해결했습니다.
- 단축키를 사용하여 랜덤 디펜스 / 즉석 추첨을 진행할 시, 두 번째 단축키 작동부터 실행되지 않는 문제를 해결했습니다. 다르게 말하면, 단축키를 길게 눌러 즉석 추첨을 켰다가 끈 후, 다시 단축키를 누르거나 길게 누를 경우 작동하지 않는 문제를 해결했습니다.

단축키 랜덤 디펜스 기능 개조 과정에서 생긴 버그이므로 이미 배포된 `v1.2.*` 버전에는 해당되지 않는 버그입니다.