### PR TITLE
[FIX] 단축키 설정과 관계없이 랜덤 디펜스 단축키가 Alt로 고정되는 문제를 해결

### DIFF
--- a/hooks/useHotkeyLongPress.ts
+++ b/hooks/useHotkeyLongPress.ts
@@ -143,6 +143,9 @@ const useHotKeyLongPress = (params: UseHotkeyLongPressParams) => {
 
   useEffect(() => {
     setBaseKey(initBaseKey);
+  }, [initBaseKey]);
+
+  useEffect(() => {
     document.addEventListener('keydown', handleKeyDown);
     document.addEventListener('keyup', handleKeyUp);
 
@@ -151,7 +154,7 @@ const useHotKeyLongPress = (params: UseHotkeyLongPressParams) => {
       document.removeEventListener('keyup', handleKeyUp);
       clearTimeout(keyPressTimerRef.current);
     };
-  }, [initBaseKey, isHotkeyLocked]);
+  }, [baseKey, isHotkeyLocked]);
 
   return { unlockHotkey };
 };


### PR DESCRIPTION
## PR 설명

본 PR에서는 아래의 버그를 해결했습니다.

- 단축키 설정과 관계없이 랜덤 디펜스 단축키가 Alt로 고정되는 문제를 해결했습니다. F2로 설정되어 있다 하더라도 Alt키로만 랜덤 디펜스를 진행할 수 있는 버그가 있었습니다.