### PR TITLE
[FIX] 단축키 미사용(null) 설정 시 퀵슬롯 데이터가 전부 소실되는 버그를 수정

### DIFF
--- a/domains/dataHandlers/quickSlotsDataHandler.test.ts
+++ b/domains/dataHandlers/quickSlotsDataHandler.test.ts
@@ -306,6 +306,34 @@ describe('Test #3 - 퀵슬롯 정보 저장하기', () => {
   });
 });
 
+describe('Test #3.5 - 단축키가 미사용(null)인 퀵슬롯 정보 저장하기', () => {
+  test('단축키가 미사용(null)인 유효한 퀵슬롯을 저장해야 할 경우, 슬롯 데이터가 보존되고 단축키가 null인 채로 저장되어야 한다.', async () => {
+    jest
+      .spyOn(browser.storage.local, 'set')
+      .mockImplementation(() => Promise.resolve());
+    const nullHotkeyQuickSlots = { ...validQuickSlots, hotkey: null };
+    const { selectedSlotNo, slots, hotkey } = nullHotkeyQuickSlots;
+
+    saveQuickSlotOptions(selectedSlotNo, slots, hotkey);
+
+    expect(browser.storage.local.set).toHaveBeenCalledWith({
+      quickSlotOptions: nullHotkeyQuickSlots,
+    });
+  });
+
+  test('단축키가 미사용(null)인 퀵슬롯을 불러올 경우, 슬롯 데이터가 보존되고 단축키가 null인 채로 반환되어야 한다.', async () => {
+    const nullHotkeyQuickSlots = { ...validQuickSlots, hotkey: null };
+
+    jest.spyOn(browser.storage.local, 'get').mockImplementation(() =>
+      Promise.resolve({
+        [STORAGE_KEY.QUICK_SLOT_OPTIONS]: nullHotkeyQuickSlots,
+      }),
+    );
+
+    expect(await fetchQuickSlotOptions()).toEqual(nullHotkeyQuickSlots);
+  });
+});
+
 describe('Test #4 - 유효하지 않은 퀵슬롯 정보 저장에 대응하기', () => {
   test('일부 데이터가 유효하지 않은 퀵슬롯을 저장해야 할 경우, 올바른 데이터에 한해서만 저장해야 한다.', async () => {
     jest

--- a/domains/dataHandlers/validators/quickSlotsValidator.ts
+++ b/domains/dataHandlers/validators/quickSlotsValidator.ts
@@ -76,8 +76,7 @@ export const isQuickSlotOptions = (data: unknown): data is QuickSlotOptions => {
       'hotkey' in data &&
       'selectedSlotNo' in data &&
       'slots' in data &&
-      typeof data.hotkey === 'string' &&
-      ['Alt', 'F2'].includes(data.hotkey) &&
+      isHotkey(data.hotkey) &&
       isQuickSlotNo(data.selectedSlotNo)
     )
   ) {


### PR DESCRIPTION
## PR 설명

본 PR에서는 단축키를 "미사용"으로 설정한 뒤 새로고침할 경우, 퀵슬롯 데이터가 전부 소실되는 버그를 수정하였습니다.

### 1️⃣ `isQuickSlotOptions` validator에서 `null` hotkey를 허용하도록 수정

- `isQuickSlotOptions`에서 hotkey를 검증할 때 `typeof data.hotkey === 'string'`으로만 검사하여, `null`(미사용)이 유효하지 않은 값으로 판정되고 있었습니다.
- 이로 인해 `sanitizeQuickSlotOptions`의 최종 검증에서 실패하여 `DEFAULT_QUICK_SLOT_OPTIONS`가 반환되었고, 슬롯 데이터 전체가 초기화되었습니다.
- 기존의 `isHotkey` 함수가 `null`을 허용하고 있었으나, `isQuickSlotOptions`에서는 이를 사용하지 않아 발생한 불일치였습니다.

### 2️⃣ `null` hotkey에 대한 테스트 케이스 추가

- 단축키가 미사용(`null`)인 퀵슬롯의 저장 및 불러오기 시, 슬롯 데이터가 보존되고 단축키가 `null`인 채로 유지되는지 검증하는 테스트를 추가하였습니다.