### PR TITLE
[FEAT] 채점 결과 텍스트의 색상을 밝게 변경하여 가시성 향상

### DIFF
--- a/assets/css/totamjungTheme.css
+++ b/assets/css/totamjungTheme.css
@@ -535,16 +535,75 @@ html[totamjungTheme='totamjung'] .blog-twitter-inner:hover::after {
   border-right: 25px solid transparent;
 }
 
-html[totamjungTheme='totamjung'] .result-ac {
-  color: rgb(0, 152, 116);
+html[totamjungTheme='totamjung'] .result-wait,
+html[totamjungTheme='totamjung'] .result-rejudge-wait,
+html[totamjungTheme='totamjung'] .result-no-judge {
+  color: #cfcfcf;
 }
 
-html[totamjungTheme='totamjung'] .result-pac {
-  color: rgb(239, 192, 80);
+html[totamjungTheme='totamjung'] .result-compile,
+html[totamjungTheme='totamjung'] .result-judging {
+  color: #ff9e48;
 }
 
-html[totamjungTheme='totamjung'] .result-wa {
-  color: rgb(221, 65, 36);
+html[totamjungTheme='totamjung'] .result-compile,
+html[totamjungTheme='totamjung'] .result-judging {
+  color: #ff9e48;
+}
+
+html[totamjungTheme='totamjung'] .result-ac,
+html[totamjungTheme='totamjung'] .result-ac:hover,
+html[totamjungTheme='totamjung'] .result-ac:active,
+html[totamjungTheme='totamjung'] .result-ac:focus {
+  color: #57ffa9;
+  text-decoration-color: #57ffa9;
+}
+
+html[totamjungTheme='totamjung'] td.result > .result-ac {
+  background-clip: text !important;
+  -webkit-background-clip: text !important;
+  color: transparent;
+  background: linear-gradient(to right, #5cff9c, #57ffe9);
+}
+
+html[totamjungTheme='totamjung'] td.result > .result-ac > a {
+  text-decoration: underline;
+}
+
+html[totamjungTheme='totamjung'] .result-pac,
+html[totamjungTheme='totamjung'] .result-pac:hover,
+html[totamjungTheme='totamjung'] .result-pac:active,
+html[totamjungTheme='totamjung'] .result-pac:focus {
+  color: #ffe199;
+  text-decoration-color: #ffe199;
+}
+
+html[totamjungTheme='totamjung'] .result-wa,
+html[totamjungTheme='totamjung'] .result-wa:hover,
+html[totamjungTheme='totamjung'] .result-wa:active,
+html[totamjungTheme='totamjung'] .result-wa:focus {
+  color: #ff684a;
+}
+
+html[totamjungTheme='totamjung'] .result-pe,
+html[totamjungTheme='totamjung'] .result-tle,
+html[totamjungTheme='totamjung'] .result-mle,
+html[totamjungTheme='totamjung'] .result-ole {
+  color: #ff9d95;
+}
+
+html[totamjungTheme='totamjung'] .result-rte {
+  color: #b290ff;
+}
+
+html[totamjungTheme='totamjung'] .result-ce {
+  color: #4e93cf;
+}
+
+html[totamjungTheme='totamjung'] .kb-text::after,
+html[totamjungTheme='totamjung'] .ms-text::after,
+html[totamjungTheme='totamjung'] .b-text::after {
+  color: #ff684a !important;
 }
 
 html[totamjungTheme='totamjung'] #favorite_button,


### PR DESCRIPTION
## PR 설명

본 PR에서는 채점 결과 텍스트의 색상을 보다 밝게 설정해, 어두운 토탐정 테마 속에서 결과가 보다 잘 보이도록 개선했습니다.

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/ff888575-22bb-48f2-931b-c24871730f9c" />
