### PR TITLE
[FIX] 문제를 이미 푼 상황에서도 출처 가리개가 동작하는 문제를 해결

### DIFF
--- a/assets/css/sourceHider.css
+++ b/assets/css/sourceHider.css
@@ -1,7 +1,7 @@
 /**
  * 문제 페이지의 출처 섹션을 가리기 위한 스타일입니다.
  */
-html[hideSource='true']
+html[hideSource='true']:not(:has(.problem-label-ac))
   section#source
   > *:not(.headline):not(.totamjung-source-toggle) {
   display: none;

--- a/entrypoints/injectionScript.content.ts
+++ b/entrypoints/injectionScript.content.ts
@@ -82,6 +82,14 @@ const injectSourceToggleButton = (htmlElement: HTMLElement) => {
 
     observer.disconnect();
 
+    const isSolved = document.querySelector(
+      '.page-header:has(#problem_title) .problem-label-ac',
+    );
+
+    if (isSolved) {
+      return;
+    }
+
     const headline = sourceSection.querySelector('.headline');
     const wrapper = document.createElement('p');
     wrapper.className = 'totamjung-source-toggle';


### PR DESCRIPTION
## PR 설명
본 PR에서는 문제를 이미 푼 상황에서도 출처 가리개가 동작하는 문제를 해결했습니다.
- 문제를 이미 맞춘 사용자에게는 스포일러의 의미가 없으므로 모든 가리개가 비활성화되는 것이 의도입니다.

배포 전 까먹은 요구사항으로, 핫픽스로 `main`에 바로 머지 진행하겠습니다.