### PR TITLE
[FEAT] `<ProblemTimer>`에 경고·위험 긴급도 시각화를 추가

### DIFF
--- a/components/ProblemTimer/ProblemTimer.stories.tsx
+++ b/components/ProblemTimer/ProblemTimer.stories.tsx
@@ -1,7 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import ProblemTimer from './ProblemTimer';
-import type { MainTheme } from '@/types/mainTheme';
+import ProblemTimerThemeStateMatrix from './ProblemTimerMatrix';
+
+const baseArgs = {
+  hours: 0,
+  minutes: 8,
+  seconds: 30,
+  progress: 65,
+  status: 'play' as const,
+  theme: 'none' as const,
+  onPlay: fn(),
+  onPause: fn(),
+  onStop: fn(),
+  onEdit: fn(),
+};
 
 const meta = {
   title: 'components/ProblemTimer',
@@ -25,6 +38,12 @@ const meta = {
       description:
         '현재 타이머의 상태를 의미합니다. 타이머가 진행 중인 경우를 의미하는 `play`, 일시정지인 경우를 의미하는 `pause`, 타이머가 종료되어 시간 설정을 다시 할 수 있는 상태인 `stop`의 세 가지가 있습니다.',
     },
+    urgency: {
+      control: { type: 'select' },
+      options: ['normal', 'warn', 'danger'],
+      description:
+        '남은 시간에 따른 긴급도입니다. `normal`은 기본, `warn`은 경고(warnThreshold 이하), `danger`는 위험(dangerThreshold 이하)을 의미합니다. `warn`/`danger`일 때 텍스트와 진행 링 색상이 테마별 액센트로 교체됩니다.',
+    },
     onPlay: {
       description: '타이머의 재생 버튼이 눌렸을 때 실행할 콜백 함수입니다.',
     },
@@ -45,18 +64,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Play: Story = {
-  args: {
-    hours: 0,
-    minutes: 8,
-    seconds: 30,
-    progress: 65,
-    status: 'play',
-    theme: 'none',
-    onPlay: fn(),
-    onPause: fn(),
-    onStop: fn(),
-    onEdit: fn(),
-  },
+  args: baseArgs,
 };
 
 export const Pause: Story = {
@@ -73,16 +81,32 @@ export const Stop: Story = {
   },
 };
 
-const createThemeStory = (theme: MainTheme): Story => ({
+export const Warn: Story = {
   args: {
     ...Play.args,
-    theme,
+    hours: 0,
+    minutes: 0,
+    seconds: 18,
+    progress: 24,
+    urgency: 'warn',
   },
-});
+};
 
-export const Totamjung = createThemeStory('totamjung');
-export const SolvedAcLight = createThemeStory('solvedAcLight');
-export const SolvedAcDark = createThemeStory('solvedAcDark');
-export const SolvedAcBlack = createThemeStory('solvedAcBlack');
-export const BojExtendedDark = createThemeStory('bojExtendedDark');
-export const BojExtendedRigel = createThemeStory('bojExtendedRigel');
+export const Danger: Story = {
+  args: {
+    ...Play.args,
+    hours: 0,
+    minutes: 0,
+    seconds: 4,
+    progress: 5,
+    urgency: 'danger',
+  },
+};
+
+export const ThemeStateMatrix: Story = {
+  args: baseArgs,
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => <ProblemTimerThemeStateMatrix />,
+};

--- a/components/ProblemTimer/ProblemTimer.styled.ts
+++ b/components/ProblemTimer/ProblemTimer.styled.ts
@@ -43,6 +43,26 @@ export const circleProgressBarColors: Record<MainTheme, string> = {
   solvedAcBlack: theme.solvedAcColors.GRAY_200,
 };
 
+export const timerWarnAccentColors: Record<MainTheme, string> = {
+  none: theme.colors.AMBER,
+  totamjung: theme.colors.MANGO,
+  bojExtendedDark: theme.colors.MANGO,
+  bojExtendedRigel: theme.colors.CANARY,
+  solvedAcLight: theme.colors.DARK_AMBER,
+  solvedAcDark: theme.colors.MANGO,
+  solvedAcBlack: theme.colors.MANGO,
+};
+
+export const timerDangerAccentColors: Record<MainTheme, string> = {
+  none: theme.colors.LIGHT_RED,
+  totamjung: theme.colors.LIGHT_RED,
+  bojExtendedDark: theme.colors.LIGHT_RED,
+  bojExtendedRigel: theme.colors.RED_400,
+  solvedAcLight: theme.colors.CRIMSON,
+  solvedAcDark: theme.colors.LIGHT_RED,
+  solvedAcBlack: theme.colors.LIGHT_RED,
+};
+
 export const circleProgressBarTrackColors: Record<MainTheme, string> = {
   none: getTransparentHexColor(theme.colors.OFF_WHITE, 0.3),
   totamjung: theme.colors.BROWN_900,

--- a/components/ProblemTimer/ProblemTimer.styled.ts
+++ b/components/ProblemTimer/ProblemTimer.styled.ts
@@ -84,4 +84,8 @@ export const Container = styled.div<{ $timerTheme: MainTheme }>`
   border-radius: 20px;
 
   user-select: none;
+
+  transition:
+    border-color 0.2s,
+    background-color 0.2s;
 `;

--- a/components/ProblemTimer/ProblemTimer.tsx
+++ b/components/ProblemTimer/ProblemTimer.tsx
@@ -9,6 +9,7 @@ interface ProblemTimerProps {
   seconds: number;
   progress: number;
   status: 'play' | 'pause' | 'stop';
+  urgency?: 'normal' | 'warn' | 'danger';
   theme: MainTheme;
   onPlay: () => void;
   onPause: () => void;
@@ -17,7 +18,18 @@ interface ProblemTimerProps {
 }
 
 const ProblemTimer = (props: ProblemTimerProps) => {
-  const { progress, theme: mainTheme, ...rest } = props;
+  const { progress, theme: mainTheme, urgency = 'normal', ...rest } = props;
+
+  const accentColor =
+    urgency === 'warn'
+      ? S.timerWarnAccentColors[mainTheme]
+      : urgency === 'danger'
+        ? S.timerDangerAccentColors[mainTheme]
+        : null;
+
+  const themeTextColor = S.timerTextColors[mainTheme];
+  const textColor = accentColor ?? themeTextColor;
+  const ringColor = accentColor ?? S.circleProgressBarColors[mainTheme];
 
   return (
     <S.Container $timerTheme={mainTheme}>
@@ -25,12 +37,13 @@ const ProblemTimer = (props: ProblemTimerProps) => {
         progress={progress}
         size={28}
         strokeWidth={14}
-        color={S.circleProgressBarColors[mainTheme]}
+        color={ringColor}
         trackColor={S.circleProgressBarTrackColors[mainTheme]}
       />
       <ProblemTimerControls
         {...rest}
-        color={S.timerTextColors[mainTheme]}
+        color={textColor}
+        transparentColor={themeTextColor}
         height={40}
         hasDeleteButton={false}
       />

--- a/components/ProblemTimer/ProblemTimer.tsx
+++ b/components/ProblemTimer/ProblemTimer.tsx
@@ -39,6 +39,7 @@ const ProblemTimer = (props: ProblemTimerProps) => {
         strokeWidth={14}
         color={ringColor}
         trackColor={S.circleProgressBarTrackColors[mainTheme]}
+        colorTransitionMs={200}
       />
       <ProblemTimerControls
         {...rest}

--- a/components/ProblemTimer/ProblemTimerMatrix.tsx
+++ b/components/ProblemTimer/ProblemTimerMatrix.tsx
@@ -13,8 +13,16 @@ const MATRIX_THEMES: {
 }[] = [
   { key: 'none', label: '테마 없음', pageBackground: '#ffffff' },
   { key: 'totamjung', label: '토탐정', pageBackground: '#1a0e0a' },
-  { key: 'bojExtendedDark', label: 'BOJ 확장 · 어둡게', pageBackground: '#202020' },
-  { key: 'bojExtendedRigel', label: 'BOJ 확장 · Rigel', pageBackground: '#001a26' },
+  {
+    key: 'bojExtendedDark',
+    label: 'BOJ 확장 · 어둡게',
+    pageBackground: '#202020',
+  },
+  {
+    key: 'bojExtendedRigel',
+    label: 'BOJ 확장 · Rigel',
+    pageBackground: '#001a26',
+  },
   { key: 'solvedAcLight', label: '솔브드 · 밝게', pageBackground: '#f7f8f9' },
   { key: 'solvedAcDark', label: '솔브드 · 어둡게', pageBackground: '#15202b' },
   { key: 'solvedAcBlack', label: '솔브드 · 암전', pageBackground: '#000000' },

--- a/components/ProblemTimer/ProblemTimerMatrix.tsx
+++ b/components/ProblemTimer/ProblemTimerMatrix.tsx
@@ -1,0 +1,167 @@
+import ProblemTimer from './ProblemTimer';
+import type { MainTheme } from '@/types/mainTheme';
+
+/**
+ * ProblemTimer 의 (테마 × 긴급도) 매트릭스 비교 뷰.
+ * 디자인 검수와 회귀 확인을 위해 모든 조합을 한 화면에 펼쳐 보여준다.
+ */
+
+const MATRIX_THEMES: {
+  key: MainTheme;
+  label: string;
+  pageBackground: string;
+}[] = [
+  { key: 'none', label: '테마 없음', pageBackground: '#ffffff' },
+  { key: 'totamjung', label: '토탐정', pageBackground: '#1a0e0a' },
+  { key: 'bojExtendedDark', label: 'BOJ 확장 · 어둡게', pageBackground: '#202020' },
+  { key: 'bojExtendedRigel', label: 'BOJ 확장 · Rigel', pageBackground: '#001a26' },
+  { key: 'solvedAcLight', label: '솔브드 · 밝게', pageBackground: '#f7f8f9' },
+  { key: 'solvedAcDark', label: '솔브드 · 어둡게', pageBackground: '#15202b' },
+  { key: 'solvedAcBlack', label: '솔브드 · 암전', pageBackground: '#000000' },
+];
+
+const MATRIX_URGENCIES: {
+  key: 'normal' | 'warn' | 'danger';
+  label: string;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  progress: number;
+  headerColor: string;
+}[] = [
+  {
+    key: 'normal',
+    label: 'Normal · 정상',
+    hours: 0,
+    minutes: 42,
+    seconds: 18,
+    progress: 68,
+    headerColor: '#5a4438',
+  },
+  {
+    key: 'warn',
+    label: 'Warn · 경고',
+    hours: 0,
+    minutes: 0,
+    seconds: 18,
+    progress: 24,
+    headerColor: '#a87000',
+  },
+  {
+    key: 'danger',
+    label: 'Danger · 위험',
+    hours: 0,
+    minutes: 0,
+    seconds: 4,
+    progress: 5,
+    headerColor: '#c8001a',
+  },
+];
+
+const noop = () => {};
+
+const ProblemTimerThemeStateMatrix = () => (
+  <div
+    style={{
+      fontFamily: 'Pretendard, sans-serif',
+      border: '1px solid rgba(0,0,0,0.1)',
+      borderRadius: 12,
+      overflow: 'hidden',
+      background: '#ffffff',
+      boxShadow: '0 4px 14px rgba(0,0,0,0.06)',
+    }}
+  >
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '200px 1fr 1fr 1fr',
+        background: '#f7f4ef',
+        borderBottom: '1px solid rgba(0,0,0,0.08)',
+      }}
+    >
+      <div
+        style={{
+          padding: '12px 16px',
+          fontSize: 11,
+          color: '#8d7669',
+          fontWeight: 700,
+          letterSpacing: 1,
+        }}
+      >
+        THEME
+      </div>
+      {MATRIX_URGENCIES.map((urgencyColumn) => (
+        <div
+          key={urgencyColumn.key}
+          style={{
+            padding: '12px 16px',
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: 1,
+            borderLeft: '1px solid rgba(0,0,0,0.06)',
+            color: urgencyColumn.headerColor,
+          }}
+        >
+          {urgencyColumn.label}
+        </div>
+      ))}
+    </div>
+    {MATRIX_THEMES.map((themeRow, index) => (
+      <div
+        key={themeRow.key}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '200px 1fr 1fr 1fr',
+          borderBottom:
+            index < MATRIX_THEMES.length - 1
+              ? '1px solid rgba(0,0,0,0.06)'
+              : 'none',
+          alignItems: 'stretch',
+        }}
+      >
+        <div style={{ padding: '14px 16px' }}>
+          <div
+            style={{
+              fontSize: 14,
+              color: '#1a0e0a',
+              fontWeight: 700,
+              marginBottom: 2,
+            }}
+          >
+            {themeRow.label}
+          </div>
+          <div style={{ fontSize: 11, color: '#8d7669' }}>{themeRow.key}</div>
+        </div>
+        {MATRIX_URGENCIES.map((urgencyColumn) => (
+          <div
+            key={urgencyColumn.key}
+            style={{
+              padding: '12px 16px',
+              borderLeft: '1px solid rgba(0,0,0,0.04)',
+              background: themeRow.pageBackground,
+              minHeight: 64,
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            <ProblemTimer
+              theme={themeRow.key}
+              hours={urgencyColumn.hours}
+              minutes={urgencyColumn.minutes}
+              seconds={urgencyColumn.seconds}
+              progress={urgencyColumn.progress}
+              status="play"
+              urgency={urgencyColumn.key}
+              onPlay={noop}
+              onPause={noop}
+              onStop={noop}
+              onEdit={noop}
+            />
+          </div>
+        ))}
+      </div>
+    ))}
+  </div>
+);
+
+export default ProblemTimerThemeStateMatrix;

--- a/components/ProblemTimerControls/ProblemTimerControls.styled.ts
+++ b/components/ProblemTimerControls/ProblemTimerControls.styled.ts
@@ -10,8 +10,13 @@ export const TimeDisplay = styled.div`
   font-variant-numeric: tabular-nums;
 `;
 
-export const TransparentDisplay = styled.span`
+export const TransparentDisplay = styled.span<{
+  $transparentColor?: string;
+}>`
   opacity: 0.2;
+
+  ${({ $transparentColor }) =>
+    $transparentColor && `color: ${$transparentColor};`}
 `;
 
 export const ButtonContainer = styled.div<{ $maxButtonCount: number }>`

--- a/components/ProblemTimerControls/ProblemTimerControls.styled.ts
+++ b/components/ProblemTimerControls/ProblemTimerControls.styled.ts
@@ -67,5 +67,6 @@ export const Container = styled.div<{
 
   & > ${TimeDisplay}, & ${ControlButton} > svg {
     color: ${({ $color }) => $color};
+    transition: color 0.2s;
   }
 `;

--- a/components/ProblemTimerControls/ProblemTimerControls.tsx
+++ b/components/ProblemTimerControls/ProblemTimerControls.tsx
@@ -14,6 +14,12 @@ interface BaseTimerControls {
   seconds: number;
   status: 'play' | 'pause' | 'stop';
   color: string;
+  /**
+   * 비활성 시간 세그먼트("00:" 같은 leading-zero 부분)의 색상.
+   * 가시성을 위해 활성 세그먼트와 다르게 지정할 수 있다.
+   * 미지정 시 `color`를 그대로 사용한다.
+   */
+  transparentColor?: string;
   height: number | string;
   onPlay: () => void;
   onPause: () => void;
@@ -59,6 +65,7 @@ const ProblemTimerControls = (props: ProblemTimerControlsProps) => {
     seconds,
     status,
     color,
+    transparentColor,
     height,
     hasDeleteButton,
     onPlay,
@@ -75,7 +82,9 @@ const ProblemTimerControls = (props: ProblemTimerControlsProps) => {
   return (
     <S.Container $color={color} $height={toPx(height)}>
       <S.TimeDisplay>
-        <S.TransparentDisplay>{transparent}</S.TransparentDisplay>
+        <S.TransparentDisplay $transparentColor={transparentColor}>
+          {transparent}
+        </S.TransparentDisplay>
         {normal}
       </S.TimeDisplay>
       <S.ButtonContainer $maxButtonCount={hasDeleteButton ? 3 : 2}>

--- a/components/common/CircleProgressBar/CircleProgressBar.stories.tsx
+++ b/components/common/CircleProgressBar/CircleProgressBar.stories.tsx
@@ -26,6 +26,11 @@ const meta = {
     trackColor: {
       description: '프로그레스 바의, **채워져 있지 않은 부분**의 색상입니다.',
     },
+    colorTransitionMs: {
+      description:
+        '`color`·`trackColor` 변경 시 적용할 stroke 전환 시간(ms)입니다. 0이면 즉시 전환되며, 기본값은 0입니다. Controls 패널에서 이 값을 0보다 크게 둔 뒤 `color`를 바꾸면 부드러운 전환을 확인할 수 있습니다.',
+      control: { type: 'range', min: 0, max: 1000, step: 50 },
+    },
   },
 } satisfies Meta<typeof CircleProgressBar>;
 

--- a/components/common/CircleProgressBar/CircleProgressBar.styled.ts
+++ b/components/common/CircleProgressBar/CircleProgressBar.styled.ts
@@ -10,6 +10,10 @@ export const Container = styled.div<{ $width: number; $height: number }>`
   }
 `;
 
-export const CircleProgressBar = styled.svg`
+export const CircleProgressBar = styled.svg<{ $colorTransitionMs: number }>`
   transform: rotate(-90deg);
+
+  & circle {
+    transition: stroke ${({ $colorTransitionMs }) => $colorTransitionMs}ms;
+  }
 `;

--- a/components/common/CircleProgressBar/CircleProgressBar.tsx
+++ b/components/common/CircleProgressBar/CircleProgressBar.tsx
@@ -6,10 +6,22 @@ interface CircleProgressBar {
   progress: number;
   color: string;
   trackColor: string;
+  /**
+   * `color`·`trackColor` 변경 시 적용할 stroke 전환 시간(ms).
+   * 0이면 즉시 전환됩니다. 기본값 0.
+   */
+  colorTransitionMs?: number;
 }
 
 const CircleProgressBar = (props: CircleProgressBar) => {
-  const { size, strokeWidth, progress, color, trackColor } = props;
+  const {
+    size,
+    strokeWidth,
+    progress,
+    color,
+    trackColor,
+    colorTransitionMs = 0,
+  } = props;
   const center = size / 2;
   const radius = size / 2 - strokeWidth / 2;
   const round = (2 * Math.PI * (size - strokeWidth)) / 2;
@@ -17,7 +29,7 @@ const CircleProgressBar = (props: CircleProgressBar) => {
 
   return (
     <S.Container $width={size} $height={size}>
-      <S.CircleProgressBar>
+      <S.CircleProgressBar $colorTransitionMs={colorTransitionMs}>
         <circle
           cx={center}
           cy={center}

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -28,6 +28,11 @@ export const theme = {
     LIGHT_PURPLE: '#dcbfff',
     PURPLE: '#963eff',
     MANGO: '#ffd900',
+    AMBER: '#ffc107',
+    CANARY: '#ffeb3b',
+    DARK_AMBER: '#ad7000',
+    RED_400: '#ff3838',
+    CRIMSON: '#c8001a',
   },
 
   solvedAcTiers: {


### PR DESCRIPTION
## PR 설명

본 PR에서는 `ProblemTimer`에 남은 시간이 얼마 남지 않은 경우 시각적으로 강조해주는 경고·위험 표시를 추가하였습니다.

### 1️⃣ 남은 시간이 임박할 때 경고·위험 색으로 강조

- 경고/위험 상태에 진입하면 타이머의 텍스트와 진행 링이 테마별 강조색으로 교체됩니다.
- 평상 시에는 기존 색상을 그대로 유지합니다.
- 다만 비활성 시간 세그먼트(`00:` 같은 leading-zero 부분)는 가독성을 위해 경고·위험 여부와 무관하게 원래 색을 유지합니다.

### 2️⃣ 색 변화를 자연스럽게 보강

- 경고·위험 진입 또는 테마 변경 시 색이 0.2초에 걸쳐 부드럽게 변하도록 변경하였습니다.

## 스크린샷
<img width="1062" height="510" alt="image" src="https://github.com/user-attachments/assets/fb25e6e9-cfdb-40a3-a328-a834d1a853dc" />