### PR TITLE
[FIX] 배추, BOJ Verdict Beautify과 원활하게 호환되도록 스타일 수정

### DIFF
--- a/assets/css/totamjungTheme.css
+++ b/assets/css/totamjungTheme.css
@@ -2655,3 +2655,10 @@ html[totamjungTheme='totamjung'] .label.baechu-label-background {
 html[totamjungTheme='totamjung'] .problem-label.problem-label-tr {
   background: var(--label-purple-gradient-color);
 }
+
+/* FOR BOJ Verdict Beautify */
+html[totamjungtheme='totamjung'] td.result > .result-ac.b-result-ac {
+  background: linear-gradient(130deg, rgb(50, 203, 62), rgb(6, 160, 98));
+  background-clip: initial !important;
+  -webkit-background-clip: initial !important;
+}


### PR DESCRIPTION
## PR 설명
본 PR에서는 배추, BOJ Verdict Beautify 확장 프로그램에서 토탐정과 충돌하는 스타일을 확인하고 원활하게 호환되도록 스타일을 수정했습니다.

### 1️⃣ 배추
배경, 뱃지 레이블에 테마가 적용되지 않는 문제를 해결했습니다. 배추 확장 프로그램의 업데이트로 레이블을 가리키는 클래스명이 바뀐 것이 원인이었습니다.

### 2️⃣ BOJ Verdict Beautify
채점 결과 AC 레이블의 배경색이 투명한 문제를 해결했습니다. 본래 맞았습니다!! 가 채점 결과일 경우 토탐정에서 그라데이션 색상으로 변경하고 여러 설정을 변경한 것이 충돌의 원인으로, 해당 확장 프로그램의 AC 레이블에 한해 스타일을 초기화하는 코드를 추가했습니다.

## 스크린샷
<img width="1219" height="212" alt="image" src="https://github.com/user-attachments/assets/092f7995-27fa-41c0-a7fc-206beda1a100" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/6a04e41b-881f-44f4-a4fb-1020f23cb7ab" />
