### PR TITLE
[FIX] 토탐정 테마 변경 시 즉시 테마가 반영되지 않는 문제를 해결

### DIFF
--- a/hooks/useTotamjungThemeState.ts
+++ b/hooks/useTotamjungThemeState.ts
@@ -13,11 +13,11 @@ const useTotamjungThemeState = () => {
     changes: { [key: string]: Browser.storage.StorageChange },
     areaName: string,
   ) => {
-    if (areaName !== 'local' || !('totamjungTheme' in changes)) {
+    if (areaName !== 'local' || !('theme' in changes)) {
       return;
     }
 
-    const { newValue } = changes.totamjungTheme;
+    const { newValue } = changes.theme;
 
     if (!isTotamjungTheme(newValue)) {
       return;


### PR DESCRIPTION
## PR 설명

본 PR에서는 토탐정 테마 변경 시 즉시 테마가 반영되지 않는 문제를 해결했습니다.
- 마이그레이션 중 스토리지 키가 `totamjungTheme`에서 `theme`으로 변경되었으나 `onChanged` 리스너가 이전 키를 기준으로 감시하고 있었습니다.