### PR TITLE
✨ feat: 알고리즘 분류 `"브루트포스 알고리즘"` 에 `"무차별 대입"`, `"무차별 대입"` 별명을 추가

### DIFF
--- a/constants/algorithmInfos.ts
+++ b/constants/algorithmInfos.ts
@@ -49,7 +49,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
     name: '브루트포스 알고리즘',
     englishName: 'Bruteforcing',
     tag: 'bruteforcing',
-    alias: ['brute force'],
+    alias: ['brute force', '무차별 대입', '무작위 대입'],
   },
   {
     id: 9,


### PR DESCRIPTION
## PR 설명
본 PR에서는 알고리즘 분류 데이터에서 아래의 변경사항을 냈습니다.
- `"브루트포스 알고리즘"` 알고리즘에 `"무차별 대입"`, `"무차별 대입"` 별명을 추가