### PR TITLE
[CHORE] 개발 서버 실행 시마다 백준, 솔브드 웹사이트를 자동으로 열도록 설정

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -22,4 +22,7 @@ export default defineConfig({
       },
     ],
   },
+  webExt: {
+    startUrls: ['https://solved.ac', 'https://www.acmicpc.net'],
+  },
 });


### PR DESCRIPTION
## PR 설명
본 PR에서는 토탐정 개발 서버를 켤 경우 열리는 브라우저에서 백준, 솔브드 두 사이트가 자동으로 열리도록 설정했습니다.

## 참고 자료
- https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#start-url