### PR TITLE
[FEAT] 2개의 알고리즘 분류명을 수정

### DIFF
--- a/constants/algorithmInfos.ts
+++ b/constants/algorithmInfos.ts
@@ -456,7 +456,7 @@ export const ALGORITHM_INFOS: Readonly<AlgorithmInfo[]> = [
   {
     id: 67,
     name: '접미사 배열과 lcp 배열',
-    englishName: 'Suffix ARray And Lcp Array',
+    englishName: 'Suffix Array And Lcp Array',
     tag: 'suffix_array',
     alias: ['서픽스 어레이'],
   },


### PR DESCRIPTION
## 관련 이슈
- #201 

## PR 설명
본 PR에서는 알고리즘 분류 데이터에서 아래의 변경사항을 냈습니다.
- (알고리즘명 수정) `"키타마사"` $\rightarrow$ `"다항식을 이용한 선형점화식 계산"`
- (알고리즘의 영문명 수정) `"Suffix ARray And Lcp Array"` $\rightarrow$ `"Suffix Array And Lcp Array"`