### PR TITLE
[FIX] 즉석 추첨에서 "추첨 기록 저장" 을 눌렀을 때 확률적으로 저장이 안 되는 문제를 해결

### DIFF
--- a/entrypoints/background/main.ts
+++ b/entrypoints/background/main.ts
@@ -301,7 +301,12 @@ const executeBackground = () => {
           return;
         }
 
-        addRandomDefenseInfosToHistory(message.randomDefenseHistoryInfos);
+        addRandomDefenseInfosToHistory(message.randomDefenseHistoryInfos).then(
+          () => {
+            sendResponse();
+          },
+        );
+        return true;
       }
 
       if (command === COMMANDS.FETCH_SHOULD_SHOW_WELCOME_MESSAGE) {

--- a/hooks/gacha/useRandomDefenseGachaModal.ts
+++ b/hooks/gacha/useRandomDefenseGachaModal.ts
@@ -168,7 +168,7 @@ const useRandomDefenseGachaModal = (
     setNotificationMessage('');
   };
 
-  const saveGachaResultToStorage = () => {
+  const saveGachaResultToStorage = async () => {
     const currentIsoString = new Date().toISOString();
     const randomDefenseHistoryInfos = problemInfos
       .map((problemInfo) => ({
@@ -177,7 +177,7 @@ const useRandomDefenseGachaModal = (
       }))
       .reverse();
 
-    browser.runtime.sendMessage({
+    await browser.runtime.sendMessage({
       command: COMMANDS.ADD_RANDOM_DEFENSE_HISTORY_INFOS,
       randomDefenseHistoryInfos,
     });


### PR DESCRIPTION
  ## PR 설명
  본 PR에서는 즉석 추첨에서 "추첨 기록 저장" 을 눌렀을 때 확률적으로 저장이 안 되는 문제를 해결했습니다.
  
  - `async`, `await` 미사용이 문제였습니다.
  - 즉석 추첨 기록 저장 시 background 메시지 리스너에서 return true 없이 비동기 작업을 수행하여, Chrome이 메시지 채널을 조기에 닫기에 이 타이밍이 어긋나면 저장이 확률적으로 실패하는 것입니다.
  - Background에서 비동기 응답을 선언(return true)하고 저장 완료 후 `sendResponse()`를 호출하도록 수정하며, sender 쪽에서도 await으로 응답을 기다리도록 변경하여 문제를 해결했습니다.