### PR TITLE
[FIX] 티어 가리개가 그룹 문제집 페이지에서 작동하지 않는 문제를 해결

### DIFF
--- a/assets/css/tierHider.css
+++ b/assets/css/tierHider.css
@@ -428,6 +428,59 @@ html[hideTier='loading']
 }
 
 /**
+* 그룹 문제집 페이지에서 맞추지 않은 문제의 티어를 가리기 위한 스타일입니다.
+*/
+html[hideTier='true']
+  .col-md-12:has(a[href^='/group/workbook'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  td:nth-child(2)
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='true']
+  .col-md-12:has(a[href^='/group/workbook'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  td:nth-child(2)
+  > .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
+html[hideTier='revealOnHover']
+  .col-md-12:has(a[href^='/group/workbook'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  td:nth-child(2)
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-hidden.svg');
+}
+
+html[hideTier='revealOnHover']
+  .col-md-12:has(a[href^='/group/workbook'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  td:nth-child(2)
+  > .solvedac-tier.warn:not([src*='/0.svg']):not([src*='/-1.svg']):not(:hover) {
+  content: url('/public/solvedac-tier-warn.svg');
+}
+
+html[hideTier='loading']
+  .col-md-12:has(a[href^='/group/workbook'])
+  ~ .col-md-12
+  .table.table-bordered.table-striped
+  tr:not(:has(.problem-label-ac))
+  td:nth-child(2)
+  > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg']) {
+  opacity: 0;
+}
+
+/**
 * BOJ Extended의 유저 프로필 페이지에서 맞추지 않은 문제의 티어를 가리기 위한 스타일입니다.
 */
 html[hideTier='true']

--- a/domains/tierHider/normalToWarnTierChanger.ts
+++ b/domains/tierHider/normalToWarnTierChanger.ts
@@ -27,6 +27,7 @@ const TIER_BADGE_CSS_SELECTORS = [
   ".row:has(li[class='active'] > a[href='/category']) ~ .row .table.table-bordered.table-striped tr:not(:has(.problem-label-ac)) > td:nth-child(3) > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg'])",
   ".row:has(li[class='active'] > a[href='/problem/added']) ~ .row .table.table-bordered.table-striped tr:not(:has(.problem-label-ac)) > td:nth-child(2) > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg'])",
   ".col-md-12:has(a[href='/workbook/top']) ~ .col-md-12 .table.table-bordered.table-striped tr:not(:has(.problem-label-ac)) td:nth-child(2) > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg'])",
+  ".col-md-12:has(a[href^='/group/workbook']) ~ .col-md-12 .table.table-bordered.table-striped tr:not(:has(.problem-label-ac)) td:nth-child(2) > .solvedac-tier:not([src*='/0.svg']):not([src*='/-1.svg'])",
 ] as const;
 
 const TIER_TEXT_CSS_SELECTOR =


### PR DESCRIPTION
## PR 설명
본 PR에서는 "그룹 문제집" 페이지에서 티어 가리개가 작동하지 않는 문제를 해결했습니다.

티어 가리개의 경우 문제가 나타나는 모든 페이지를 찾아 CSS 스타일 및 이미지를 덮어씌우는 방식인지라, 찾지 못한 페이지의 경우 이 문제가 생기곤 합니다.

해당 페이지의 URL 형식은 `https://www.acmicpc.net/group/workbook/view/*`입니다.

## 스크린샷
<img width="1570" height="763" alt="image" src="https://github.com/user-attachments/assets/bab386e0-ccb3-4752-bde4-868f492656d2" />
