### PR TITLE
[FIX] 백준의 "추가된 문제" 페이지에서 티어 가리개가 작동하지 않는 문제를 해결

### DIFF
--- a/assets/css/tierHider.css
+++ b/assets/css/tierHider.css
@@ -322,6 +322,59 @@ html[hideTier='loading']
 }
 
 /**
+* 출처 페이지의 "추가된 문제" 페이지에서 문제 목록의 티어를 가리기 위한 스타일입니다.
+*/
+html[hideTier='true']
+  .row:has(li[class='active'] > a[href='/problem/added'])
+  ~ .row
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  > td:nth-child(2)
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='true']
+  .row:has(li[class='active'] > a[href='/problem/added'])
+  ~ .row
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  > td:nth-child(2)
+  > .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
+html[hideTier='revealOnHover']
+  .row:has(li[class='active'] > a[href='/problem/added'])
+  ~ .row
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  > td:nth-child(2)
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='revealOnHover']
+  .row:has(li[class='active'] > a[href='/problem/added'])
+  ~ .row
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  > td:nth-child(2)
+  > .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
+html[hideTier='loading']
+  .row:has(li[class='active'] > a[href='/problem/added'])
+  ~ .row
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  > td:nth-child(2)
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  opacity: 0;
+}
+
+/**
 * 문제집 페이지에서 문제 티어를 가리기 위한 스타일입니다.
 */
 html[hideTier='true']

--- a/domains/tierHider/normalToWarnTierChanger.ts
+++ b/domains/tierHider/normalToWarnTierChanger.ts
@@ -25,6 +25,7 @@ const TIER_BADGE_CSS_SELECTORS = [
   ".col-md-12:has(a[href='/board/list/solvedac']) ~ .col-md-12 .table.table-bordered.table-striped td:nth-child(2):not(:has(.result-ac)) > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg'])",
   ".nav.nav-pills.no-print.problem-menu:not(:has(a[href^=\"https://solved.ac/contribute/\"])) .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg'])",
   ".row:has(li[class='active'] > a[href='/category']) ~ .row .table.table-bordered.table-striped tr:not(:has(.problem-label-ac)) > td:nth-child(3) > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg'])",
+  ".row:has(li[class='active'] > a[href='/problem/added']) ~ .row .table.table-bordered.table-striped tr:not(:has(.problem-label-ac)) > td:nth-child(2) > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg'])",
   ".col-md-12:has(a[href='/workbook/top']) ~ .col-md-12 .table.table-bordered.table-striped tr:not(:has(.problem-label-ac)) td:nth-child(2) > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg'])",
 ] as const;
 


### PR DESCRIPTION
## PR 설명
본 PR에서는 백준의 "추가된 문제" 페이지에서 티어 가리개가 작동하지 않는 문제를 해결했습니다.
- https://www.acmicpc.net/problem/added

새롭게 변경된 레이아웃으로 기존 로직이 동작하지 않게 되었으며, 새롭게 변경된 레이아웃을 기준으로 다시 CSS 선택자를 작성하여 해결했습니다.