### PR TITLE
[FEAT] 랜덤 디펜스/즉석 추첨 시 403 에러가 발생하는 경우 그에 맞는 에러 메시지를 보여주도록 개선

### DIFF
--- a/domains/randomDefense/randomDefenseProblemChooser.ts
+++ b/domains/randomDefense/randomDefenseProblemChooser.ts
@@ -24,6 +24,17 @@ export const getRandomDefenseResult = async (
         };
       }
 
+      if (response.status === 403) {
+        return {
+          success: false,
+          errorMessage: '문제 추첨 중 에러가 발생했습니다.',
+          errorDescriptions: [
+            '현재 접속하신 IP에서는 솔브드 API를 이용하실 수 없도록 차단되어 있습니다.',
+            'VPN을 사용하고 계시다면 VPN을 끄신 후 다시 시도해 주세요.',
+          ],
+        };
+      }
+
       if (response.status === 429) {
         return {
           success: false,


### PR DESCRIPTION
## PR 설명
본 PR에서는 랜덤 디펜스/즉석 추첨 시 403 에러가 발생하는 경우 그에 맞는 에러 메시지를 보여주도록 개선했습니다.
- 기존의 경우 403 에러는 발생할 수 있는 에러라고 생각하지 않았기에 "토탐정이 모르는 에러입니다. Status Code는 403입니다." 와 같은 기본 에러 메시지를 보여주었습니다.

## 스크린샷
- 즉석 추첨 시
<img width="700" alt="image" src="https://github.com/user-attachments/assets/4976b585-5e6b-4708-8d5f-fc1d112287fe" />

- 랜덤 디펜스 진행 시
<img width="350" alt="image" src="https://github.com/user-attachments/assets/c8c04c04-9590-439d-95f1-d6109d885eaa" />
