### PR TITLE
[FIX] 레거시 데이터 마이그레이션의 reduce 타입 오류를 수정

### DIFF
--- a/domains/dataHandlers/legacyDataUpdater.ts
+++ b/domains/dataHandlers/legacyDataUpdater.ts
@@ -45,7 +45,9 @@ export const updateAllLegacyData = async () => {
 
   const result = converters
     .slice(dataVersion - 2)
-    .reduce((acc, convert) => convert(acc), data);
+    .reduce<
+      Record<string, unknown>
+    >((acc, convert) => ({ ...convert(acc) }), { ...data });
 
   await browser.storage.local.set(result);
   await browser.storage.local.remove(LEGACY_LOCAL_STORAGE_KEYS);


### PR DESCRIPTION
## PR 설명

본 PR에서는 옛 버전 데이터를 최신 버전(v5)으로 변환하는 마이그레이션 코드에서 타입 검사가 실패하던 문제를 해결했습니다.

### 1️⃣ 컨버터를 차례로 적용하는 reduce에 타입을 명시

- `legacyDataUpdater.ts`에서 v2 → v3 → v4 → v5 컨버터를 `reduce`로 하나씩 이어 적용하는 부분이 있습니다.
- 이 부분에서 거쳐 가는 값의 타입을 TypeScript가 제대로 파악하지 못해, 타입 검사(`tsc`)가 실패하고 있었습니다.
- 거쳐 가는 값의 타입을 직접 지정해 타입이 흔들리지 않도록 고정했습니다.

## 참고

- 이 문제는 본 PR에서 새로 생긴 것이 아니라, develop 브랜치에도 원래 있던 문제입니다. develop 소스를 그대로 빌드해도 같은 에러가 나는 것을 확인했습니다.
- 예전에는 TypeScript 버전이 더 낮아 이 코드를 그냥 통과시켜 주었는데, 지금은 lock 파일의 TypeScript가 5.9.3으로 올라오면서 검사가 더 엄격해져 걸리게 되었습니다.
- 그래서 #219 같은 과거 PR은 통과했지만, 지금 새로 설치해서 빌드하면 어느 브랜치든 같은 에러가 납니다.